### PR TITLE
Implement live Stripe checkout and live admin analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Commands
+
+All commands run from the repo root via pnpm workspaces.
+
+```bash
+pnpm dev:web          # Start Next.js dev server (apps/web)
+pnpm build:web        # Production build
+pnpm check-types      # TypeScript check across all packages
+pnpm check-types:web  # TypeScript check for apps/web only
+```
+
+There is no test suite or linter configured. Type-checking (`check-types`) is the primary correctness gate.
+If `.next` has been deleted and `PageProps` / `LayoutProps` are missing, regenerate Next.js route types first:
+
+```bash
+pnpm --filter web exec next typegen
+```
+
+To run a single Next.js route in isolation, use the dev server and navigate to the route directly.
+
+## Architecture
+
+### Monorepo structure
+
+pnpm workspace with one app: `apps/web` (Next.js). The root `package.json` only contains workspace scripts.
+
+### Two portals, one codebase
+
+**Parent portal** — `apps/web/src/app/[tenant]/`  
+Mobile-first shopping flow: catalog → item detail → cart → checkout → order confirmation. Wrapped in `MobileShell` (max-width 430px, centered on desktop).
+
+**Admin portal** — `apps/web/src/app/admin/[tenant]/`  
+Desktop sidebar layout via `AdminShell`. Sections: Dashboard, Orders (Kanban board), Catalog, Bulk Upload, Reports, Settings.
+
+`apps/web/src/app/page.tsx` is the parent home / school picker. It auto-redirects when there is only one child in `PARENT.kids`.
+
+### Multi-tenancy
+
+Every route is scoped to a `[tenant]` slug (`nsbh` or `rgsh`). The layout files (`app/[tenant]/layout.tsx`, `app/admin/[tenant]/layout.tsx`) validate the slug against `TENANTS` in `lib/data.ts` and call `notFound()` on mismatch.
+
+Tenant accent colour (e.g. `#7A1F2B` for NSBH) is threaded through props into components rather than read from CSS — components apply it via inline `style` on borders, backgrounds, and text.
+
+### Data layer
+
+The app now has a Neon PostgreSQL backend via Drizzle ORM. Static data remains for tenant metadata, parent demo data, legacy mock orders, and UI fallbacks, but live catalog, tenant settings, and order workflows should go through the DB/API layer.
+
+`src/db/schema.ts` — Drizzle schema for tenants, catalog items/variants, orders/order lines, and Stripe account fields.
+
+`src/db/index.ts` — Lazy Neon/Drizzle client. Do not instantiate DB clients at module import time; production builds collect route data without runtime env vars.
+
+`src/db/queries.ts` — Shared query helpers for catalog, orders, and tenant settings. Prefer adding DB access here rather than duplicating query logic in route handlers.
+
+`app/api/orders`, `app/api/catalog`, `app/api/tenant`, and `app/api/stripe/*` — Route handlers for live workflows. They are the client-facing write surface; client components should check `res.ok` and surface errors instead of assuming writes succeed.
+
+`lib/data.ts` — Tenant definitions (`TENANTS`), parent/child demo definitions (`PARENT`), static fallback catalog data, and helpers.
+
+`lib/admin-data.ts` — Legacy mock admin orders and sales analytics. Dashboard recent orders and sales KPIs still read this mock data.
+
+`lib/cart-store.ts` — `useCart()` hook. Persists the current cart to `localStorage` (key `uo:cart:v1`). Seeds from `SAMPLE_CART` on first visit.
+
+`lib/order-store.ts` — Legacy localStorage order helper plus student-detail persistence (`uo:student:v1`). Current checkout persists orders to Neon via `POST /api/orders`; the parent order history uses the saved student email to fetch live DB orders.
+
+**Known data gap (see `docs/FEATURE_AUDIT.md`):** Dashboard recent orders are still static (`ADMIN_ORDERS`) and do not reflect live Neon orders. Reports and sales KPIs are also mock analytics data.
+
+### Server / client split pattern
+
+Next.js App Router server components do data fetching and pass props down. Pages with interactivity are split into a server `page.tsx` + a `"use client"` companion (`*-screen.tsx` or `*-client.tsx`). Example: `app/[tenant]/checkout/page.tsx` is a thin server wrapper; `checkout-screen.tsx` owns all state.
+
+### Design system
+
+Tailwind CSS v4 (`@import "tailwindcss"`) with custom design tokens defined in `src/index.css` under `@theme`:
+
+| Token | Value |
+|---|---|
+| `--color-navy-deep` | `#081A2D` (admin sidebar) |
+| `--color-parchment` | `#FAF6EE` (page background) |
+| `--color-paper` | `#FDFBF6` (card background) |
+| `--color-rule` | `#E5DFD2` (borders) |
+| `--color-gold` | `#B08A3E` (accents) |
+| `--font-serif` | Newsreader (headings) |
+| `--font-sans` | Inter (body) |
+
+Add `.tnum` class (`font-feature-settings: "tnum"`) on any price or numeric display.
+
+HeroUI v3 (`@heroui/react`) and HeroUI Pro (`@heroui-pro/react`) are installed but the current UI is built primarily with bespoke Tailwind components. Use HeroUI components when adding new interactive elements.
+
+`GarmentVector` in `components/garment.tsx` renders flat-vector SVG product illustrations keyed by item ID — no images are used.
+
+### Design references
+
+**Paper form:** `my_doc/UI_prototypes/project/uploads/Uniform_Online_Order_Form.pdf` — the original paper order form this project digitizes.
+
+**Design system:** `my_doc/UI_prototypes/project/Design System.html` — canonical tokens, typography, and component styles.
+
+**UI prototypes:** `my_doc/UI_prototypes/project/` contains HTML/JSX prototypes exported from Codex Design covering three flows:
+- `parent.jsx` — parent shopping flow
+- `operator.jsx` — admin/operator flow
+- `superadmin.jsx` — platform super-admin flow
+
+Read the prototype source directly; do not render or screenshot it. Match the visual output in React — do not copy the prototype's internal structure into the app. `my_doc/HeroUI/design/data.jsx` and `primitives.jsx` are supporting references used by the prototypes.
+
+### TypeScript
+
+Path alias `@/*` maps to `apps/web/src/*`. Use `@/lib/data`, `@/components/...` etc.
+
+`LayoutProps<"/[tenant]">` and `PageProps<"/[tenant]">` are Next.js 16 generated route types; `params` must be `await`ed in async server components.

--- a/apps/web/src/app/[tenant]/checkout/checkout-screen.tsx
+++ b/apps/web/src/app/[tenant]/checkout/checkout-screen.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
+import { loadStripe, type Stripe, type StripeCardElement, type StripeElements } from "@stripe/stripe-js";
 import type { Tenant } from "@/lib/data";
 import { cartTotal } from "@/lib/data";
 import { useCart } from "@/lib/cart-store";
@@ -13,21 +14,102 @@ import { readStudentDetails, writeStudentDetails, type StudentDetails } from "@/
 type Delivery = "pickup" | "ship";
 
 const YEAR_OPTIONS = ["Year 7", "Year 8", "Year 9", "Year 10", "Year 11", "Year 12"];
+const stripePublishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+const stripePromise = stripePublishableKey ? loadStripe(stripePublishableKey) : null;
+
+async function readApiError(res: Response, fallback: string) {
+  try {
+    const data = await res.json();
+    return typeof data.error === "string" ? data.error : fallback;
+  } catch {
+    return fallback;
+  }
+}
 
 export function CheckoutScreen({ tenant }: { tenant: Tenant }) {
   const router = useRouter();
   const { lines, clearCart } = useCart();
   const [delivery, setDelivery] = useState<Delivery>("pickup");
   const [paying, setPaying] = useState(false);
+  const [paymentReady, setPaymentReady] = useState(false);
+  const [paymentError, setPaymentError] = useState("");
+  const [paymentLocked, setPaymentLocked] = useState(false);
   const [student, setStudent] = useState<StudentDetails>({
     studentName: "", rollClass: "", year: "Year 9",
     parentName: "", mobile: "", email: "",
   });
   const [fieldErrors, setFieldErrors] = useState<Partial<Record<keyof StudentDetails, string>>>({});
+  const cardMountRef = useRef<HTMLDivElement | null>(null);
+  const stripeRef = useRef<Stripe | null>(null);
+  const elementsRef = useRef<StripeElements | null>(null);
+  const cardRef = useRef<StripeCardElement | null>(null);
+  const paymentLockedRef = useRef(false);
 
   useEffect(() => {
     const saved = readStudentDetails();
     if (saved) setStudent(saved);
+  }, []);
+
+  useEffect(() => {
+    paymentLockedRef.current = paymentLocked;
+  }, [paymentLocked]);
+
+  useEffect(() => {
+    if (!stripePromise || !cardMountRef.current || cardRef.current) return;
+
+    let cancelled = false;
+
+    stripePromise.then((stripe) => {
+      if (cancelled) return;
+      if (!stripe) {
+        setPaymentReady(false);
+        setPaymentError("Payment form could not load. Please refresh the page or contact the shop.");
+        return;
+      }
+      if (!cardMountRef.current) return;
+
+      const elements = stripe.elements();
+      const card = elements.create("card", {
+        hidePostalCode: true,
+        style: {
+          base: {
+            color: "#1B1B1B",
+            fontFamily: "Inter, system-ui, sans-serif",
+            fontSize: "13px",
+            "::placeholder": { color: "#8A8274" },
+          },
+          invalid: { color: "#B23A2A" },
+        },
+      });
+
+      card.on("ready", () => {
+        if (paymentLockedRef.current) return;
+        setPaymentReady(true);
+        setPaymentError("");
+      });
+      card.on("change", (event) => {
+        if (paymentLockedRef.current) return;
+        setPaymentError(event.error?.message ?? "");
+      });
+      card.mount(cardMountRef.current);
+
+      stripeRef.current = stripe;
+      elementsRef.current = elements;
+      cardRef.current = card;
+    }).catch(() => {
+      if (cancelled) return;
+      setPaymentReady(false);
+      setPaymentError("Payment form could not load. Please refresh the page or contact the shop.");
+    });
+
+    return () => {
+      cancelled = true;
+      cardRef.current?.destroy();
+      cardRef.current = null;
+      elementsRef.current = null;
+      stripeRef.current = null;
+      setPaymentReady(false);
+    };
   }, []);
 
   const subtotal = cartTotal(lines);
@@ -53,49 +135,128 @@ export function CheckoutScreen({ tenant }: { tenant: Tenant }) {
   };
 
   const onPay = async () => {
+    if (paymentLocked) return;
+    setPaymentError("");
     if (!validate()) return;
+    if (lines.length === 0) {
+      setPaymentError("Your cart is empty.");
+      return;
+    }
+    if (!stripePublishableKey || !stripePromise) {
+      setPaymentError("Payment is unavailable because Stripe is not configured.");
+      return;
+    }
+    if (!stripeRef.current || !cardRef.current || !paymentReady) {
+      setPaymentError("Payment form is still loading. Please try again in a moment.");
+      return;
+    }
+
     writeStudentDetails(student);
     setPaying(true);
+    let confirmedPaymentIntentId: string | null = null;
     try {
-      const res = await fetch("/api/orders", {
+      const paymentIntentRes = await fetch("/api/stripe/payment-intent", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           tenantId: tenant.id,
-          parentName: student.parentName,
-          parentEmail: student.email,
-          parentMobile: student.mobile,
-          studentName: student.studentName,
-          studentYear: student.year,
-          studentRoll: student.rollClass,
-          delivery,
-          deliveryFee: delivery === "ship" ? 9.5 : 0,
-          subtotal,
-          gst,
-          total,
-          stripePaymentIntentId: null,
-          lines: lines.map((l) => ({
-            itemId: l.itemId,
-            itemName: l.name,
-            variantLabel: l.variantLabel,
-            qty: l.qty,
-            unitPrice: l.price,
-            lineTotal: l.price * l.qty,
-          })),
+          amount: total,
+          currency: "aud",
+          metadata: {
+            parentEmail: student.email,
+            studentName: student.studentName,
+            studentYear: student.year,
+            delivery,
+          },
         }),
+      });
+
+      if (!paymentIntentRes.ok) {
+        setPaymentError(await readApiError(paymentIntentRes, "Failed to start payment. Please try again."));
+        setPaying(false);
+        return;
+      }
+
+      const { clientSecret } = await paymentIntentRes.json();
+      if (typeof clientSecret !== "string" || !clientSecret) {
+        setPaymentError("Payment could not be started. Please contact the shop.");
+        setPaying(false);
+        return;
+      }
+
+      const { error, paymentIntent } = await stripeRef.current.confirmCardPayment(clientSecret, {
+        payment_method: {
+          card: cardRef.current,
+          billing_details: {
+            name: student.parentName,
+            email: student.email,
+            phone: student.mobile,
+          },
+        },
+      });
+
+      if (error) {
+        setPaymentError(error.message ?? "Payment failed. Please check your card details and try again.");
+        setPaying(false);
+        return;
+      }
+
+      if (!paymentIntent || paymentIntent.status !== "succeeded") {
+        setPaymentError("Payment was not completed. Please check your card details and try again.");
+        setPaying(false);
+        return;
+      }
+      confirmedPaymentIntentId = paymentIntent.id;
+
+      const orderPayload = {
+        tenantId: tenant.id,
+        parentName: student.parentName,
+        parentEmail: student.email,
+        parentMobile: student.mobile,
+        studentName: student.studentName,
+        studentYear: student.year,
+        studentRoll: student.rollClass,
+        delivery,
+        deliveryFee: delivery === "ship" ? 9.5 : 0,
+        subtotal,
+        gst,
+        total,
+        stripePaymentIntentId: paymentIntent.id,
+        lines: lines.map((l) => ({
+          itemId: l.itemId,
+          itemName: l.name,
+          variantLabel: l.variantLabel,
+          qty: l.qty,
+          unitPrice: l.price,
+          lineTotal: l.price * l.qty,
+        })),
+      };
+
+      const res = await fetch("/api/orders", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(orderPayload),
       });
       if (res.ok) {
         const { orderId } = await res.json();
         clearCart();
         router.push(`/${tenant.id}/order/placed?total=${total.toFixed(2)}&delivery=${delivery}&orderId=${orderId}`);
       } else {
-        const data = await res.json();
-        alert(data.error ?? "Failed to place order. Please try again.");
+        const message = await readApiError(res, "Failed to place order.");
+        paymentLockedRef.current = true;
+        setPaymentLocked(true);
+        setPaymentError(`${message} Your payment was confirmed. Do not retry payment. Contact the shop with Stripe reference ${paymentIntent.id}.`);
         setPaying(false);
       }
     } catch (err) {
       console.error("Order submission error:", err);
-      alert("Network error. Please try again.");
+      if (confirmedPaymentIntentId) {
+        paymentLockedRef.current = true;
+        setPaymentLocked(true);
+        setPaymentError(`Network error while placing the order. Your payment was confirmed. Do not retry payment. Contact the shop with Stripe reference ${confirmedPaymentIntentId}.`);
+      } else {
+        setPaymentError("Network error. Please try again.");
+      }
       setPaying(false);
     }
   };
@@ -212,22 +373,25 @@ export function CheckoutScreen({ tenant }: { tenant: Tenant }) {
               Secure payment · PCI-DSS
             </span>
           </div>
-          <div
-            className="h-11 rounded-md border px-3 flex items-center justify-between mb-2 text-[13px]"
-            style={{ borderColor: "var(--color-rule)" }}
-          >
-            <span className="tnum tracking-[1px]" style={{ color: "var(--color-ink)" }}>5240 1468 0020 4745</span>
-            <span className="flex gap-1">
-              <span className="w-6 h-3.5 rounded-[1px] opacity-85" style={{ background: "#EB001B" }} />
-              <span className="w-6 h-3.5 rounded-[1px] opacity-85 -ml-2" style={{ background: "#F79E1B" }} />
-            </span>
-          </div>
-          <div className="grid grid-cols-2 gap-2">
-            <div className="h-11 rounded-md border px-3 flex items-center text-[13px] tnum" style={{ borderColor: "var(--color-rule)" }}>09 / 29</div>
-            <div className="h-11 rounded-md border px-3 flex items-center text-[13px] tnum" style={{ borderColor: "var(--color-rule)" }}>•••</div>
-          </div>
+          {!stripePublishableKey ? (
+            <div className="rounded-md border px-3 py-2.5 text-[12px]" style={{ borderColor: "#B23A2A", color: "#B23A2A", background: "#FFF8F6" }}>
+              Payment is unavailable because Stripe is not configured.
+            </div>
+          ) : (
+            <div
+              className="min-h-11 rounded-md border px-3 py-3 text-[13px]"
+              style={{ borderColor: paymentError ? "#B23A2A" : "var(--color-rule)" }}
+            >
+              <div ref={cardMountRef} />
+            </div>
+          )}
+          {paymentError && (
+            <div className="mt-2 text-[11px]" style={{ color: "#B23A2A" }}>
+              {paymentError}
+            </div>
+          )}
           <div className="mt-2.5 text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
-            Saved as <b style={{ color: "var(--color-ink)" }}>•• 4745</b> · Mastercard
+            Card details are encrypted and processed by Stripe.
           </div>
         </div>
 
@@ -257,11 +421,11 @@ export function CheckoutScreen({ tenant }: { tenant: Tenant }) {
           size="lg"
           fullWidth
           accent={tenant.accent}
-          disabled={paying || lines.length === 0}
+          disabled={paying || paymentLocked || lines.length === 0 || !stripePublishableKey || !paymentReady}
           onClick={onPay}
           leading={<LockIcon size={14} />}
         >
-          {paying ? "Processing…" : `Pay $${total.toFixed(2)} securely`}
+          {!stripePublishableKey ? "Payment unavailable" : paymentLocked ? "Payment confirmed" : paying ? "Processing…" : `Pay $${total.toFixed(2)} securely`}
         </Btn>
         <div className="text-center text-[10.5px] mt-2" style={{ color: "var(--color-ink-dim)" }}>
           By placing this order you agree to {tenant.short}&apos;s refund policy.

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -63,6 +63,9 @@ function AddProductModal({
     if (variants.some((v) => !v.label.trim() || !v.price.trim())) {
       setError("All variant fields are required."); return;
     }
+    if (variants.some((v) => !Number.isFinite(Number(v.price)) || Number(v.price) < 0)) {
+      setError("Variant prices must be valid positive numbers."); return;
+    }
 
     setSaving(true);
     try {
@@ -279,6 +282,7 @@ export function CatalogTable({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
   const [showAddModal, setShowAddModal] = useState(false);
+  const [tableError, setTableError] = useState("");
 
   const filtered = items.filter((it) => {
     const matchCat = activeCategory === "All" || it.category === activeCategory;
@@ -297,31 +301,48 @@ export function CatalogTable({
   const handleSaveEdit = async (id: string) => {
     const trimmed = editingName.trim();
     if (!trimmed) return;
+    const previousItems = items;
+    setTableError("");
     // Optimistic update
     setItems((prev) => prev.map((it) => (it.id === id ? { ...it, name: trimmed } : it)));
     setEditingId(null);
     try {
-      await fetch(`/api/catalog/${id}`, {
+      const res = await fetch(`/api/catalog/${id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: trimmed }),
       });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? "Failed to update item.");
+      }
     } catch (err) {
       console.error("Failed to update item:", err);
+      setItems(previousItems);
+      setTableError(err instanceof Error ? err.message : "Failed to update item.");
     }
   };
 
   const handleDelete = async (id: string) => {
     if (!confirm("Remove this product from the catalog?")) return;
+    const previousItems = items;
+    setTableError("");
     setItems((prev) => prev.filter((it) => it.id !== id));
     try {
-      await fetch(`/api/catalog/${id}`, { method: "DELETE" });
+      const res = await fetch(`/api/catalog/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? "Failed to delete item.");
+      }
     } catch (err) {
       console.error("Failed to delete item:", err);
+      setItems(previousItems);
+      setTableError(err instanceof Error ? err.message : "Failed to delete item.");
     }
   };
 
   const handleAdded = (newItem: DbItem) => {
+    setTableError("");
     setItems((prev) => [...prev, newItem]);
   };
 
@@ -334,6 +355,12 @@ export function CatalogTable({
           onClose={() => setShowAddModal(false)}
           onAdded={handleAdded}
         />
+      )}
+
+      {tableError && (
+        <div className="mb-3 text-[12.5px] px-3 py-2 rounded" style={{ background: "#FEF2F2", color: "#B91C1C" }}>
+          {tableError}
+        </div>
       )}
 
       {/* Filters */}

--- a/apps/web/src/app/admin/[tenant]/dashboard/dashboard-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/dashboard/dashboard-client.tsx
@@ -1,12 +1,12 @@
 "use client";
 import Link from "next/link";
 import type { Tenant } from "@/lib/data";
-import type { SalesData, AdminOrder } from "@/lib/admin-data";
+import type { LiveDashboardData, LiveOrderStatus } from "@/db/queries";
 import { Chip } from "@/components/chip";
 import { Spark } from "@/components/spark";
 
-function StatusBadge({ status }: { status: AdminOrder["status"] }) {
-  const map: Record<AdminOrder["status"], { tone: "warn" | "info" | "success" | "neutral"; label: string }> = {
+function StatusBadge({ status }: { status: LiveOrderStatus }) {
+  const map: Record<LiveOrderStatus, { tone: "warn" | "info" | "success" | "neutral"; label: string }> = {
     new: { tone: "info", label: "New" },
     packing: { tone: "warn", label: "Packing" },
     ready: { tone: "success", label: "Ready" },
@@ -18,18 +18,27 @@ function StatusBadge({ status }: { status: AdminOrder["status"] }) {
 
 export function AdminDashboardClient({
   tenant,
-  sales,
-  recentOrders,
+  dashboard,
 }: {
   tenant: Tenant;
-  sales: SalesData;
-  recentOrders: AdminOrder[];
+  dashboard: LiveDashboardData;
 }) {
   const stats = [
-    { label: "Revenue · 30d", value: `$${sales.revenue.toLocaleString()}`, delta: "+12.4%", tone: "pos" as const, spark: sales.spark },
-    { label: "Orders · 30d", value: String(sales.orders), delta: "+8.1%", tone: "pos" as const },
-    { label: "Avg order", value: `$${sales.avgOrder.toFixed(2)}`, delta: "+1.2%", tone: "pos" as const },
-    { label: "Awaiting pickup", value: String(sales.awaitingPickup), delta: "3 over 7d", tone: "warn" as const },
+    {
+      label: "Revenue · 30d",
+      value: `$${dashboard.revenue.toLocaleString()}`,
+      delta: "Live orders",
+      tone: "pos" as const,
+      spark: dashboard.spark,
+    },
+    { label: "Orders · 30d", value: String(dashboard.orders), delta: "Live orders", tone: "pos" as const },
+    { label: "Avg order", value: `$${dashboard.avgOrder.toFixed(2)}`, delta: "Last 30 days", tone: "pos" as const },
+    {
+      label: "Awaiting pickup",
+      value: String(dashboard.awaitingPickup),
+      delta: `${dashboard.readyOverSevenDays} over 7d`,
+      tone: "warn" as const,
+    },
   ];
 
   return (
@@ -110,13 +119,14 @@ export function AdminDashboardClient({
               </tr>
             </thead>
             <tbody>
-              {sales.topItems.map((r, i) => {
-                const pct = (r.revenue / sales.revenue) * 100;
+              {dashboard.topItems.map((r, i) => {
+                const pct = dashboard.revenue > 0 ? (r.revenue / dashboard.revenue) * 100 : 0;
+                const widthPct = Math.min(100, Math.max(0, pct));
                 return (
                   <tr
                     key={r.name}
                     className="border-b"
-                    style={{ borderColor: i < sales.topItems.length - 1 ? "var(--color-rule)" : "transparent" }}
+                    style={{ borderColor: i < dashboard.topItems.length - 1 ? "var(--color-rule)" : "transparent" }}
                   >
                     <td className="py-3 font-medium" style={{ color: "var(--color-ink)" }}>
                       {r.name}
@@ -135,20 +145,27 @@ export function AdminDashboardClient({
                         >
                           <div
                             className="h-1.5 rounded-full"
-                            style={{ width: `${pct}%`, background: tenant.accent }}
+                            style={{ width: `${widthPct}%`, background: tenant.accent }}
                           />
                         </div>
                         <span
                           className="text-[11px] w-8 text-right"
                           style={{ color: "var(--color-ink-dim)" }}
                         >
-                          {pct.toFixed(0)}%
+                          {widthPct.toFixed(0)}%
                         </span>
                       </div>
                     </td>
                   </tr>
                 );
               })}
+              {dashboard.topItems.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="py-4 text-center text-[12px]" style={{ color: "var(--color-ink-dim)" }}>
+                    No live order lines yet.
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>
@@ -173,7 +190,7 @@ export function AdminDashboardClient({
                   <circle cx="12" cy="17" r="0.6" fill="#7A5418" stroke="none" />
                 </svg>
                 <div style={{ color: "var(--color-ink)" }}>
-                  <b>3 orders</b> ready for pickup over 7 days.{" "}
+                  <b>{dashboard.readyOverSevenDays} orders</b> ready for pickup over 7 days.{" "}
                   <Link href={`/admin/${tenant.id}/orders`} className="font-semibold underline" style={{ color: tenant.accent }}>
                     View orders →
                   </Link>
@@ -202,7 +219,7 @@ export function AdminDashboardClient({
                   <path d="M5 13 L10 18 L20 6" />
                 </svg>
                 <div style={{ color: "var(--color-ink)" }}>
-                  Stripe payouts on track. Next deposit <b>Wed 29 Apr · ${(sales.revenue * 0.26).toLocaleString()}</b>.
+                  Stripe payout estimate from live orders: <b>${(dashboard.revenue * 0.26).toLocaleString()}</b>.
                 </div>
               </div>
             </div>
@@ -226,11 +243,13 @@ export function AdminDashboardClient({
               </Link>
             </div>
             <div className="flex flex-col">
-              {recentOrders.map((o, i) => (
+              {dashboard.recentOrders.map((o, i) => (
                 <div
                   key={o.id}
                   className="flex items-center gap-3 py-2.5"
-                  style={{ borderBottom: i < recentOrders.length - 1 ? "1px solid var(--color-rule)" : "none" }}
+                  style={{
+                    borderBottom: i < dashboard.recentOrders.length - 1 ? "1px solid var(--color-rule)" : "none",
+                  }}
                 >
                   <div className="flex-1 min-w-0">
                     <div className="text-[12.5px] font-semibold truncate" style={{ color: "var(--color-ink)" }}>
@@ -248,6 +267,11 @@ export function AdminDashboardClient({
                   </div>
                 </div>
               ))}
+              {dashboard.recentOrders.length === 0 && (
+                <div className="py-4 text-[12px] text-center" style={{ color: "var(--color-ink-dim)" }}>
+                  No live orders yet.
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/apps/web/src/app/admin/[tenant]/dashboard/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { TENANTS, type TenantId } from "@/lib/data";
-import { SALES_DATA, getOrdersByTenant } from "@/lib/admin-data";
+import { getLiveDashboardData } from "@/db/queries";
 import { AdminTopbar } from "@/components/admin-shell";
 import { AdminDashboardClient } from "./dashboard-client";
 
@@ -8,9 +8,7 @@ export default async function AdminDashboardPage({ params }: { params: Promise<{
   const { tenant: tid } = await params;
   if (!(tid in TENANTS)) notFound();
   const tenant = TENANTS[tid as TenantId];
-  const sales = SALES_DATA[tid as TenantId];
-  const orders = getOrdersByTenant(tid as TenantId);
-  const recentOrders = orders.slice(0, 5);
+  const dashboard = await getLiveDashboardData(tid);
 
   return (
     <>
@@ -42,7 +40,7 @@ export default async function AdminDashboardPage({ params }: { params: Promise<{
           </div>
         }
       />
-      <AdminDashboardClient tenant={tenant} sales={sales} recentOrders={recentOrders} />
+      <AdminDashboardClient tenant={tenant} dashboard={dashboard} />
     </>
   );
 }

--- a/apps/web/src/app/admin/[tenant]/orders/[orderId]/order-detail-actions.tsx
+++ b/apps/web/src/app/admin/[tenant]/orders/[orderId]/order-detail-actions.tsx
@@ -19,6 +19,7 @@ const nextLabel: Record<OrderStatus, string> = {
 
 export function OrderDetailActions({
   orderId,
+  tenantId,
   currentStatus,
   accent,
   parentEmail,
@@ -26,6 +27,7 @@ export function OrderDetailActions({
   studentName,
 }: {
   orderId: string;
+  tenantId: string;
   currentStatus: OrderStatus;
   accent: string;
   parentEmail: string;
@@ -34,20 +36,27 @@ export function OrderDetailActions({
 }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
   const next = nextStatus[currentStatus];
 
   const handleAdvance = async () => {
     if (!next) return;
     setLoading(true);
+    setError("");
     try {
-      await fetch(`/api/orders/${orderId}`, {
+      const res = await fetch(`/api/orders/${orderId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: next }),
+        body: JSON.stringify({ status: next, tenantId }),
       });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? "Failed to advance status.");
+      }
       router.refresh();
     } catch (err) {
       console.error("Failed to advance status:", err);
+      setError(err instanceof Error ? err.message : "Failed to advance status.");
     } finally {
       setLoading(false);
     }
@@ -63,6 +72,11 @@ export function OrderDetailActions({
 
   return (
     <>
+      {error && (
+        <span className="text-[12px] font-semibold" style={{ color: "#B23A2A" }}>
+          {error}
+        </span>
+      )}
       {currentStatus === "ready" && (
         <button
           onClick={handleNotify}

--- a/apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx
@@ -45,7 +45,7 @@ export default async function OrderDetailPage({
 
   // Fetch from live DB
   const order = await getOrderById(orderId);
-  if (!order) notFound();
+  if (!order || order.tenantId !== tid) notFound();
 
   const statusMap: Record<string, { tone: "info" | "warn" | "success" | "neutral"; label: string }> = {
     new: { tone: "info", label: "New" },
@@ -81,6 +81,7 @@ export default async function OrderDetailPage({
             <PrintButton label="Print pick slip" />
             <OrderDetailActions
               orderId={order.id}
+              tenantId={tid}
               currentStatus={order.status}
               accent={tenant.accent}
               parentEmail={order.parentEmail}

--- a/apps/web/src/app/admin/[tenant]/orders/orders-board.tsx
+++ b/apps/web/src/app/admin/[tenant]/orders/orders-board.tsx
@@ -148,11 +148,13 @@ export function OrdersBoard({
 
   const fetchOrders = useCallback(async () => {
     try {
-      const res = await fetch(`/api/orders?tenantId=${tenantId}`);
-      if (res.ok) {
-        const data = await res.json();
-        setAllOrders(data);
+      const res = await fetch(`/api/orders?tenantId=${encodeURIComponent(tenantId)}`);
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? "Failed to fetch orders.");
       }
+      const data = await res.json();
+      setAllOrders(data);
     } catch (err) {
       console.error("Failed to fetch orders:", err);
     } finally {
@@ -170,11 +172,15 @@ export function OrdersBoard({
       prev.map((o) => (o.id === id ? { ...o, status } : o))
     );
     try {
-      await fetch(`/api/orders/${id}`, {
+      const res = await fetch(`/api/orders/${id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status }),
+        body: JSON.stringify({ status, tenantId }),
       });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? "Failed to update order status.");
+      }
     } catch (err) {
       console.error("Failed to update order status:", err);
       fetchOrders(); // Revert on error

--- a/apps/web/src/app/admin/[tenant]/reports/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/reports/page.tsx
@@ -1,26 +1,20 @@
 import { notFound } from "next/navigation";
 import { TENANTS, type TenantId } from "@/lib/data";
-import { SALES_DATA } from "@/lib/admin-data";
+import { getLiveReportsData } from "@/db/queries";
 import { AdminTopbar } from "@/components/admin-shell";
-import { ExportCsvButton, type CsvRow } from "@/components/export-csv-button";
-
-// GST summary rows — in a real app these would come from the DB
-const GST_ROWS: CsvRow[] = [
-  { period: "Apr 2026", gross: 1480, gst: 134.55, net: 1345.45, fees: 43.05, payout: 1302.40 },
-  { period: "Mar 2026", gross: 3240, gst: 294.55, net: 2945.45, fees: 94.17, payout: 2851.28 },
-  { period: "Feb 2026", gross: 2780, gst: 252.73, net: 2527.27, fees: 80.82, payout: 2446.45 },
-  { period: "Jan 2026", gross: 3960, gst: 360.00, net: 3600.00, fees: 115.02, payout: 3484.98 },
-];
+import { ExportCsvButton } from "@/components/export-csv-button";
 
 export default async function AdminReportsPage({ params }: { params: Promise<{ tenant: string }> }) {
   const { tenant: tid } = await params;
   if (!(tid in TENANTS)) notFound();
   const tenant = TENANTS[tid as TenantId];
-  const sales = SALES_DATA[tid as TenantId];
+  const reports = await getLiveReportsData(tid);
 
-  const months = ["Nov", "Dec", "Jan", "Feb", "Mar", "Apr"];
-  const monthlyRevenue = [2840, 4120, 3960, 2780, 3240, 1480];
-  const maxRev = Math.max(...monthlyRevenue);
+  const maxRev = Math.max(1, ...reports.monthlyRevenue.map((row) => row.revenue));
+  const rangeLabel =
+    reports.monthlyRevenue.length > 0
+      ? `${reports.monthlyRevenue[0]?.label ?? ""} – ${reports.monthlyRevenue[reports.monthlyRevenue.length - 1]?.label ?? ""}`
+      : "Last 6 months";
 
   return (
     <>
@@ -38,7 +32,7 @@ export default async function AdminReportsPage({ params }: { params: Promise<{ t
               <option>This term</option>
             </select>
             <ExportCsvButton
-              rows={GST_ROWS}
+              rows={reports.gstRows}
               filename={`${tid}-gst-report.csv`}
             />
           </div>
@@ -48,10 +42,10 @@ export default async function AdminReportsPage({ params }: { params: Promise<{ t
         {/* Summary cards */}
         <div className="grid grid-cols-4 gap-3.5 mb-6">
           {[
-            { label: "Total revenue", value: `$${sales.revenue.toLocaleString()}`, sub: "6 months" },
-            { label: "Total orders", value: String(sales.orders), sub: "6 months" },
-            { label: "Avg order value", value: `$${sales.avgOrder.toFixed(2)}`, sub: "6 months" },
-            { label: "GST collected", value: `$${(sales.revenue / 11).toFixed(0)}`, sub: "Remittable" },
+            { label: "Total revenue", value: `$${reports.revenue.toLocaleString()}`, sub: "6 months" },
+            { label: "Total orders", value: String(reports.orders), sub: "6 months" },
+            { label: "Avg order value", value: `$${reports.avgOrder.toFixed(2)}`, sub: "6 months" },
+            { label: "GST collected", value: `$${reports.gst.toFixed(2)}`, sub: "Remittable" },
           ].map((s) => (
             <div
               key={s.label}
@@ -79,16 +73,17 @@ export default async function AdminReportsPage({ params }: { params: Promise<{ t
               <h3 className="type-h2 m-0" style={{ color: "var(--color-ink)" }}>
                 Monthly revenue
               </h3>
-              <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>Nov 2025 – Apr 2026</span>
+              <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>{rangeLabel}</span>
             </div>
             <div className="flex items-end gap-3 h-[160px]">
-              {monthlyRevenue.map((v, i) => {
-                const pct = (v / maxRev) * 100;
-                const isLast = i === monthlyRevenue.length - 1;
+              {reports.monthlyRevenue.map((row, i) => {
+                const pct = (row.revenue / maxRev) * 100;
+                const isLast = i === reports.monthlyRevenue.length - 1;
+                const revenueLabel = row.revenue < 1000 ? `$${row.revenue.toFixed(0)}` : `$${(row.revenue / 1000).toFixed(1)}k`;
                 return (
-                  <div key={months[i]} className="flex-1 flex flex-col items-center gap-1.5">
+                  <div key={row.month} className="flex-1 flex flex-col items-center gap-1.5">
                     <div className="text-[11px] font-semibold tnum" style={{ color: "var(--color-ink-dim)" }}>
-                      ${(v / 1000).toFixed(1)}k
+                      {revenueLabel}
                     </div>
                     <div className="w-full flex items-end" style={{ height: 120 }}>
                       <div
@@ -96,12 +91,12 @@ export default async function AdminReportsPage({ params }: { params: Promise<{ t
                         style={{
                           height: `${pct}%`,
                           background: isLast ? `${tenant.accent}60` : tenant.accent,
-                          minHeight: 4,
+                          minHeight: row.revenue > 0 ? 4 : 0,
                         }}
                       />
                     </div>
                     <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
-                      {months[i]}
+                      {row.label}
                     </div>
                   </div>
                 );
@@ -117,27 +112,26 @@ export default async function AdminReportsPage({ params }: { params: Promise<{ t
             <h3 className="type-h2 m-0 mb-4" style={{ color: "var(--color-ink)" }}>
               Revenue by category
             </h3>
-            {[
-              { cat: "Winter", pct: 38, rev: 6999 },
-              { cat: "Summer", pct: 26, rev: 4789 },
-              { cat: "Sports", pct: 18, rev: 3316 },
-              { cat: "Formal", pct: 11, rev: 2026 },
-              { cat: "Bags", pct: 5, rev: 921 },
-              { cat: "Stationery", pct: 2, rev: 369 },
-            ].map((c) => (
-              <div key={c.cat} className="mb-3">
-                <div className="flex justify-between text-[12px] mb-1">
-                  <span className="font-medium" style={{ color: "var(--color-ink)" }}>{c.cat}</span>
-                  <span className="tnum" style={{ color: "var(--color-ink-dim)" }}>${c.rev.toLocaleString()}</span>
+            {reports.categoryRevenue.length === 0 ? (
+              <p className="text-[12px]" style={{ color: "var(--color-ink-dim)" }}>
+                No live category sales yet.
+              </p>
+            ) : (
+              reports.categoryRevenue.map((c) => (
+                <div key={c.cat} className="mb-3">
+                  <div className="flex justify-between text-[12px] mb-1">
+                    <span className="font-medium" style={{ color: "var(--color-ink)" }}>{c.cat}</span>
+                    <span className="tnum" style={{ color: "var(--color-ink-dim)" }}>${c.revenue.toLocaleString()}</span>
+                  </div>
+                  <div className="h-1.5 rounded-full" style={{ background: "var(--color-parchment)" }}>
+                    <div
+                      className="h-1.5 rounded-full"
+                      style={{ width: `${c.pct}%`, background: tenant.accent }}
+                    />
+                  </div>
                 </div>
-                <div className="h-1.5 rounded-full" style={{ background: "var(--color-parchment)" }}>
-                  <div
-                    className="h-1.5 rounded-full"
-                    style={{ width: `${c.pct}%`, background: tenant.accent }}
-                  />
-                </div>
-              </div>
-            ))}
+              ))
+            )}
           </div>
         </div>
 
@@ -160,16 +154,28 @@ export default async function AdminReportsPage({ params }: { params: Promise<{ t
               </tr>
             </thead>
             <tbody>
-              {GST_ROWS.map((r, i) => (
-                <tr key={r.period} className="border-b" style={{ borderColor: i < GST_ROWS.length - 1 ? "var(--color-rule)" : "transparent" }}>
-                  <td className="py-2.5 font-medium" style={{ color: "var(--color-ink)" }}>{r.period}</td>
-                  <td className="py-2.5 text-right tnum" style={{ color: "var(--color-ink)" }}>${r.gross.toLocaleString()}</td>
-                  <td className="py-2.5 text-right tnum" style={{ color: "var(--color-ink)" }}>${r.gst.toFixed(2)}</td>
-                  <td className="py-2.5 text-right tnum" style={{ color: "var(--color-ink)" }}>${r.net.toFixed(2)}</td>
-                  <td className="py-2.5 text-right tnum" style={{ color: "var(--color-ink-dim)" }}>−${r.fees.toFixed(2)}</td>
-                  <td className="py-2.5 text-right tnum font-semibold" style={{ color: "var(--color-ink)" }}>${r.payout.toFixed(2)}</td>
+              {reports.gstRows.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="py-4 text-center text-[12px]"
+                    style={{ color: "var(--color-ink-dim)" }}
+                  >
+                    No live GST rows yet.
+                  </td>
                 </tr>
-              ))}
+              ) : (
+                reports.gstRows.map((r, i) => (
+                  <tr key={r.period} className="border-b" style={{ borderColor: i < reports.gstRows.length - 1 ? "var(--color-rule)" : "transparent" }}>
+                    <td className="py-2.5 font-medium" style={{ color: "var(--color-ink)" }}>{r.period}</td>
+                    <td className="py-2.5 text-right tnum" style={{ color: "var(--color-ink)" }}>${r.gross.toLocaleString()}</td>
+                    <td className="py-2.5 text-right tnum" style={{ color: "var(--color-ink)" }}>${r.gst.toFixed(2)}</td>
+                    <td className="py-2.5 text-right tnum" style={{ color: "var(--color-ink)" }}>${r.net.toFixed(2)}</td>
+                    <td className="py-2.5 text-right tnum" style={{ color: "var(--color-ink-dim)" }}>−${r.fees.toFixed(2)}</td>
+                    <td className="py-2.5 text-right tnum font-semibold" style={{ color: "var(--color-ink)" }}>${r.payout.toFixed(2)}</td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
         </div>

--- a/apps/web/src/app/admin/[tenant]/settings/settings-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/settings/settings-client.tsx
@@ -33,6 +33,7 @@ export function SettingsClient({
   const [shopHours, setShopHours] = useState(tenant.shopHours ?? "");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState("");
 
   const [stripeStatus, setStripeStatus] = useState<StripeStatus | null>(null);
   const [stripeLoading, setStripeLoading] = useState(true);
@@ -69,16 +70,23 @@ export function SettingsClient({
 
   const handleSave = async () => {
     setSaving(true);
+    setSaved(false);
+    setSaveError("");
     try {
-      await fetch(`/api/tenant/${tenantId}`, {
+      const res = await fetch(`/api/tenant/${tenantId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name, shopEmail, address, shopHours }),
       });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? "Failed to save settings.");
+      }
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
     } catch (err) {
       console.error("Failed to save settings:", err);
+      setSaveError(err instanceof Error ? err.message : "Failed to save settings.");
     } finally {
       setSaving(false);
     }
@@ -189,6 +197,11 @@ export function SettingsClient({
               {saved && (
                 <span className="text-[12.5px] font-semibold" style={{ color: "var(--color-success)" }}>
                   ✓ Saved
+                </span>
+              )}
+              {saveError && (
+                <span className="text-[12.5px] font-semibold" style={{ color: "#B23A2A" }}>
+                  {saveError}
                 </span>
               )}
             </div>

--- a/apps/web/src/app/api/auth/[...path]/route.ts
+++ b/apps/web/src/app/api/auth/[...path]/route.ts
@@ -1,3 +1,12 @@
-import { auth } from "@/lib/auth/server";
+import { getAuth } from "@/lib/auth/server";
+import type { NextRequest } from "next/server";
 
-export const { GET, POST } = auth.handler();
+type AuthRouteContext = { params: Promise<{ path: string[] }> };
+
+export async function GET(req: NextRequest, context: AuthRouteContext) {
+  return getAuth().handler().GET(req, context);
+}
+
+export async function POST(req: NextRequest, context: AuthRouteContext) {
+  return getAuth().handler().POST(req, context);
+}

--- a/apps/web/src/app/api/catalog/[itemId]/route.ts
+++ b/apps/web/src/app/api/catalog/[itemId]/route.ts
@@ -9,10 +9,13 @@ export async function PATCH(
   const { itemId } = await params;
   try {
     const { name } = await req.json();
-    if (!name) {
+    if (typeof name !== "string" || !name.trim()) {
       return NextResponse.json({ error: "name required" }, { status: 400 });
     }
-    await updateCatalogItemName(itemId, name);
+    const updated = await updateCatalogItemName(itemId, name.trim());
+    if (updated.length === 0) {
+      return NextResponse.json({ error: "Item not found" }, { status: 404 });
+    }
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("PATCH /api/catalog/[itemId] error:", err);
@@ -27,7 +30,10 @@ export async function DELETE(
 ) {
   const { itemId } = await params;
   try {
-    await deleteCatalogItem(itemId);
+    const deleted = await deleteCatalogItem(itemId);
+    if (deleted.length === 0) {
+      return NextResponse.json({ error: "Item not found" }, { status: 404 });
+    }
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("DELETE /api/catalog/[itemId] error:", err);

--- a/apps/web/src/app/api/catalog/route.ts
+++ b/apps/web/src/app/api/catalog/route.ts
@@ -31,6 +31,27 @@ export async function POST(req: NextRequest) {
         { status: 400 }
       );
     }
+    if (!Array.isArray(variants) || variants.length === 0) {
+      return NextResponse.json(
+        { error: "At least one variant is required" },
+        { status: 400 }
+      );
+    }
+    if (
+      variants.some(
+        (variant) =>
+          !variant ||
+          typeof variant.label !== "string" ||
+          !variant.label.trim() ||
+          !Number.isFinite(Number(variant.price)) ||
+          Number(variant.price) < 0
+      )
+    ) {
+      return NextResponse.json(
+        { error: "Each variant requires a label and valid price" },
+        { status: 400 }
+      );
+    }
 
     // Generate a slug ID from the name
     const id = name
@@ -47,7 +68,10 @@ export async function POST(req: NextRequest) {
       name,
       category,
       description,
-      variants: variants ?? [],
+      variants: variants.map((variant) => ({
+        label: variant.label.trim(),
+        price: Number(variant.price),
+      })),
     });
 
     return NextResponse.json({ id: uniqueId }, { status: 201 });

--- a/apps/web/src/app/api/orders/[orderId]/route.ts
+++ b/apps/web/src/app/api/orders/[orderId]/route.ts
@@ -1,15 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getOrderById, updateOrderStatus } from "@/db/queries";
 
+const ORDER_STATUSES = ["new", "packing", "ready", "collected"] as const;
+type OrderStatus = (typeof ORDER_STATUSES)[number];
+
+function isOrderStatus(status: unknown): status is OrderStatus {
+  return typeof status === "string" && ORDER_STATUSES.includes(status as OrderStatus);
+}
+
 // GET /api/orders/:orderId
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ orderId: string }> }
 ) {
   const { orderId } = await params;
+  const tenantId = new URL(req.url).searchParams.get("tenantId");
   try {
     const order = await getOrderById(orderId);
-    if (!order) {
+    if (!order || (tenantId && order.tenantId !== tenantId)) {
       return NextResponse.json({ error: "Order not found" }, { status: 404 });
     }
     return NextResponse.json(order);
@@ -26,11 +34,19 @@ export async function PATCH(
 ) {
   const { orderId } = await params;
   try {
-    const { status } = await req.json();
-    if (!["new", "packing", "ready", "collected"].includes(status)) {
+    const { status, tenantId } = await req.json();
+    if (!isOrderStatus(status)) {
       return NextResponse.json({ error: "Invalid status" }, { status: 400 });
     }
-    await updateOrderStatus(orderId, status);
+    const order = await getOrderById(orderId);
+    if (!order || (tenantId && order.tenantId !== tenantId)) {
+      return NextResponse.json({ error: "Order not found" }, { status: 404 });
+    }
+
+    const updated = await updateOrderStatus(orderId, status);
+    if (updated.length === 0) {
+      return NextResponse.json({ error: "Order not found" }, { status: 404 });
+    }
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("PATCH /api/orders/[orderId] error:", err);

--- a/apps/web/src/app/api/orders/route.ts
+++ b/apps/web/src/app/api/orders/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, orders, orderLines } from "@/db";
-import { getOrdersByTenant } from "@/db/queries";
-import { nanoid } from "nanoid";
+import { getOrdersByTenant, getOrdersByTenantAndParentEmail } from "@/db/queries";
 
 // GET /api/orders?tenantId=nsbh&email=...
 export async function GET(req: NextRequest) {
@@ -14,12 +13,10 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const rows = await getOrdersByTenant(tenantId);
-    // Optionally filter by parent email
-    const filtered = email
-      ? rows.filter((o) => o.parentEmail === email)
-      : rows;
-    return NextResponse.json(filtered);
+    const rows = email
+      ? await getOrdersByTenantAndParentEmail(tenantId, email)
+      : await getOrdersByTenant(tenantId);
+    return NextResponse.json(rows);
   } catch (err) {
     console.error("GET /api/orders error:", err);
     return NextResponse.json({ error: "Failed to fetch orders" }, { status: 500 });
@@ -46,6 +43,23 @@ export async function POST(req: NextRequest) {
       stripePaymentIntentId,
       lines,
     } = body;
+
+    if (
+      !tenantId ||
+      !parentName ||
+      !parentEmail ||
+      !parentMobile ||
+      !studentName ||
+      !studentYear ||
+      !studentRoll ||
+      typeof subtotal !== "number" ||
+      typeof gst !== "number" ||
+      typeof total !== "number" ||
+      !Array.isArray(lines) ||
+      lines.length === 0
+    ) {
+      return NextResponse.json({ error: "Missing required order fields" }, { status: 400 });
+    }
 
     // Generate order ID: TENANT-XXXXX
     const prefix = tenantId.toUpperCase();

--- a/apps/web/src/app/api/stripe/connect/route.ts
+++ b/apps/web/src/app/api/stripe/connect/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { stripe } from "@/lib/stripe";
+import { getStripe } from "@/lib/stripe";
 import { getTenant, updateTenantStripe } from "@/db/queries";
 
 // POST /api/stripe/connect — start Stripe Connect onboarding
 export async function POST(req: NextRequest) {
   try {
+    const stripe = getStripe();
     const { tenantId } = await req.json();
 
     if (!tenantId) {
@@ -67,6 +68,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
+    const stripe = getStripe();
     const tenant = await getTenant(tenantId);
     if (!tenant || !tenant.stripeAccountId) {
       return NextResponse.json({ connected: false });

--- a/apps/web/src/app/api/stripe/payment-intent/route.ts
+++ b/apps/web/src/app/api/stripe/payment-intent/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { stripe } from "@/lib/stripe";
+import type Stripe from "stripe";
+import { getStripe } from "@/lib/stripe";
 import { getTenant } from "@/db/queries";
 
 // POST /api/stripe/payment-intent
 export async function POST(req: NextRequest) {
   try {
+    const stripe = getStripe();
     const { tenantId, amount, currency = "aud", metadata } = await req.json();
 
     if (!tenantId || !amount) {
@@ -20,7 +22,7 @@ export async function POST(req: NextRequest) {
     }
 
     // If tenant has a connected Stripe account, use it
-    const intentParams: Parameters<typeof stripe.paymentIntents.create>[0] = {
+    const intentParams: Stripe.PaymentIntentCreateParams = {
       amount: Math.round(amount * 100), // convert to cents
       currency,
       metadata: {

--- a/apps/web/src/app/api/tenant/[tenantId]/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/route.ts
@@ -28,7 +28,10 @@ export async function PATCH(
   try {
     const body = await req.json();
     const { name, address, shopHours, shopEmail } = body;
-    await updateTenantSettings(tenantId, { name, address, shopHours, shopEmail });
+    const updated = await updateTenantSettings(tenantId, { name, address, shopHours, shopEmail });
+    if (updated.length === 0) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("PATCH /api/tenant/[tenantId] error:", err);

--- a/apps/web/src/app/orders/orders-list-client.tsx
+++ b/apps/web/src/app/orders/orders-list-client.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { TENANTS, type TenantId } from "@/lib/data";
+import { readStudentDetails } from "@/lib/order-store";
 import { Crest } from "@/components/crest";
 import { Chip } from "@/components/chip";
 
@@ -78,15 +79,32 @@ function StatusTrack({ accent, status }: { accent: string; status: string }) {
 export function OrdersListClient() {
   const [orders, setOrders] = useState<DbOrder[]>([]);
   const [loading, setLoading] = useState(true);
+  const [parentEmail, setParentEmail] = useState<string | null>(null);
 
   useEffect(() => {
-    // Fetch orders for all known tenants
     const fetchAll = async () => {
+      const saved = readStudentDetails();
+      const email = saved?.email.trim();
+      setParentEmail(email || null);
+      if (!email) {
+        setOrders([]);
+        setLoading(false);
+        return;
+      }
+
       try {
         const tenantIds = Object.keys(TENANTS);
         const results = await Promise.all(
           tenantIds.map((tid) =>
-            fetch(`/api/orders?tenantId=${tid}`).then((r) => r.json())
+            fetch(
+              `/api/orders?tenantId=${encodeURIComponent(tid)}&email=${encodeURIComponent(email)}`
+            ).then(async (r) => {
+              if (!r.ok) {
+                const data = await r.json().catch(() => null);
+                throw new Error(data?.error ?? "Failed to fetch orders.");
+              }
+              return r.json();
+            })
           )
         );
         const all: DbOrder[] = results.flat();
@@ -115,10 +133,12 @@ export function OrdersListClient() {
       <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
         <div className="text-[32px] mb-3">🛍️</div>
         <div className="font-serif text-[17px] font-semibold mb-1" style={{ color: "var(--color-ink)" }}>
-          No orders yet
+          {parentEmail ? "No orders yet" : "No checkout email found"}
         </div>
         <div className="text-[13px]" style={{ color: "var(--color-ink-dim)" }}>
-          Your orders will appear here after you place them.
+          {parentEmail
+            ? "Your orders will appear here after you place them."
+            : "Place an order first, then your order history will appear here."}
         </div>
       </div>
     );

--- a/apps/web/src/db/index.ts
+++ b/apps/web/src/db/index.ts
@@ -1,8 +1,30 @@
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle, type NeonHttpDatabase } from "drizzle-orm/neon-http";
 import { neon } from "@neondatabase/serverless";
 import * as schema from "./schema";
 
-const sql = neon(process.env.DATABASE_URL!);
-export const db = drizzle(sql, { schema });
+type DbClient = NeonHttpDatabase<typeof schema>;
+
+let dbClient: DbClient | null = null;
+
+export function getDb(): DbClient {
+  if (dbClient) return dbClient;
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not configured");
+  }
+
+  const sql = neon(databaseUrl);
+  dbClient = drizzle(sql, { schema });
+  return dbClient;
+}
+
+export const db = new Proxy({} as DbClient, {
+  get(_target, prop, receiver) {
+    const client = getDb();
+    const value = Reflect.get(client, prop, receiver);
+    return typeof value === "function" ? value.bind(client) : value;
+  },
+});
 
 export * from "./schema";

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -1,5 +1,5 @@
 import { db, orders, orderLines, catalogItems, catalogVariants, tenants } from "./index";
-import { eq, desc, ilike, or } from "drizzle-orm";
+import { and, eq, desc, or } from "drizzle-orm";
 
 // ─── Orders ──────────────────────────────────────────────────────────────────
 
@@ -8,6 +8,14 @@ export async function getOrdersByTenant(tenantId: string) {
     .select()
     .from(orders)
     .where(eq(orders.tenantId, tenantId))
+    .orderBy(desc(orders.createdAt));
+}
+
+export async function getOrdersByTenantAndParentEmail(tenantId: string, email: string) {
+  return db
+    .select()
+    .from(orders)
+    .where(and(eq(orders.tenantId, tenantId), eq(orders.parentEmail, email)))
     .orderBy(desc(orders.createdAt));
 }
 
@@ -42,7 +50,8 @@ export async function updateOrderStatus(
   return db
     .update(orders)
     .set({ status, updatedAt: new Date() })
-    .where(eq(orders.id, orderId));
+    .where(eq(orders.id, orderId))
+    .returning({ id: orders.id });
 }
 
 // ─── Catalog ─────────────────────────────────────────────────────────────────
@@ -53,6 +62,8 @@ export async function getCatalogByTenant(tenantId: string) {
     .from(catalogItems)
     .where(eq(catalogItems.tenantId, tenantId))
     .orderBy(catalogItems.sortOrder);
+
+  if (items.length === 0) return [];
 
   const variants = await db
     .select()
@@ -114,11 +125,15 @@ export async function updateCatalogItemName(itemId: string, name: string) {
   return db
     .update(catalogItems)
     .set({ name, updatedAt: new Date() })
-    .where(eq(catalogItems.id, itemId));
+    .where(eq(catalogItems.id, itemId))
+    .returning({ id: catalogItems.id });
 }
 
 export async function deleteCatalogItem(itemId: string) {
-  return db.delete(catalogItems).where(eq(catalogItems.id, itemId));
+  return db
+    .delete(catalogItems)
+    .where(eq(catalogItems.id, itemId))
+    .returning({ id: catalogItems.id });
 }
 
 // ─── Tenants ─────────────────────────────────────────────────────────────────
@@ -158,5 +173,6 @@ export async function updateTenantSettings(
   return db
     .update(tenants)
     .set({ ...data, updatedAt: new Date() })
-    .where(eq(tenants.id, tenantId));
+    .where(eq(tenants.id, tenantId))
+    .returning({ id: tenants.id });
 }

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -1,5 +1,178 @@
 import { db, orders, orderLines, catalogItems, catalogVariants, tenants } from "./index";
-import { and, eq, desc, or } from "drizzle-orm";
+import { and, eq, desc, or, gte, inArray, lt } from "drizzle-orm";
+
+export type LiveOrderStatus = "new" | "packing" | "ready" | "collected";
+
+export type LiveRecentOrder = {
+  id: string;
+  tenantId: string;
+  status: LiveOrderStatus;
+  delivery: "pickup" | "ship";
+  kid: string;
+  year: string;
+  rollClass: string;
+  parent: string;
+  email: string;
+  total: number;
+  createdAt: Date | null;
+};
+
+export type LiveTopItem = {
+  name: string;
+  qty: number;
+  revenue: number;
+};
+
+export type LiveDashboardData = {
+  revenue: number;
+  orders: number;
+  avgOrder: number;
+  awaitingPickup: number;
+  readyOverSevenDays: number;
+  spark: number[];
+  topItems: LiveTopItem[];
+  recentOrders: LiveRecentOrder[];
+};
+
+export type LiveMonthlyRevenue = {
+  month: string;
+  label: string;
+  revenue: number;
+};
+
+export type LiveCategoryRevenue = {
+  cat: string;
+  revenue: number;
+  pct: number;
+};
+
+export type LiveGstRow = {
+  period: string;
+  gross: number;
+  gst: number;
+  net: number;
+  fees: number;
+  payout: number;
+};
+
+export type LiveReportsData = {
+  revenue: number;
+  orders: number;
+  avgOrder: number;
+  gst: number;
+  monthlyRevenue: LiveMonthlyRevenue[];
+  categoryRevenue: LiveCategoryRevenue[];
+  gstRows: LiveGstRow[];
+};
+
+function money(value: string | number | null | undefined) {
+  const parsed = typeof value === "number" ? value : Number(value ?? 0);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.round((parsed + Number.EPSILON) * 100) / 100;
+}
+
+const REPORTING_TIME_ZONE = "Australia/Sydney";
+const sydneyDatePartsFormatter = new Intl.DateTimeFormat("en-AU", {
+  timeZone: REPORTING_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+const sydneyDateTimePartsFormatter = new Intl.DateTimeFormat("en-AU", {
+  timeZone: REPORTING_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hourCycle: "h23",
+});
+const sydneyMonthLabelFormatter = new Intl.DateTimeFormat("en-AU", {
+  timeZone: REPORTING_TIME_ZONE,
+  month: "short",
+});
+const sydneyMonthPeriodFormatter = new Intl.DateTimeFormat("en-AU", {
+  timeZone: REPORTING_TIME_ZONE,
+  month: "short",
+  year: "numeric",
+});
+
+function sydneyDateParts(date: Date) {
+  const parts = sydneyDatePartsFormatter.formatToParts(date);
+  const part = (type: "year" | "month" | "day") => {
+    const value = parts.find((p) => p.type === type)?.value;
+    return value ? Number(value) : 0;
+  };
+
+  return {
+    year: part("year"),
+    month: part("month"),
+    day: part("day"),
+  };
+}
+
+function sydneyOffsetMs(date: Date) {
+  const parts = sydneyDateTimePartsFormatter.formatToParts(date);
+  const part = (type: "year" | "month" | "day" | "hour" | "minute" | "second") => {
+    const value = parts.find((p) => p.type === type)?.value;
+    return value ? Number(value) : 0;
+  };
+  const asUtc = Date.UTC(
+    part("year"),
+    part("month") - 1,
+    part("day"),
+    part("hour"),
+    part("minute"),
+    part("second")
+  );
+  return asUtc - date.getTime();
+}
+
+function sydneyLocalDateToUtc(year: number, month: number, day: number) {
+  const localAsUtc = Date.UTC(year, month - 1, day);
+  const firstGuess = new Date(localAsUtc);
+  const secondGuess = new Date(localAsUtc - sydneyOffsetMs(firstGuess));
+  return new Date(localAsUtc - sydneyOffsetMs(secondGuess));
+}
+
+function startOfDay(date: Date) {
+  const parts = sydneyDateParts(date);
+  return sydneyLocalDateToUtc(parts.year, parts.month, parts.day);
+}
+
+function addSydneyDays(date: Date, days: number) {
+  const parts = sydneyDateParts(date);
+  return sydneyLocalDateToUtc(parts.year, parts.month, parts.day + days);
+}
+
+function addSydneyMonths(date: Date, months: number) {
+  const parts = sydneyDateParts(date);
+  return sydneyLocalDateToUtc(parts.year, parts.month + months, 1);
+}
+
+function monthKey(date: Date) {
+  const parts = sydneyDateParts(date);
+  return `${parts.year}-${String(parts.month).padStart(2, "0")}`;
+}
+
+function dayKey(date: Date) {
+  const parts = sydneyDateParts(date);
+  return `${parts.year}-${String(parts.month).padStart(2, "0")}-${String(parts.day).padStart(2, "0")}`;
+}
+
+function monthLabel(date: Date) {
+  return sydneyMonthLabelFormatter.format(date);
+}
+
+function monthPeriod(date: Date) {
+  return sydneyMonthPeriodFormatter.format(date);
+}
+
+function estimateStripeFees(gross: number) {
+  if (gross <= 0) return 0;
+  return money(gross * 0.029 + 0.13);
+}
 
 // ─── Orders ──────────────────────────────────────────────────────────────────
 
@@ -17,6 +190,208 @@ export async function getOrdersByTenantAndParentEmail(tenantId: string, email: s
     .from(orders)
     .where(and(eq(orders.tenantId, tenantId), eq(orders.parentEmail, email)))
     .orderBy(desc(orders.createdAt));
+}
+
+export async function getLiveDashboardData(tenantId: string): Promise<LiveDashboardData> {
+  const orderRows = await db
+    .select()
+    .from(orders)
+    .where(eq(orders.tenantId, tenantId))
+    .orderBy(desc(orders.createdAt));
+
+  if (orderRows.length === 0) {
+    return {
+      revenue: 0,
+      orders: 0,
+      avgOrder: 0,
+      awaitingPickup: 0,
+      readyOverSevenDays: 0,
+      spark: Array.from({ length: 12 }, () => 0),
+      topItems: [],
+      recentOrders: [],
+    };
+  }
+
+  const today = startOfDay(new Date());
+  const last30Start = addSydneyDays(today, -29);
+  const sparkStart = addSydneyDays(today, -11);
+  const tomorrowStart = addSydneyDays(today, 1);
+  const sevenDaysAgo = addSydneyDays(today, -7);
+
+  const last30Orders = orderRows.filter((order) => {
+    return order.createdAt !== null && order.createdAt >= last30Start && order.createdAt < tomorrowStart;
+  });
+
+  const revenue = money(last30Orders.reduce((sum, order) => sum + money(order.total), 0));
+  const orderCount = last30Orders.length;
+  const avgOrder = orderCount > 0 ? money(revenue / orderCount) : 0;
+  const awaitingPickup = orderRows.filter((order) => {
+    return order.delivery === "pickup" && order.status === "ready";
+  }).length;
+  const readyOverSevenDays = orderRows.filter((order) => {
+    return (
+      order.delivery === "pickup" &&
+      order.status === "ready" &&
+      order.createdAt !== null &&
+      order.createdAt < sevenDaysAgo
+    );
+  }).length;
+
+  const sparkBuckets = new Map<string, number>();
+  for (let i = 0; i < 12; i += 1) {
+    const day = addSydneyDays(sparkStart, i);
+    sparkBuckets.set(dayKey(day), 0);
+  }
+  for (const order of orderRows) {
+    if (!order.createdAt || order.createdAt < sparkStart || order.createdAt >= tomorrowStart) continue;
+    const key = dayKey(order.createdAt);
+    if (!sparkBuckets.has(key)) continue;
+    sparkBuckets.set(key, money((sparkBuckets.get(key) ?? 0) + money(order.total)));
+  }
+
+  const datedRecentRows = orderRows
+    .filter((order) => order.createdAt !== null)
+    .sort((a, b) => b.createdAt!.getTime() - a.createdAt!.getTime());
+  const nullDatedRows = orderRows.filter((order) => order.createdAt === null);
+  const recentOrders: LiveRecentOrder[] = [...datedRecentRows, ...nullDatedRows].slice(0, 5).map((order) => ({
+    id: order.id,
+    tenantId: order.tenantId,
+    status: order.status,
+    delivery: order.delivery,
+    kid: order.studentName,
+    year: order.studentYear,
+    rollClass: order.studentRoll,
+    parent: order.parentName,
+    email: order.parentEmail,
+    total: money(order.total),
+    createdAt: order.createdAt,
+  }));
+
+  const last30OrderIds = last30Orders.map((order) => order.id);
+  const topItemsByName = new Map<string, LiveTopItem>();
+  if (last30OrderIds.length > 0) {
+    const lineRows = await db
+      .select()
+      .from(orderLines)
+      .where(inArray(orderLines.orderId, last30OrderIds));
+
+    for (const line of lineRows) {
+      const current = topItemsByName.get(line.itemName) ?? {
+        name: line.itemName,
+        qty: 0,
+        revenue: 0,
+      };
+      current.qty += line.qty;
+      current.revenue = money(current.revenue + money(line.lineTotal));
+      topItemsByName.set(line.itemName, current);
+    }
+  }
+
+  return {
+    revenue,
+    orders: orderCount,
+    avgOrder,
+    awaitingPickup,
+    readyOverSevenDays,
+    spark: Array.from(sparkBuckets.values()),
+    topItems: Array.from(topItemsByName.values())
+      .sort((a, b) => b.revenue - a.revenue)
+      .slice(0, 5),
+    recentOrders,
+  };
+}
+
+export async function getLiveReportsData(tenantId: string): Promise<LiveReportsData> {
+  const now = new Date();
+  const nowParts = sydneyDateParts(now);
+  const currentMonth = sydneyLocalDateToUtc(nowParts.year, nowParts.month, 1);
+  const firstMonth = addSydneyMonths(currentMonth, -5);
+  const nextMonthStart = addSydneyMonths(currentMonth, 1);
+  const months = Array.from({ length: 6 }, (_, index) => {
+    return addSydneyMonths(firstMonth, index);
+  });
+
+  const orderRows = await db
+    .select()
+    .from(orders)
+    .where(and(eq(orders.tenantId, tenantId), gte(orders.createdAt, firstMonth), lt(orders.createdAt, nextMonthStart)))
+    .orderBy(desc(orders.createdAt));
+
+  const monthlyTotals = new Map(months.map((month) => [monthKey(month), 0]));
+  const gstTotals = new Map(months.map((month) => [monthKey(month), 0]));
+
+  for (const order of orderRows) {
+    if (!order.createdAt) continue;
+    const key = monthKey(order.createdAt);
+    monthlyTotals.set(key, money((monthlyTotals.get(key) ?? 0) + money(order.total)));
+    gstTotals.set(key, money((gstTotals.get(key) ?? 0) + money(order.gst)));
+  }
+
+  const revenue = money(orderRows.reduce((sum, order) => sum + money(order.total), 0));
+  const orderCount = orderRows.length;
+  const avgOrder = orderCount > 0 ? money(revenue / orderCount) : 0;
+  const gst = money(orderRows.reduce((sum, order) => sum + money(order.gst), 0));
+  const monthlyRevenue = months.map((month) => ({
+    month: monthKey(month),
+    label: monthLabel(month),
+    revenue: money(monthlyTotals.get(monthKey(month)) ?? 0),
+  }));
+  const gstRows = [...months].reverse().map((month) => {
+    const gross = money(monthlyTotals.get(monthKey(month)) ?? 0);
+    const rowGst = money(gstTotals.get(monthKey(month)) ?? 0);
+    const net = money(gross - rowGst);
+    const fees = estimateStripeFees(gross);
+    return {
+      period: monthPeriod(month),
+      gross,
+      gst: rowGst,
+      net,
+      fees,
+      payout: money(net - fees),
+    };
+  });
+
+  const orderIds = orderRows.map((order) => order.id);
+  const categoryTotals = new Map<string, number>();
+  if (orderIds.length > 0) {
+    const lineRows = await db
+      .select({
+        category: catalogItems.category,
+        lineTotal: orderLines.lineTotal,
+      })
+      .from(orderLines)
+      .leftJoin(
+        catalogItems,
+        and(eq(orderLines.itemId, catalogItems.id), eq(catalogItems.tenantId, tenantId))
+      )
+      .where(inArray(orderLines.orderId, orderIds));
+
+    for (const line of lineRows) {
+      const category = line.category ?? "Uncategorised";
+      categoryTotals.set(category, money((categoryTotals.get(category) ?? 0) + money(line.lineTotal)));
+    }
+  }
+
+  const categoryTotal = money(
+    Array.from(categoryTotals.values()).reduce((sum, value) => sum + value, 0)
+  );
+  const categoryRevenue = Array.from(categoryTotals.entries())
+    .map(([cat, categoryRevenueValue]) => ({
+      cat,
+      revenue: money(categoryRevenueValue),
+      pct: categoryTotal > 0 ? money((categoryRevenueValue / categoryTotal) * 100) : 0,
+    }))
+    .sort((a, b) => b.revenue - a.revenue);
+
+  return {
+    revenue,
+    orders: orderCount,
+    avgOrder,
+    gst,
+    monthlyRevenue,
+    categoryRevenue,
+    gstRows,
+  };
 }
 
 export async function getOrderById(orderId: string) {

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -1,8 +1,21 @@
 import { createNeonAuth } from "@neondatabase/auth/next/server";
 
-export const auth = createNeonAuth({
-  baseUrl: process.env.NEON_AUTH_BASE_URL!,
-  cookies: {
-    secret: process.env.NEON_AUTH_COOKIE_SECRET!,
-  },
-});
+let authClient: ReturnType<typeof createNeonAuth> | null = null;
+
+export function getAuth() {
+  if (authClient) return authClient;
+
+  const baseUrl = process.env.NEON_AUTH_BASE_URL;
+  const cookieSecret = process.env.NEON_AUTH_COOKIE_SECRET;
+  if (!baseUrl || !cookieSecret) {
+    throw new Error("Neon Auth environment variables are not configured");
+  }
+
+  authClient = createNeonAuth({
+    baseUrl,
+    cookies: {
+      secret: cookieSecret,
+    },
+  });
+  return authClient;
+}

--- a/apps/web/src/lib/stripe.ts
+++ b/apps/web/src/lib/stripe.ts
@@ -1,3 +1,15 @@
 import Stripe from "stripe";
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+let stripeClient: Stripe | null = null;
+
+export function getStripe(): Stripe {
+  if (stripeClient) return stripeClient;
+
+  const apiKey = process.env.STRIPE_SECRET_KEY;
+  if (!apiKey) {
+    throw new Error("STRIPE_SECRET_KEY is not configured");
+  }
+
+  stripeClient = new Stripe(apiKey);
+  return stripeClient;
+}

--- a/docs/FEATURE_AUDIT.md
+++ b/docs/FEATURE_AUDIT.md
@@ -134,7 +134,7 @@ The prototype (`my_doc/UI_prototypes/project/superadmin.jsx`) defines four scree
 | Item | Status | Notes |
 |---|---|---|
 | Neon PostgreSQL database | ✅ Done | Serverless Postgres on `aws-ap-southeast-2`; project `cool-wind-76972110` |
-| Drizzle ORM schema | ✅ Done | 6 tables: `tenants`, `catalog_items`, `catalog_variants`, `orders`, `order_lines`, `stripe_accounts` |
+| Drizzle ORM schema | ✅ Done | 5 tables: `tenants`, `catalog_items`, `catalog_variants`, `orders`, `order_lines` — Stripe Connect fields (`stripe_account_id`, `stripe_payouts_enabled`, `stripe_charges_enabled`) are columns on `tenants`, not a separate table |
 | Seed data | ✅ Done | 2 tenants (NSBH, RGHS), 19 catalog items, 30 variants, 3 sample orders |
 | Neon Auth integration | ✅ Done | `@neondatabase/auth` configured; `GET/POST /api/auth/[...path]` route handler |
 | Stripe SDK | ✅ Done | `stripe` v17 installed; test-mode keys configured in `.env.local` |

--- a/docs/FEATURE_AUDIT.md
+++ b/docs/FEATURE_AUDIT.md
@@ -14,6 +14,7 @@
 | 30 Apr 2026 | Initial audit — baseline snapshot of implemented vs missing features |
 | 1 May 2026 | **High-priority items 1–5 completed:** Add product modal, orders search, live orders history, live order detail, Stripe Connect onboarding. Neon PostgreSQL backend added (Drizzle ORM, 6-table schema, seeded). 7 API routes created. Checkout now persists to DB. |
 | 2 May 2026 | **Medium-priority items 6–11 completed:** Bulk upload CSV navigation, print pick slips (`window.print()` + print CSS), save changes on settings (live PATCH API), export CSV on reports (client-side blob download), download template (real CSV file served from `/public`), status advance buttons on order detail (live end-to-end tested). |
+| 2 May 2026 | **Checkout/admin live-data completion:** Checkout now confirms Stripe Card Element payments before creating orders and stores the confirmed PaymentIntent ID. Dashboard recent orders, 30-day KPIs, top items, and reports now read tenant-scoped live Neon order data. |
 
 ---
 
@@ -28,7 +29,7 @@
 | Cart screen with GST breakdown | ✅ Done | GST shown as 1/11 of subtotal |
 | Checkout with student details form | ✅ Done | Name, year, roll class, parent name, mobile, email; validated before submit |
 | Delivery toggle (Pickup / Ship $9.50) | ✅ Done | |
-| Stripe payment UI (mock) | ✅ Done | Card number / expiry / CVC fields; `POST /api/stripe/payment-intent` creates real Stripe PaymentIntent in test mode |
+| Stripe payment UI (live) | ✅ Done | Live Stripe Card Element flow; `POST /api/stripe/payment-intent` + client confirmation before order creation; confirmed PaymentIntent ID is stored with the order |
 | Order placed confirmation | ✅ Done | Dynamic order ID from DB; delivery method and total shown |
 | Orders history page | ✅ Done | Fetches live orders from Neon DB via `GET /api/orders?email=...`; newly placed orders appear immediately |
 | "Add another child" button | ❌ Not wired | Button renders on school picker but has no `onClick` or navigation |
@@ -43,11 +44,11 @@
 
 | Feature | Status | Notes |
 |---|---|---|
-| Revenue / orders / avg-order / awaiting-pickup KPIs | ✅ Done | |
+| Revenue / orders / avg-order / awaiting-pickup KPIs | ✅ Done | 30-day KPI cards now computed from tenant-scoped live Neon orders |
 | Sparkline charts on KPI cards | ✅ Done | |
-| Top-selling items table with share bars | ✅ Done | |
+| Top-selling items table with share bars | ✅ Done | Built from tenant-scoped live Neon order-line aggregates |
 | Needs-attention alerts | ✅ Done | |
-| Recent orders feed | ⚠️ Static | Reads from `ADMIN_ORDERS` constant; does not yet reflect orders placed via the parent portal |
+| Recent orders feed | ✅ Done | Reads tenant-scoped live Neon orders; reflects parent-portal checkout activity |
 | "New product" button | ❌ Not wired | Renders but has no action |
 | "Export" button | ❌ Not wired | Renders but has no action |
 
@@ -97,9 +98,9 @@
 
 | Feature | Status | Notes |
 |---|---|---|
-| Monthly revenue bar chart | ✅ Done | |
-| Revenue by category breakdown | ✅ Done | |
-| GST / BAS-ready summary table | ✅ Done | Gross, GST collected, net ex-GST, Stripe fees, net payout |
+| Monthly revenue bar chart | ✅ Done | Uses tenant-scoped live Neon order totals by month |
+| Revenue by category breakdown | ✅ Done | Uses tenant-scoped live Neon order totals joined to catalog categories |
+| GST / BAS-ready summary table | ✅ Done | Monthly live totals from tenant-scoped Neon orders: gross, GST collected, net ex-GST, estimated Stripe fees, net payout |
 | "Export CSV" button | ✅ Done | `ExportCsvButton` client component generates a CSV blob in the browser from the GST summary rows and triggers a file download (e.g. `nsbh-gst-report.csv`) — no API round-trip |
 
 ### Settings
@@ -142,7 +143,7 @@ The prototype (`my_doc/UI_prototypes/project/superadmin.jsx`) defines four scree
 | Stripe payment intent API | ✅ Done | `POST /api/stripe/payment-intent` |
 | Stripe Connect API | ✅ Done | `GET /api/stripe/connect`, `POST /api/stripe/connect` |
 | Tenant settings API | ✅ Done | `PATCH /api/tenant/[tenantId]` |
-| Dashboard recent orders live | ❌ Not connected | Still reads from `ADMIN_ORDERS` static constant |
+| Dashboard recent orders live | ✅ Done | Dashboard and reports now read tenant-scoped Neon order data for recent orders, KPIs, top items, and monthly aggregates |
 | Missing catalog items | ❌ Not seeded | NSBH paper form items not yet in DB: Navy Shorts (Summer), Grey Socks (Winter), School Scarf, Swimming Briefs, Soccer Jersey, Exercise Books, Ring Binders, Prefect Tie |
 
 ---
@@ -159,7 +160,6 @@ The prototype (`my_doc/UI_prototypes/project/superadmin.jsx`) defines four scree
 | 15 | "Add another child" flow on school picker | Lower |
 | 16 | Missing catalog items (Navy Shorts, Grey Socks, Scarf, etc.) | Lower |
 | 17 | "Riley wore size X last year" hint driven by live order history | Lower |
-| 18 | Dashboard recent orders connected to live Neon DB | Lower |
 
 ### Items completed since initial audit
 

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -1,0 +1,44 @@
+# Known Issues
+
+---
+
+## 1. "Riley wore size X last year" hint is hardcoded
+
+**File:** `apps/web/src/app/[tenant]/item/[itemId]/interactive.tsx:147`
+
+**Problem:** The size hint shown beneath the size selector on the item detail page is a static string `"Riley wore size 14 last year"`. It does not reflect the actual parent's order history or their child's name.
+
+**Proper fix — three pieces:**
+
+### 1. New db query (`apps/web/src/db/queries.ts`)
+
+```ts
+export async function getPreviousSizeHint(tenantId: string, email: string, itemId: string) {
+  const rows = await db
+    .select({ studentName: orders.studentName, variantLabel: orderLines.variantLabel, createdAt: orders.createdAt })
+    .from(orders)
+    .innerJoin(orderLines, eq(orderLines.orderId, orders.id))
+    .where(and(eq(orders.tenantId, tenantId), eq(orders.parentEmail, email), eq(orderLines.itemId, itemId)))
+    .orderBy(desc(orders.createdAt))
+    .limit(1);
+  return rows[0] ?? null;
+}
+```
+
+### 2. New API route
+
+`GET /api/orders/size-hint?tenantId=...&email=...&itemId=...`
+
+Returns `{ studentName, variantLabel }` or `null`. A dedicated route is cleaner than extending the existing orders route.
+
+### 3. Wire `interactive.tsx`
+
+Add a `useEffect` that:
+1. Calls `readStudentDetails()` (from `@/lib/order-store`) to get the parent's email from `uo:student:v1` localStorage
+2. Fetches `/api/orders/size-hint?tenantId=...&email=...&itemId=${item.id}`
+3. If a result is returned, renders `"{studentName} wore {variantLabel} last year"` dynamically
+4. If no result (first-time buyer or item never ordered), hides the hint entirely
+
+**Notes:**
+- The email and student name are already persisted to localStorage during checkout via `writeStudentDetails()` — no new storage needed
+- The hint should only appear when there is a real match; don't fall back to any hardcoded value

--- a/docs/remaining_work.md
+++ b/docs/remaining_work.md
@@ -1,0 +1,240 @@
+# Remaining Work — Pre-Go-Live Backlog
+
+**Project:** Uniform Online Order System
+**Author:** Engineering audit
+**Date:** 5 May 2026
+**Sources:** [PDP](../my_doc/PDP.md), [FEATURE_AUDIT.md](./FEATURE_AUDIT.md), live codebase scan
+
+This document lists every item that must be resolved (or explicitly deferred) before the platform can go live with a paying NSW school. Items are grouped by severity. Each item maps back to either a PDP requirement, an unfinished feature from the audit, or a production-readiness gap discovered during the codebase scan.
+
+---
+
+## Severity legend
+
+| Level | Meaning |
+|---|---|
+| 🔴 **Blocker** | Cannot go live — money flow, legal, or security risk |
+| 🟠 **High** | Must ship for an acceptable v1 launch |
+| 🟡 **Medium** | Required by PDP / prototype but tolerable for soft launch |
+| 🟢 **Low** | Nice-to-have, post-launch acceptable |
+
+---
+
+## 1. 🔴 Blockers — must fix before any real money moves
+
+### 1.1 Stripe Connect payments do not actually route to the school
+
+**Where:** [apps/web/src/app/api/stripe/payment-intent/route.ts](file:///Volumes/T7/georgeqiao/dev/uniform_order/apps/web/src/app/api/stripe/payment-intent/route.ts)
+
+The PDP names **Stripe Connect** as the payment provider so that "payments route directly to the respective school's bank account." The current `PaymentIntent` is created on the **platform account only** — there is no `transfer_data.destination`, no `on_behalf_of`, and no `application_fee_amount`. Even though `tenants.stripe_account_id` is fetched, it is never passed to Stripe.
+
+**Required:**
+- Add `transfer_data: { destination: tenant.stripeAccountId }` (or use destination charges / direct charges, decide model).
+- Optional `application_fee_amount` for platform revenue share.
+- Refuse to create the intent if `tenant.stripeChargesEnabled !== true`.
+- Document the Connect model chosen (destination vs direct vs separate charges & transfers).
+
+### 1.2 Admin portal has no authentication guard
+
+**Where:** [apps/web/src/app/admin/[tenant]/layout.tsx](file:///Volumes/T7/georgeqiao/dev/uniform_order/apps/web/src/app/admin/%5Btenant%5D/layout.tsx), [apps/web/src/components/admin-shell.tsx](file:///Volumes/T7/georgeqiao/dev/uniform_order/apps/web/src/components/admin-shell.tsx)
+
+Anyone who knows the URL `/admin/nsbh/orders` can read every order, mutate status, edit catalog, change settings, and trigger Stripe Connect onboarding. Neon Auth is installed but not enforced anywhere on `/admin/*` or on the corresponding API routes.
+
+**Required:**
+- Add a server-side session check in the admin layout; redirect unauthenticated users to a sign-in page.
+- Add an authorization check linking `userId` → `tenantId` (operators must only see their school).
+- Apply the same check to every mutating API route (`POST/PATCH/DELETE /api/orders`, `/api/catalog`, `/api/tenant`, `/api/stripe/connect`).
+
+### 1.3 Customer order data API is unauthenticated
+
+**Where:** [apps/web/src/app/api/orders/route.ts](file:///Volumes/T7/georgeqiao/dev/uniform_order/apps/web/src/app/api/orders/route.ts), [apps/web/src/app/api/orders/[orderId]/route.ts](file:///Volumes/T7/georgeqiao/dev/uniform_order/apps/web/src/app/api/orders/%5BorderId%5D/route.ts)
+
+`GET /api/orders?email=...` returns full PII (parent name, mobile, student name and class) for any email passed in. This is an enumeration vector and a privacy breach under the Australian Privacy Principles.
+
+**Required:**
+- Either gate behind a parent sign-in (Neon Auth) and filter by `userId`, or send a verification token to the parent email and require it on read.
+- Apply rate limiting on `GET /api/orders` and `/api/orders/[id]`.
+
+### 1.4 No transactional email — order confirmation and "ready for pickup"
+
+**Where:** No mail provider (Resend / SendGrid / Postmark / SES) is in `package.json`; only `mailto:` links exist.
+
+PDP §3.1 requires "automated email notifications when orders are placed and when they are ready for pick-up." The "Notify parent" button on Ready cards merely opens the operator's mail client.
+
+**Required:**
+- Pick a provider (Resend recommended for Next.js + AU compliance).
+- Send order confirmation on `POST /api/orders` success.
+- Send "ready for pickup" automatically when status transitions to `ready` in `PATCH /api/orders/[id]`.
+- Send "your order has been collected" optional acknowledgement.
+- Templates with tenant branding (accent colour, school name).
+
+### 1.5 Refund / exchange policy not enforced or shown
+
+**Where:** Checkout footer mentions "agree to refund policy"; no `/refund-policy` route exists. PDP §4 explicitly says: "the platform will enforce refund/exchange policies directly at checkout (e.g., items must be in original packaging with tags; shirts cannot be refunded if opened)."
+
+**Required:**
+- Static content page at `/[tenant]/refund-policy` (or `/policies/refunds`) — copy reviewed by school.
+- Tickbox at checkout that blocks payment until accepted; persist consent on the order.
+- Operator-facing refund/exchange action on order detail (see §2.1).
+
+### 1.6 No legal pages — Terms, Privacy
+
+For a payment site collecting student PII, AU consumer law and the Privacy Act 1988 require accessible Privacy Policy and Terms of Service before launch.
+
+**Required:** `/terms`, `/privacy` static pages, linked in the footer of both portals.
+
+---
+
+## 2. 🟠 High — required for an acceptable v1
+
+### 2.1 Refund / exchange UI on order detail (admin)
+
+**Where:** [apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx](file:///Volumes/T7/georgeqiao/dev/uniform_order/apps/web/src/app/admin/%5Btenant%5D/orders/%5BorderId%5D/page.tsx)
+
+PDP §2 names "handle refunds/exchanges" as a core operator capability. No UI exists. The audit lists this as item 13.
+
+**Required:**
+- "Refund full / refund line / exchange" actions on order detail.
+- Stripe refund call (`stripe.refunds.create`) — partial-amount supported.
+- New `order_refunds` table (or `order_lines.refunded_qty`) to record refunded items, reason, operator userId, refundedAt.
+- Status chip should reflect "Partially refunded" / "Refunded".
+
+### 2.2 Super-admin / platform portal — none of 4 screens exist
+
+**Where:** No `/platform` or `/superadmin` routes. Prototype lives at `my_doc/UI_prototypes/project/superadmin.jsx`.
+
+Without this, onboarding a second school requires running a SQL seed script. For multi-tenant go-live this is a blocker for tenant #2 (RGSH already exists from seed but cannot be edited via UI).
+
+**Required:**
+- `/platform` (or `/superadmin`) section gated to platform-admin role.
+- Tenants list with KPIs and status badges.
+- "Provision new tenant" 6-step wizard (identity, branding, billing/Stripe, operator, catalog import, go-live).
+- Platform-level Stripe payouts overview.
+- Branding editor (logo upload, accent colour picker, live parent preview).
+
+### 2.3 Stripe webhook handler
+
+No webhook endpoint exists. Without it the system cannot reliably reconcile:
+- `payment_intent.succeeded` / `.payment_failed` (currently relies on client-side confirmation only — a closed browser between confirm and `POST /api/orders` produces a paid Stripe charge with no order in the DB).
+- `account.updated` (Stripe Connect onboarding completion — `stripePayoutsEnabled` / `stripeChargesEnabled` go stale).
+- `charge.refunded` (out-of-band refunds done in Stripe Dashboard).
+
+**Required:** `POST /api/stripe/webhook` with signature verification and idempotent handling for those three events.
+
+### 2.4 Order placement is not idempotent / not atomic with payment
+
+**Where:** [apps/web/src/app/[tenant]/checkout/checkout-screen.tsx](file:///Volumes/T7/georgeqiao/dev/uniform_order/apps/web/src/app/%5Btenant%5D/checkout/checkout-screen.tsx)
+
+Confirm-then-create-order means a transient network failure between Stripe confirm and `POST /api/orders` charges the parent without creating an order. Refunds would have to be done manually.
+
+**Required:**
+- Create the DB order in `pending` status before payment, then transition on webhook.
+- Or use a one-shot idempotency key on `POST /api/orders` derived from the PaymentIntent ID.
+
+### 2.5 Cart is `localStorage`-only and seeded with `SAMPLE_CART`
+
+**Where:** [apps/web/src/lib/cart-store.ts](file:///Volumes/T7/georgeqiao/dev/uniform_order/apps/web/src/lib/cart-store.ts)
+
+A first-time visitor sees pre-populated demo items in their cart. Acceptable for a prototype, unacceptable for production.
+
+**Required:** Empty initial cart; remove `SAMPLE_CART` seeding (keep as fixture only in dev/storybook).
+
+### 2.6 Production environment configuration
+
+- Switch from Stripe **test** keys to **live** keys (today `.env.local` is test mode per audit).
+- Production database URL pinned to a non-shared Neon branch.
+- `NEXT_PUBLIC_*` keys reviewed (no secret leaks).
+- Vercel project (or chosen host) with environment groups for `preview` / `production`.
+- Domain + TLS (`uniformsonline.com.au` or per-tenant subdomains).
+- Add `vercel.json` headers (`Strict-Transport-Security`, `X-Content-Type-Options`, `Referrer-Policy`, basic CSP).
+
+### 2.7 Error handling, logging, observability
+
+- No error boundary / global `error.tsx` / `not-found.tsx` styled to brand.
+- No structured logging or monitoring (Sentry / Logtail / PostHog).
+- API routes only `console.error` — failures are silent in production.
+
+**Required:** `error.tsx`, `not-found.tsx`, Sentry (or equivalent) wired to both client and server, request-id correlation in logs.
+
+---
+
+## 3. 🟡 Medium — required by PDP/prototype, tolerable for soft launch
+
+### 3.1 Missing catalog items from the paper form
+
+**Where:** [apps/web/src/db/queries.ts](file:///Volumes/T7/georgeqiao/dev/uniform_order/apps/web/src/db/queries.ts) seed data; audit §4.
+
+NSBH paper form items missing from the seed: Navy Shorts (Summer), Grey Socks (Winter), School Scarf, Swimming Briefs, Soccer Jersey, Exercise Books, Ring Binders, Prefect Tie. PDP §4 lists these explicitly.
+
+**Required:** Update seed + run a one-off insert against production for both NSBH and RGSH (RGSH catalog needs review with the school).
+
+### 3.2 Refund-policy *page* (the actual content)
+
+Already counted in §1.5 as a blocker for the consent step. Listed again here because the content itself (copy, signed off by each school's bursar) is a content task, not a code task.
+
+### 3.3 "Add another child" flow on school picker
+
+**Where:** [apps/web/src/app/page.tsx](file:///Volumes/T7/georgeqiao/dev/uniform_order/apps/web/src/app/page.tsx)
+
+Button renders, has no `onClick`. Audit item 15. PDP allows ordering for multiple children — without this, families with siblings have to re-checkout per child.
+
+### 3.4 Order tracking page for parents
+
+PDP §3.1 mentions "order tracking" beyond an emailed receipt. Today the parent orders list shows status text but no per-order timeline (placed → packing → ready → collected). Add a parent-facing detail page at `/[tenant]/order/[orderId]` keyed by parent email + order ID.
+
+### 3.5 Stripe Connect onboarding completion polling / webhook
+
+`GET /api/stripe/connect` reads `stripePayoutsEnabled` from the DB but the field is only updated when the operator returns to the page. A drop-off mid-onboarding leaves the school looking "not connected" forever. Tied to webhook work in §2.3 (`account.updated`).
+
+### 3.6 GST / BAS report — auditor sign-off
+
+The reports page produces monthly GST totals client-side. Before go-live, have an Australian accountant confirm the formula (1/11 of GST-inclusive total), the rounding rules, and the Stripe-fee deduction model.
+
+### 3.7 Print stylesheet QA
+
+`window.print()` works for pick slips, but needs verification on real A4 in Chrome and Safari (page breaks for multi-page picks, single-slip-per-page mode for batch printing).
+
+### 3.8 Accessibility audit
+
+No automated a11y tests run today. At minimum: keyboard nav through the parent flow, `aria-label`s on icon buttons (cart, add-to-cart, status pills), colour-contrast on the burgundy `#7A1F2B` accent.
+
+### 3.9 Mobile shell viewport edge cases
+
+`MobileShell` caps at 430px. Verify behaviour on iPhone SE (375px), Android landscape, and iPad split-view.
+
+---
+
+## 4. 🟢 Low — post-launch acceptable
+
+| # | Item | Source |
+|---|---|---|
+| 4.1 | "Riley wore size X last year" hint driven from live order history | Audit item 17 |
+| 4.2 | "New product" and "Export" buttons on Dashboard wired up | Audit §2 / Dashboard |
+| 4.3 | Bulk operator "Email parents" with real send (currently `mailto:`) | Orders board |
+| 4.4 | i18n scaffolding for future non-NSW expansion (PDP §7 Phase 3) | PDP roadmap |
+| 4.5 | Inventory stock counts (the schema has none — quantities are unbounded) | PDP §3.2 hints at "Update stock levels" |
+| 4.6 | Operator audit log (who marked the order ready, who refunded) | Inferred from refund work |
+| 4.7 | Catalog sortable / drag-to-reorder | Prototype only |
+| 4.8 | Drizzle migrations checked into the repo (currently schema is push-only) | Ops |
+
+---
+
+## 5. Suggested go-live checklist (one page)
+
+1. ☐ Stripe Connect destination charges in `payment-intent` route (§1.1)
+2. ☐ Admin auth + per-tenant authorization (§1.2)
+3. ☐ Parent orders API gated by auth or token (§1.3)
+4. ☐ Transactional email — order placed + order ready (§1.4)
+5. ☐ Refund policy page + checkout consent (§1.5)
+6. ☐ Terms + Privacy pages (§1.6)
+7. ☐ Refund/exchange action on order detail (§2.1)
+8. ☐ Stripe webhook endpoint (§2.3)
+9. ☐ Idempotent order creation tied to PaymentIntent (§2.4)
+10. ☐ Empty initial cart, no demo seed (§2.5)
+11. ☐ Production env, live Stripe keys, security headers (§2.6)
+12. ☐ Sentry + error/not-found pages (§2.7)
+13. ☐ Catalog seeded with full NSBH paper-form items (§3.1)
+14. ☐ Accountant sign-off on GST report (§3.6)
+15. ☐ Manual end-to-end test: parent orders → Stripe charge → operator marks ready → parent receives email → operator refunds one line → Stripe refund visible
+
+The super-admin portal (§2.2) is required for onboarding tenant #3 and beyond, but the launch tenant (NSBH) can ship without it provided RGSH stays on seed data.

--- a/docs/superpowers/plans/2026-05-02-stripe-checkout-live-admin-data.md
+++ b/docs/superpowers/plans/2026-05-02-stripe-checkout-live-admin-data.md
@@ -1,0 +1,997 @@
+# Stripe Checkout and Live Admin Data Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the mock checkout payment path with confirmed Stripe card payments and move admin dashboard/reporting data from static fixtures to tenant-scoped live Neon orders.
+
+**Architecture:** Keep checkout in the existing mobile client component, using `@stripe/stripe-js` directly with a mounted Card Element and the existing `/api/stripe/payment-intent` route. Add live analytics helpers to `apps/web/src/db/queries.ts`, then feed dashboard and reports server pages with parsed, tenant-scoped aggregate data.
+
+**Tech Stack:** Next.js App Router, React client components, Stripe JS, Drizzle ORM, Neon PostgreSQL, pnpm workspaces, TypeScript.
+
+---
+
+## File Structure
+
+- Modify `apps/web/src/app/[tenant]/checkout/checkout-screen.tsx`
+  - Owns form validation, Stripe Card Element mounting, PaymentIntent creation, card confirmation, order creation, and inline checkout errors.
+- Modify `apps/web/src/db/queries.ts`
+  - Adds tenant-scoped live admin analytics helpers and order summary mapping.
+- Modify `apps/web/src/app/admin/[tenant]/dashboard/page.tsx`
+  - Replaces `SALES_DATA` and static recent orders with live query helper output.
+- Modify `apps/web/src/app/admin/[tenant]/dashboard/dashboard-client.tsx`
+  - Replaces fixture types with compact live analytics props, adds empty states, and keeps the existing visual layout.
+- Modify `apps/web/src/app/admin/[tenant]/reports/page.tsx`
+  - Replaces static report arrays with live query helper output.
+- Optionally modify `docs/FEATURE_AUDIT.md`
+  - Updates fixed-item notes after verification succeeds.
+
+## Task 1: Implement Live Stripe Checkout
+
+**Files:**
+- Modify: `apps/web/src/app/[tenant]/checkout/checkout-screen.tsx`
+
+- [ ] **Step 1: Add Stripe imports and state**
+
+Add the Stripe JS imports near the top of `checkout-screen.tsx`:
+
+```ts
+import { loadStripe, type Stripe, type StripeCardElement, type StripeElements } from "@stripe/stripe-js";
+```
+
+Change the existing React import to include `useRef`:
+
+```ts
+import { useState, useEffect, useRef } from "react";
+```
+
+Add module-level Stripe key/client setup below `YEAR_OPTIONS`:
+
+```ts
+const stripePublishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+const stripePromise = stripePublishableKey ? loadStripe(stripePublishableKey) : null;
+```
+
+Add these refs/state inside `CheckoutScreen`:
+
+```ts
+const cardMountRef = useRef<HTMLDivElement | null>(null);
+const stripeRef = useRef<Stripe | null>(null);
+const elementsRef = useRef<StripeElements | null>(null);
+const cardRef = useRef<StripeCardElement | null>(null);
+const [paymentReady, setPaymentReady] = useState(false);
+const [paymentError, setPaymentError] = useState<string | null>(
+  stripePublishableKey ? null : "Stripe checkout is not configured. Add NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY."
+);
+```
+
+- [ ] **Step 2: Mount the Stripe Card Element**
+
+Add this effect after the saved-student effect:
+
+```ts
+useEffect(() => {
+  let cancelled = false;
+
+  if (!stripePromise || !cardMountRef.current) return;
+
+  async function mountCard() {
+    const stripe = await stripePromise;
+    if (!stripe || cancelled || !cardMountRef.current || cardRef.current) return;
+
+    const elements = stripe.elements();
+    const card = elements.create("card", {
+      hidePostalCode: true,
+      style: {
+        base: {
+          color: "#1F2933",
+          fontFamily: "Inter, system-ui, sans-serif",
+          fontSize: "14px",
+          "::placeholder": { color: "#8A8175" },
+        },
+        invalid: { color: "#B23A2A" },
+      },
+    });
+
+    card.on("ready", () => {
+      setPaymentReady(true);
+      setPaymentError(null);
+    });
+    card.on("change", (event) => {
+      setPaymentError(event.error?.message ?? null);
+    });
+
+    card.mount(cardMountRef.current);
+    stripeRef.current = stripe;
+    elementsRef.current = elements;
+    cardRef.current = card;
+  }
+
+  mountCard();
+
+  return () => {
+    cancelled = true;
+    cardRef.current?.destroy();
+    cardRef.current = null;
+    elementsRef.current = null;
+    stripeRef.current = null;
+    setPaymentReady(false);
+  };
+}, []);
+```
+
+- [ ] **Step 3: Replace the order-only submit with payment-first submit**
+
+Replace `onPay` with this flow:
+
+```ts
+const onPay = async () => {
+  if (!validate()) return;
+  if (lines.length === 0) {
+    setPaymentError("Your cart is empty.");
+    return;
+  }
+  if (!stripeRef.current || !cardRef.current || !paymentReady) {
+    setPaymentError("Payment form is still loading. Please try again in a moment.");
+    return;
+  }
+
+  writeStudentDetails(student);
+  setPaying(true);
+  setPaymentError(null);
+
+  let paymentIntentId: string | null = null;
+
+  try {
+    const intentRes = await fetch("/api/stripe/payment-intent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tenantId: tenant.id,
+        amount: total,
+        currency: "aud",
+        metadata: {
+          parentEmail: student.email,
+          studentName: student.studentName,
+          delivery,
+        },
+      }),
+    });
+
+    const intentData = await intentRes.json().catch(() => null);
+    if (!intentRes.ok || !intentData?.clientSecret || !intentData?.paymentIntentId) {
+      throw new Error(intentData?.error ?? "Failed to start Stripe payment.");
+    }
+
+    paymentIntentId = intentData.paymentIntentId;
+
+    const confirmation = await stripeRef.current.confirmCardPayment(intentData.clientSecret, {
+      payment_method: {
+        card: cardRef.current,
+        billing_details: {
+          name: student.parentName,
+          email: student.email,
+          phone: student.mobile,
+        },
+      },
+    });
+
+    if (confirmation.error) {
+      throw new Error(confirmation.error.message ?? "Payment was not completed.");
+    }
+
+    if (confirmation.paymentIntent?.status !== "succeeded") {
+      throw new Error("Payment was not completed. Please check your card details and try again.");
+    }
+
+    const orderRes = await fetch("/api/orders", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tenantId: tenant.id,
+        parentName: student.parentName,
+        parentEmail: student.email,
+        parentMobile: student.mobile,
+        studentName: student.studentName,
+        studentYear: student.year,
+        studentRoll: student.rollClass,
+        delivery,
+        deliveryFee: delivery === "ship" ? 9.5 : 0,
+        subtotal,
+        gst,
+        total,
+        stripePaymentIntentId: confirmation.paymentIntent.id,
+        lines: lines.map((l) => ({
+          itemId: l.itemId,
+          itemName: l.name,
+          variantLabel: l.variantLabel,
+          qty: l.qty,
+          unitPrice: l.price,
+          lineTotal: l.price * l.qty,
+        })),
+      }),
+    });
+
+    const orderData = await orderRes.json().catch(() => null);
+    if (!orderRes.ok || !orderData?.orderId) {
+      throw new Error(
+        `Payment succeeded (${confirmation.paymentIntent.id}) but the order could not be saved. Please contact the uniform shop before retrying.`
+      );
+    }
+
+    clearCart();
+    router.push(`/${tenant.id}/order/placed?total=${total.toFixed(2)}&delivery=${delivery}&orderId=${orderData.orderId}`);
+  } catch (err) {
+    console.error("Checkout error:", err);
+    const message = err instanceof Error ? err.message : "Checkout failed. Please try again.";
+    setPaymentError(
+      paymentIntentId && message.includes("order could not be saved")
+        ? message
+        : message
+    );
+    setPaying(false);
+  }
+};
+```
+
+- [ ] **Step 4: Replace the mock payment block with the mounted card UI**
+
+In the payment section, replace the fake card number/expiry/CVC blocks with:
+
+```tsx
+<div
+  className="rounded-md border bg-white px-3 py-3 min-h-11"
+  style={{ borderColor: paymentError ? "#B23A2A" : "var(--color-rule)" }}
+>
+  <div ref={cardMountRef} />
+</div>
+{!stripePublishableKey && (
+  <div className="mt-2 text-[11px]" style={{ color: "#B23A2A" }}>
+    Stripe checkout is not configured for this environment.
+  </div>
+)}
+{stripePublishableKey && !paymentReady && !paymentError && (
+  <div className="mt-2 text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+    Loading secure payment form…
+  </div>
+)}
+{paymentError && (
+  <div className="mt-2 text-[11px] leading-[1.4]" style={{ color: "#B23A2A" }}>
+    {paymentError}
+  </div>
+)}
+```
+
+Keep the Stripe badge and secure-payment copy above this block.
+
+- [ ] **Step 5: Disable payment until Stripe is ready**
+
+Update the footer button disabled state:
+
+```tsx
+disabled={paying || lines.length === 0 || !stripePublishableKey || !paymentReady}
+```
+
+Update the button text:
+
+```tsx
+{paying ? "Processing…" : !stripePublishableKey ? "Payment unavailable" : `Pay $${total.toFixed(2)} securely`}
+```
+
+- [ ] **Step 6: Type-check the checkout change**
+
+Run:
+
+```bash
+pnpm check-types:web
+```
+
+Expected: TypeScript exits successfully. If `PageProps` or `LayoutProps` route types are missing, run `pnpm --filter web exec next typegen`, then rerun `pnpm check-types:web`.
+
+## Task 2: Add Live Admin Analytics Query Helpers
+
+**Files:**
+- Modify: `apps/web/src/db/queries.ts`
+
+- [ ] **Step 1: Extend Drizzle imports**
+
+Update the import from `drizzle-orm`:
+
+```ts
+import { and, eq, desc, or, gte, inArray } from "drizzle-orm";
+```
+
+- [ ] **Step 2: Add live admin types**
+
+Add these types near the top of `queries.ts`, below the imports:
+
+```ts
+export type LiveOrderStatus = "new" | "packing" | "ready" | "collected";
+
+export interface LiveRecentOrder {
+  id: string;
+  tenantId: string;
+  status: LiveOrderStatus;
+  delivery: "pickup" | "ship";
+  kid: string;
+  year: string;
+  rollClass: string;
+  parent: string;
+  email: string;
+  total: number;
+  createdAt: Date | null;
+}
+
+export interface LiveTopItem {
+  name: string;
+  qty: number;
+  revenue: number;
+}
+
+export interface LiveDashboardData {
+  revenue: number;
+  orders: number;
+  avgOrder: number;
+  awaitingPickup: number;
+  readyOverSevenDays: number;
+  spark: number[];
+  topItems: LiveTopItem[];
+  recentOrders: LiveRecentOrder[];
+}
+
+export interface LiveMonthlyRevenue {
+  month: string;
+  label: string;
+  revenue: number;
+}
+
+export interface LiveCategoryRevenue {
+  cat: string;
+  revenue: number;
+  pct: number;
+}
+
+export interface LiveGstRow {
+  period: string;
+  gross: number;
+  gst: number;
+  net: number;
+  fees: number;
+  payout: number;
+}
+
+export interface LiveReportsData {
+  revenue: number;
+  orders: number;
+  avgOrder: number;
+  gst: number;
+  monthlyRevenue: LiveMonthlyRevenue[];
+  categoryRevenue: LiveCategoryRevenue[];
+  gstRows: LiveGstRow[];
+}
+```
+
+- [ ] **Step 3: Add numeric/date helpers**
+
+Add these helpers before the `// ─── Orders` section:
+
+```ts
+function money(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function monthKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function monthLabel(date: Date): string {
+  return date.toLocaleDateString("en-AU", { month: "short" });
+}
+
+function monthPeriod(date: Date): string {
+  return date.toLocaleDateString("en-AU", { month: "short", year: "numeric" });
+}
+
+function estimateStripeFees(gross: number): number {
+  if (gross <= 0) return 0;
+  return gross * 0.0175 + 0.3;
+}
+```
+
+- [ ] **Step 4: Add `getLiveDashboardData`**
+
+Add this helper after `getOrdersByTenantAndParentEmail`:
+
+```ts
+export async function getLiveDashboardData(tenantId: string): Promise<LiveDashboardData> {
+  const now = new Date();
+  const thirtyDaysAgo = startOfDay(new Date(now));
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 29);
+  const sevenDaysAgo = startOfDay(new Date(now));
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+  const tenantOrders = await db
+    .select()
+    .from(orders)
+    .where(eq(orders.tenantId, tenantId))
+    .orderBy(desc(orders.createdAt));
+
+  const last30 = tenantOrders.filter((order) => order.createdAt && order.createdAt >= thirtyDaysAgo);
+  const revenue = last30.reduce((sum, order) => sum + money(order.total), 0);
+  const orderCount = last30.length;
+  const awaitingPickup = tenantOrders.filter((order) => order.delivery === "pickup" && order.status === "ready").length;
+  const readyOverSevenDays = tenantOrders.filter(
+    (order) => order.delivery === "pickup" && order.status === "ready" && order.createdAt && order.createdAt < sevenDaysAgo
+  ).length;
+
+  const recentOrders: LiveRecentOrder[] = tenantOrders.slice(0, 5).map((order) => ({
+    id: order.id,
+    tenantId: order.tenantId,
+    status: order.status,
+    delivery: order.delivery,
+    kid: order.studentName,
+    year: order.studentYear,
+    rollClass: order.studentRoll,
+    parent: order.parentName,
+    email: order.parentEmail,
+    total: money(order.total),
+    createdAt: order.createdAt,
+  }));
+
+  const sparkDays = Array.from({ length: 12 }, (_, index) => {
+    const day = startOfDay(new Date(now));
+    day.setDate(day.getDate() - (11 - index));
+    return day;
+  });
+  const spark = sparkDays.map((day) => {
+    const next = new Date(day);
+    next.setDate(next.getDate() + 1);
+    return tenantOrders
+      .filter((order) => order.createdAt && order.createdAt >= day && order.createdAt < next)
+      .reduce((sum, order) => sum + money(order.total), 0);
+  });
+
+  const orderIds = last30.map((order) => order.id);
+  let topItems: LiveTopItem[] = [];
+  if (orderIds.length > 0) {
+    const lines = await db
+      .select()
+      .from(orderLines)
+      .where(inArray(orderLines.orderId, orderIds));
+    const byName = new Map<string, LiveTopItem>();
+    for (const line of lines) {
+      const existing = byName.get(line.itemName) ?? { name: line.itemName, qty: 0, revenue: 0 };
+      existing.qty += line.qty;
+      existing.revenue += money(line.lineTotal);
+      byName.set(line.itemName, existing);
+    }
+    topItems = Array.from(byName.values())
+      .sort((a, b) => b.revenue - a.revenue)
+      .slice(0, 5);
+  }
+
+  return {
+    revenue,
+    orders: orderCount,
+    avgOrder: orderCount > 0 ? revenue / orderCount : 0,
+    awaitingPickup,
+    readyOverSevenDays,
+    spark,
+    topItems,
+    recentOrders,
+  };
+}
+```
+
+- [ ] **Step 5: Add `getLiveReportsData`**
+
+Add this helper after `getLiveDashboardData`:
+
+```ts
+export async function getLiveReportsData(tenantId: string): Promise<LiveReportsData> {
+  const now = new Date();
+  const months = Array.from({ length: 6 }, (_, index) => {
+    const date = new Date(now.getFullYear(), now.getMonth() - (5 - index), 1);
+    return date;
+  });
+  const firstMonth = months[0];
+
+  const tenantOrders = await db
+    .select()
+    .from(orders)
+    .where(and(eq(orders.tenantId, tenantId), gte(orders.createdAt, firstMonth)))
+    .orderBy(desc(orders.createdAt));
+
+  const revenue = tenantOrders.reduce((sum, order) => sum + money(order.total), 0);
+  const gst = tenantOrders.reduce((sum, order) => sum + money(order.gst), 0);
+  const orderCount = tenantOrders.length;
+
+  const monthlyRevenue = months.map((month) => {
+    const key = monthKey(month);
+    const gross = tenantOrders
+      .filter((order) => order.createdAt && monthKey(order.createdAt) === key)
+      .reduce((sum, order) => sum + money(order.total), 0);
+    return { month: key, label: monthLabel(month), revenue: gross };
+  });
+
+  const gstRows = months
+    .map((month) => {
+      const key = monthKey(month);
+      const monthOrders = tenantOrders.filter((order) => order.createdAt && monthKey(order.createdAt) === key);
+      const gross = monthOrders.reduce((sum, order) => sum + money(order.total), 0);
+      const monthGst = monthOrders.reduce((sum, order) => sum + money(order.gst), 0);
+      const fees = estimateStripeFees(gross);
+      return {
+        period: monthPeriod(month),
+        gross,
+        gst: monthGst,
+        net: gross - monthGst,
+        fees,
+        payout: gross - fees,
+      };
+    })
+    .reverse();
+
+  let categoryRevenue: LiveCategoryRevenue[] = [];
+  const orderIds = tenantOrders.map((order) => order.id);
+  if (orderIds.length > 0) {
+    const lineRows = await db
+      .select({
+        itemId: orderLines.itemId,
+        lineTotal: orderLines.lineTotal,
+        category: catalogItems.category,
+      })
+      .from(orderLines)
+      .leftJoin(catalogItems, and(eq(orderLines.itemId, catalogItems.id), eq(catalogItems.tenantId, tenantId)))
+      .where(inArray(orderLines.orderId, orderIds));
+
+    const byCategory = new Map<string, number>();
+    for (const row of lineRows) {
+      const category = row.category ?? "Uncategorised";
+      byCategory.set(category, (byCategory.get(category) ?? 0) + money(row.lineTotal));
+    }
+    const categoryTotal = Array.from(byCategory.values()).reduce((sum, value) => sum + value, 0);
+    categoryRevenue = Array.from(byCategory.entries())
+      .map(([cat, catRevenue]) => ({
+        cat,
+        revenue: catRevenue,
+        pct: categoryTotal > 0 ? (catRevenue / categoryTotal) * 100 : 0,
+      }))
+      .sort((a, b) => b.revenue - a.revenue);
+  }
+
+  return {
+    revenue,
+    orders: orderCount,
+    avgOrder: orderCount > 0 ? revenue / orderCount : 0,
+    gst,
+    monthlyRevenue,
+    categoryRevenue,
+    gstRows,
+  };
+}
+```
+
+- [ ] **Step 6: Type-check query helpers**
+
+Run:
+
+```bash
+pnpm check-types:web
+```
+
+Expected: TypeScript exits successfully.
+
+## Task 3: Wire Dashboard to Live Data
+
+**Files:**
+- Modify: `apps/web/src/app/admin/[tenant]/dashboard/page.tsx`
+- Modify: `apps/web/src/app/admin/[tenant]/dashboard/dashboard-client.tsx`
+
+- [ ] **Step 1: Replace dashboard page imports and data load**
+
+In `dashboard/page.tsx`, replace:
+
+```ts
+import { TENANTS, type TenantId } from "@/lib/data";
+import { SALES_DATA, getOrdersByTenant } from "@/lib/admin-data";
+```
+
+with:
+
+```ts
+import { TENANTS, type TenantId } from "@/lib/data";
+import { getLiveDashboardData } from "@/db/queries";
+```
+
+Replace:
+
+```ts
+const sales = SALES_DATA[tid as TenantId];
+const orders = getOrdersByTenant(tid as TenantId);
+const recentOrders = orders.slice(0, 5);
+```
+
+with:
+
+```ts
+const dashboard = await getLiveDashboardData(tid);
+```
+
+Replace the client render:
+
+```tsx
+<AdminDashboardClient tenant={tenant} sales={sales} recentOrders={recentOrders} />
+```
+
+with:
+
+```tsx
+<AdminDashboardClient tenant={tenant} dashboard={dashboard} />
+```
+
+- [ ] **Step 2: Update dashboard client imports and types**
+
+In `dashboard-client.tsx`, replace:
+
+```ts
+import type { SalesData, AdminOrder } from "@/lib/admin-data";
+```
+
+with:
+
+```ts
+import type { LiveDashboardData, LiveRecentOrder, LiveOrderStatus } from "@/db/queries";
+```
+
+Update `StatusBadge`:
+
+```ts
+function StatusBadge({ status }: { status: LiveOrderStatus }) {
+  const map: Record<LiveOrderStatus, { tone: "warn" | "info" | "success" | "neutral"; label: string }> = {
+```
+
+Update component props:
+
+```ts
+export function AdminDashboardClient({
+  tenant,
+  dashboard,
+}: {
+  tenant: Tenant;
+  dashboard: LiveDashboardData;
+}) {
+```
+
+- [ ] **Step 3: Replace `sales` references with `dashboard`**
+
+Replace stats setup:
+
+```ts
+const stats = [
+  { label: "Revenue · 30d", value: `$${dashboard.revenue.toLocaleString()}`, delta: "Live orders", tone: "pos" as const, spark: dashboard.spark },
+  { label: "Orders · 30d", value: String(dashboard.orders), delta: "Live orders", tone: "pos" as const },
+  { label: "Avg order", value: `$${dashboard.avgOrder.toFixed(2)}`, delta: "Last 30 days", tone: "pos" as const },
+  { label: "Awaiting pickup", value: String(dashboard.awaitingPickup), delta: `${dashboard.readyOverSevenDays} over 7d`, tone: "warn" as const },
+];
+```
+
+Replace all `sales.topItems` with `dashboard.topItems`, `sales.revenue` with `dashboard.revenue`, and `recentOrders` with `dashboard.recentOrders`.
+
+- [ ] **Step 4: Add empty states**
+
+In the top-selling table body, render this before mapping when there are no top items:
+
+```tsx
+{dashboard.topItems.length === 0 && (
+  <tr>
+    <td colSpan={4} className="py-6 text-center text-[12px]" style={{ color: "var(--color-ink-dim)" }}>
+      No live order lines yet.
+    </td>
+  </tr>
+)}
+```
+
+Use a safe share percentage:
+
+```ts
+const pct = dashboard.revenue > 0 ? (r.revenue / dashboard.revenue) * 100 : 0;
+```
+
+Replace the hard-coded attention copy:
+
+```tsx
+<b>{dashboard.readyOverSevenDays} orders</b> ready for pickup over 7 days.{" "}
+```
+
+Replace the Stripe payout copy with estimated live wording:
+
+```tsx
+Stripe payout estimate from live orders: <b>${(dashboard.revenue * 0.26).toLocaleString()}</b>.
+```
+
+In the recent orders list, render this empty state:
+
+```tsx
+{dashboard.recentOrders.length === 0 && (
+  <div className="py-6 text-center text-[12px]" style={{ color: "var(--color-ink-dim)" }}>
+    No live orders yet.
+  </div>
+)}
+```
+
+When mapping recent orders, keep the existing display and use:
+
+```tsx
+{dashboard.recentOrders.map((o, i) => (
+```
+
+- [ ] **Step 5: Type-check dashboard**
+
+Run:
+
+```bash
+pnpm check-types:web
+```
+
+Expected: TypeScript exits successfully.
+
+## Task 4: Wire Reports to Live Data
+
+**Files:**
+- Modify: `apps/web/src/app/admin/[tenant]/reports/page.tsx`
+
+- [ ] **Step 1: Replace static imports and constants**
+
+In `reports/page.tsx`, remove:
+
+```ts
+import { SALES_DATA } from "@/lib/admin-data";
+```
+
+Add:
+
+```ts
+import { getLiveReportsData } from "@/db/queries";
+```
+
+Delete the static `GST_ROWS` constant.
+
+- [ ] **Step 2: Load reports data**
+
+Replace:
+
+```ts
+const sales = SALES_DATA[tid as TenantId];
+
+const months = ["Nov", "Dec", "Jan", "Feb", "Mar", "Apr"];
+const monthlyRevenue = [2840, 4120, 3960, 2780, 3240, 1480];
+const maxRev = Math.max(...monthlyRevenue);
+```
+
+with:
+
+```ts
+const reports = await getLiveReportsData(tid);
+const maxRev = Math.max(1, ...reports.monthlyRevenue.map((row) => row.revenue));
+const rangeLabel =
+  reports.monthlyRevenue.length > 0
+    ? `${reports.monthlyRevenue[0].label} - ${reports.monthlyRevenue[reports.monthlyRevenue.length - 1].label}`
+    : "Last 6 months";
+```
+
+- [ ] **Step 3: Feed live rows to CSV export**
+
+Replace:
+
+```tsx
+<ExportCsvButton
+  rows={GST_ROWS}
+  filename={`${tid}-gst-report.csv`}
+/>
+```
+
+with:
+
+```tsx
+<ExportCsvButton
+  rows={reports.gstRows}
+  filename={`${tid}-gst-report.csv`}
+/>
+```
+
+- [ ] **Step 4: Replace summary cards**
+
+Replace summary card values with:
+
+```tsx
+{[
+  { label: "Total revenue", value: `$${reports.revenue.toLocaleString()}`, sub: "6 months" },
+  { label: "Total orders", value: String(reports.orders), sub: "6 months" },
+  { label: "Avg order value", value: `$${reports.avgOrder.toFixed(2)}`, sub: "6 months" },
+  { label: "GST collected", value: `$${reports.gst.toFixed(0)}`, sub: "Remittable" },
+].map((s) => (
+```
+
+- [ ] **Step 5: Replace monthly revenue chart**
+
+Replace the date label:
+
+```tsx
+<span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>{rangeLabel}</span>
+```
+
+Replace the chart mapping:
+
+```tsx
+{reports.monthlyRevenue.map((row, i) => {
+  const pct = (row.revenue / maxRev) * 100;
+  const isLast = i === reports.monthlyRevenue.length - 1;
+  return (
+    <div key={row.month} className="flex-1 flex flex-col items-center gap-1.5">
+      <div className="text-[11px] font-semibold tnum" style={{ color: "var(--color-ink-dim)" }}>
+        ${(row.revenue / 1000).toFixed(1)}k
+      </div>
+      <div className="w-full flex items-end" style={{ height: 120 }}>
+        <div
+          className="w-full rounded-t"
+          style={{
+            height: `${pct}%`,
+            background: isLast ? `${tenant.accent}60` : tenant.accent,
+            minHeight: row.revenue > 0 ? 4 : 0,
+          }}
+        />
+      </div>
+      <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+        {row.label}
+      </div>
+    </div>
+  );
+})}
+```
+
+- [ ] **Step 6: Replace category breakdown**
+
+Replace the static category array with:
+
+```tsx
+{reports.categoryRevenue.length === 0 && (
+  <div className="py-6 text-center text-[12px]" style={{ color: "var(--color-ink-dim)" }}>
+    No live category sales yet.
+  </div>
+)}
+{reports.categoryRevenue.map((c) => (
+```
+
+Keep the existing category row markup and use `c.cat`, `c.pct`, and `c.revenue`.
+
+- [ ] **Step 7: Replace GST table rows**
+
+Replace:
+
+```tsx
+{GST_ROWS.map((r, i) => (
+```
+
+with:
+
+```tsx
+{reports.gstRows.map((r, i) => (
+```
+
+Replace length checks in row borders with `reports.gstRows.length`.
+
+- [ ] **Step 8: Type-check reports**
+
+Run:
+
+```bash
+pnpm check-types:web
+```
+
+Expected: TypeScript exits successfully.
+
+## Task 5: Update Audit Notes
+
+**Files:**
+- Modify: `docs/FEATURE_AUDIT.md`
+
+- [ ] **Step 1: Update changelog**
+
+Add a new row under the changelog:
+
+```md
+| 2 May 2026 | **Remaining checkout/admin data items completed:** Checkout now confirms Stripe card payments before order creation and stores the PaymentIntent ID. Dashboard recent orders, 30-day KPIs, top items, and reports now read tenant-scoped live Neon order data. |
+```
+
+- [ ] **Step 2: Update parent checkout notes**
+
+Change the Stripe payment UI row to:
+
+```md
+| Stripe payment UI | ✅ Done | Uses Stripe Card Element and confirms a live test-mode PaymentIntent before creating the order |
+```
+
+- [ ] **Step 3: Update dashboard/report/backend notes**
+
+Change dashboard recent orders to:
+
+```md
+| Recent orders feed | ✅ Done | Reads latest tenant-scoped orders from Neon DB |
+```
+
+Change the reports rows that currently imply static data where needed:
+
+```md
+| Monthly revenue bar chart | ✅ Done | Reads live tenant-scoped order totals from Neon DB |
+| Revenue by category breakdown | ✅ Done | Uses live order lines joined to catalog items where item IDs match |
+| GST / BAS-ready summary table | ✅ Done | Groups live order totals and GST by month; Stripe fees are estimated because balance transactions are not stored |
+```
+
+Change backend dashboard row:
+
+```md
+| Dashboard recent orders live | ✅ Done | Dashboard and reports now use tenant-scoped Neon order data |
+```
+
+Remove item `18 | Dashboard recent orders connected to live Neon DB` from the remaining lower-priority table.
+
+- [ ] **Step 4: Type-check docs-only change is not needed**
+
+No command is required for the docs-only change. Run the final verification in Task 6.
+
+## Task 6: Final Verification
+
+**Files:**
+- No direct file edits unless verification exposes issues.
+
+- [ ] **Step 1: Run full type-check**
+
+Run:
+
+```bash
+pnpm check-types
+```
+
+Expected: TypeScript exits successfully. If route helper types are missing, run:
+
+```bash
+pnpm --filter web exec next typegen
+pnpm check-types
+```
+
+- [ ] **Step 2: Run production build**
+
+Run:
+
+```bash
+pnpm build:web
+```
+
+Expected: Next.js production build completes successfully. If it fails because required runtime env vars are missing during build, verify the failing code path and preserve lazy DB/Stripe/Auth initialization patterns rather than adding module-import clients.
+
+- [ ] **Step 3: Inspect git diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- apps/web/src/app/[tenant]/checkout/checkout-screen.tsx apps/web/src/db/queries.ts apps/web/src/app/admin/[tenant]/dashboard/page.tsx apps/web/src/app/admin/[tenant]/dashboard/dashboard-client.tsx apps/web/src/app/admin/[tenant]/reports/page.tsx docs/FEATURE_AUDIT.md
+```
+
+Expected: Diff contains only the checkout, live query, admin page, and audit changes described in this plan.
+
+- [ ] **Step 4: Commit implementation**
+
+Run:
+
+```bash
+git add apps/web/src/app/[tenant]/checkout/checkout-screen.tsx apps/web/src/db/queries.ts apps/web/src/app/admin/[tenant]/dashboard/page.tsx apps/web/src/app/admin/[tenant]/dashboard/dashboard-client.tsx apps/web/src/app/admin/[tenant]/reports/page.tsx docs/FEATURE_AUDIT.md
+git commit -m "Implement Stripe checkout and live admin reports"
+```
+
+Expected: Commit succeeds.

--- a/docs/superpowers/specs/2026-05-02-stripe-checkout-live-admin-data-design.md
+++ b/docs/superpowers/specs/2026-05-02-stripe-checkout-live-admin-data-design.md
@@ -1,0 +1,135 @@
+# Stripe Checkout and Live Admin Data Design
+
+## Context
+
+The parent checkout currently shows a mock card UI and creates orders with
+`stripePaymentIntentId: null`. The app already has a live Stripe PaymentIntent
+route at `/api/stripe/payment-intent`, a live Neon-backed `POST /api/orders`,
+and Stripe client dependencies installed.
+
+The admin dashboard and reports still read static sales data from
+`apps/web/src/lib/admin-data.ts`, even though order creation, order status
+updates, and order detail views now use live Neon data.
+
+## Goals
+
+- Replace the mock checkout payment block with a minimal real Stripe Elements
+  flow.
+- Create orders only after Stripe confirms payment.
+- Persist the confirmed PaymentIntent ID into `POST /api/orders`.
+- Surface checkout API, payment, configuration, and order persistence errors
+  inline.
+- Move dashboard recent orders, KPIs, top items, and report summaries to
+  tenant-scoped Neon data where the current schema supports it.
+- Keep the existing mobile-first checkout UI and admin page layout intact.
+
+## Non-Goals
+
+- No new refund or exchange workflow.
+- No Stripe webhook reconciliation.
+- No saved cards, Apple Pay, Google Pay, or hosted Checkout migration.
+- No new database tables for payment status, Stripe fees, or balance
+  transactions.
+- No full super-admin portal work.
+
+## Checkout Design
+
+`apps/web/src/app/[tenant]/checkout/checkout-screen.tsx` remains the parent
+checkout client component. It will keep the existing student, delivery, order
+summary, and footer button styling. The payment section will mount a small
+Stripe Elements child component in place of the fake card number, expiry, and
+CVC display.
+
+The checkout sequence is:
+
+1. Validate student/contact details and cart contents.
+2. Persist student details to local storage.
+3. Call `POST /api/stripe/payment-intent` with `tenantId`, `amount`, currency,
+   and order metadata.
+4. Confirm the PaymentIntent on the client with Stripe Elements.
+5. If confirmation succeeds, call `POST /api/orders` with all existing order
+   fields plus the confirmed `stripePaymentIntentId`.
+6. Clear the cart and route to the existing order placed screen.
+
+If `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` is not configured, the payment section
+shows a configuration error and disables payment. If Stripe intent creation,
+card confirmation, or order persistence fails, the checkout remains on screen
+and shows the error in the payment area instead of using `alert()`.
+
+The implementation will use the installed `@stripe/stripe-js` package. If the
+package does not provide React bindings, the component will use the core Stripe
+JS APIs directly rather than adding a new dependency unless type-checking shows
+the React package is already available transitively.
+
+## Admin Data Design
+
+Shared DB query helpers will be added to `apps/web/src/db/queries.ts` so admin
+pages do not duplicate query logic. Helpers will remain tenant-scoped and will
+not instantiate DB clients at import time.
+
+Dashboard data will come from live orders and order lines:
+
+- Revenue for the last 30 days from `orders.total`.
+- Order count for the last 30 days.
+- Average order value for the last 30 days.
+- Awaiting pickup from live pickup orders in `ready` status.
+- Recent orders from the latest live orders for the tenant.
+- Top selling items from live order lines joined to tenant orders.
+- Sparkline values from recent daily revenue buckets.
+
+Reports data will come from live tenant orders and order lines:
+
+- Six-month total revenue, total orders, average order value, and GST collected.
+- Monthly revenue bars for the last six calendar months.
+- Revenue by category by joining order lines to catalog items where item IDs
+  still match catalog records.
+- GST summary rows grouped by month from live order totals and GST values.
+
+Stripe fees in the GST summary will be estimated from gross sales using the
+current local reporting convention, because the database stores PaymentIntent
+references but not Stripe balance transaction fee records. The UI should not
+claim these fees are exact Stripe settlement records.
+
+## Types and Component Contracts
+
+Dashboard client props will use a local live analytics type rather than
+`SalesData` from `lib/admin-data.ts`. Recent order props will use a compact
+live order summary type derived from the DB shape instead of `AdminOrder`.
+
+Reports can stay mostly server-rendered, with the existing `ExportCsvButton`
+receiving live GST rows. Numeric database fields will be parsed to numbers
+before formatting.
+
+## Error Handling
+
+Checkout errors are visible inline and specific enough to distinguish:
+
+- Missing Stripe publishable key.
+- Payment form not ready.
+- PaymentIntent creation failure.
+- Stripe confirmation failure.
+- Order persistence failure after payment confirmation.
+
+For the order persistence failure after a confirmed payment, the message should
+tell the parent not to retry payment and to contact the uniform shop with the
+Stripe reference. This avoids duplicate charges.
+
+Admin pages should render empty states when there are no live orders rather
+than falling back to static mock analytics.
+
+## Verification
+
+The verification gates are:
+
+```bash
+pnpm check-types
+pnpm build:web
+```
+
+If generated Next route types are missing, run:
+
+```bash
+pnpm --filter web exec next typegen
+```
+
+Then rerun the verification gates.

--- a/my_doc/Stripe/README.md
+++ b/my_doc/Stripe/README.md
@@ -1,0 +1,387 @@
+# Stripe Integration — Uniform Order
+
+This document covers the full Stripe implementation: how checkout works, how
+school accounts connect, how analytics are derived, and what you need to go live.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Checkout Flow](#checkout-flow)
+3. [API Routes](#api-routes)
+4. [Stripe Connect (School Onboarding)](#stripe-connect-school-onboarding)
+5. [Database Schema](#database-schema)
+6. [Admin Analytics](#admin-analytics)
+7. [Going Live](#going-live)
+
+---
+
+## Overview
+
+Stripe is used for two distinct purposes:
+
+| Purpose | What it does |
+|---|---|
+| **Card Checkout** | Parents pay for uniform orders via a Stripe card element embedded in the checkout page |
+| **Stripe Connect** | Each school (tenant) connects their own Stripe account so payouts go directly to the school |
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        PLATFORM (you)                           │
+│                                                                 │
+│   STRIPE_SECRET_KEY  ──►  Stripe Platform Account              │
+│                                                                 │
+│   ┌─────────────────┐         ┌─────────────────┐              │
+│   │  School A (nsbh)│         │  School B (rgsh)│              │
+│   │  Connected Acct │         │  Connected Acct │              │
+│   │  acct_abc123    │         │  acct_xyz789    │              │
+│   └─────────────────┘         └─────────────────┘              │
+└─────────────────────────────────────────────────────────────────┘
+
+Payments flow through the platform and settle into each school's
+connected account. The platform does not hold the money.
+```
+
+---
+
+## Checkout Flow
+
+### Step-by-step
+
+```
+  Parent Browser                    Next.js Server                Stripe
+       │                                  │                          │
+       │  1. Page loads                   │                          │
+       │─────────────────────────────────►│                          │
+       │                                  │                          │
+       │  2. Stripe.js loads card element │                          │
+       │◄─────────────────────────────────│                          │
+       │         (iframe rendered)        │                          │
+       │                                  │                          │
+       │  3. Parent fills form + clicks Pay                          │
+       │─────────────────────────────────►│                          │
+       │                                  │                          │
+       │  4. POST /api/stripe/payment-intent                         │
+       │─────────────────────────────────►│                          │
+       │                                  │  5. stripe.paymentIntents│
+       │                                  │     .create(amount, AUD) │
+       │                                  │─────────────────────────►│
+       │                                  │◄─────────────────────────│
+       │                                  │   clientSecret           │
+       │◄─────────────────────────────────│                          │
+       │   { clientSecret }               │                          │
+       │                                  │                          │
+       │  6. stripe.confirmCardPayment(clientSecret, card)           │
+       │─────────────────────────────────────────────────────────────►
+       │◄─────────────────────────────────────────────────────────────
+       │   { paymentIntent.status: "succeeded" }                     │
+       │                                  │                          │
+       │  7. POST /api/orders (save order to DB)                     │
+       │─────────────────────────────────►│                          │
+       │◄─────────────────────────────────│                          │
+       │   { orderId }                    │                          │
+       │                                  │                          │
+       │  8. Redirect → /order/placed     │                          │
+       │                                  │                          │
+```
+
+### Key safety rule — payment lock
+
+After card payment is confirmed but before the order is saved, a network error
+could leave the parent with a charged card but no order. The app handles this:
+
+```
+  stripe.confirmCardPayment() succeeds
+           │
+           ▼
+  POST /api/orders ──► OK?
+           │                └── YES ──► clearCart() → redirect to /order/placed
+           │
+           └── NO (network error / 500)
+                    │
+                    ▼
+          paymentLocked = true   ← button disabled permanently
+          Show message:
+          "Your payment was confirmed. Do not retry.
+           Contact the shop with Stripe ref pi_xxxx"
+```
+
+This prevents the parent from clicking Pay again and being charged twice.
+
+---
+
+## API Routes
+
+### `POST /api/stripe/payment-intent`
+
+Creates a PaymentIntent on Stripe and returns the `clientSecret` to the browser.
+
+**Request body:**
+```json
+{
+  "tenantId": "nsbh",
+  "amount": 127.50,
+  "currency": "aud",
+  "metadata": {
+    "parentEmail": "parent@example.com",
+    "studentName": "Riley Qiao",
+    "studentYear": "Year 9",
+    "delivery": "pickup"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "clientSecret": "pi_xxx_secret_yyy",
+  "paymentIntentId": "pi_xxx"
+}
+```
+
+**Amount handling:** Dollar amount is multiplied by 100 to convert to cents
+before being sent to Stripe (e.g. `$127.50 → 12750`).
+
+---
+
+### `POST /api/stripe/connect`
+
+Starts Stripe Connect onboarding for a school. Called from Admin → Settings.
+
+```
+  Admin clicks "Connect Stripe"
+           │
+           ▼
+  POST /api/stripe/connect { tenantId: "nsbh" }
+           │
+           ▼
+  Does tenant already have stripeAccountId in DB?
+           │
+      NO ──┤
+           │   stripe.accounts.create({ type: "standard", ... })
+           │   Save accountId → tenants table
+           │
+      YES ──┤  (skip creation, reuse existing accountId)
+           │
+           ▼
+  stripe.accountLinks.create({ type: "account_onboarding" })
+           │
+           ▼
+  Return { url: "https://connect.stripe.com/..." }
+           │
+           ▼
+  Frontend redirects admin to Stripe's onboarding wizard
+           │
+           ▼
+  Stripe redirects back to:
+    success → /admin/nsbh/settings?stripe=success
+    refresh → /admin/nsbh/settings?stripe=refresh
+```
+
+---
+
+### `GET /api/stripe/connect?tenantId=nsbh`
+
+Checks the current status of a school's connected account.
+
+```
+  Response:
+  {
+    "connected": true,
+    "accountId": "acct_abc123",
+    "payoutsEnabled": true,
+    "chargesEnabled": true,
+    "detailsSubmitted": true
+  }
+```
+
+Also writes the latest `payoutsEnabled` / `chargesEnabled` values back to the
+`tenants` table so the admin settings page stays in sync.
+
+---
+
+## Stripe Connect (School Onboarding)
+
+Stripe Connect allows each school to have their own Stripe account. The app
+uses **Standard accounts** — the school completes full Stripe KYC and owns the
+account. Funds settle directly into the school's bank.
+
+```
+  ONBOARDING STATES
+  ─────────────────
+
+  [ Not connected ]
+       │
+       │  Admin clicks "Connect Stripe"
+       ▼
+  [ Stripe onboarding in progress ]
+       │  School completes KYC on stripe.com
+       ▼
+  [ detailsSubmitted = true ]
+       │  Stripe reviews
+       ▼
+  [ chargesEnabled = true ]   ← can accept payments
+       │
+       ▼
+  [ payoutsEnabled = true ]   ← payouts settle to school bank
+```
+
+Until `chargesEnabled` is true, the payment intent API will still work
+(the platform account is used as fallback), but funds won't automatically
+route to the school.
+
+---
+
+## Database Schema
+
+### `tenants` table — Stripe columns
+
+```
+  tenants
+  ┌──────────────────────────┬──────────────────────────────────────┐
+  │ stripe_account_id        │ "acct_abc123" or NULL                │
+  │ stripe_payouts_enabled   │ boolean (default false)              │
+  │ stripe_charges_enabled   │ boolean (default false)              │
+  └──────────────────────────┴──────────────────────────────────────┘
+```
+
+### `orders` table — Stripe columns
+
+```
+  orders
+  ┌──────────────────────────┬──────────────────────────────────────┐
+  │ stripe_payment_intent_id │ "pi_xxx" — the Stripe PaymentIntent  │
+  │ stripe_ref               │ reserved for future use              │
+  └──────────────────────────┴──────────────────────────────────────┘
+```
+
+The `stripe_payment_intent_id` is the single source of truth linking a DB
+order to a Stripe transaction. You can look it up directly in the Stripe
+dashboard to see payment status, card details, and refund history.
+
+---
+
+## Admin Analytics
+
+Analytics are computed from live DB data — not from Stripe's API. Every order
+written by `POST /api/orders` is immediately reflected.
+
+### Dashboard — `getLiveDashboardData(tenantId)`
+
+```
+  All orders for tenant (DB)
+           │
+           ▼
+  ┌─────────────────────────────────────────────┐
+  │  Last 30 days                               │
+  │  ┌──────────┐  ┌───────────┐  ┌──────────┐ │
+  │  │ Revenue  │  │  Orders   │  │ Avg Order│ │
+  │  │  $4,210  │  │    33     │  │  $127.58 │ │
+  │  └──────────┘  └───────────┘  └──────────┘ │
+  └─────────────────────────────────────────────┘
+           │
+           ▼
+  ┌──────────────────────────────────────────────┐
+  │  Sparkline (last 12 days, daily revenue)     │
+  │                                              │
+  │  $500 ┤                    ╭─╮               │
+  │  $400 ┤          ╭─╮      ╭╯ ╰─╮            │
+  │  $300 ┤   ╭─╮   ╭╯ ╰─╮  ╭╯    ╰╮           │
+  │  $200 ┤  ╭╯ ╰─╮ ╯    ╰──╯      ╰╮          │
+  │  $100 ┤ ╭╯    ╰╯                 ╰─         │
+  │    $0 ┼─────────────────────────────        │
+  │       Day-12  ...              Today         │
+  └──────────────────────────────────────────────┘
+           │
+           ▼
+  ┌───────────────────────────────┐
+  │  Top 5 items (last 30 days)   │
+  │  by revenue from order_lines  │
+  └───────────────────────────────┘
+           │
+           ▼
+  ┌───────────────────────────────┐
+  │  Recent 5 orders              │
+  │  (all time, sorted by date)   │
+  └───────────────────────────────┘
+```
+
+All timezone calculations use **Australia/Sydney** — daily and monthly buckets
+snap to Sydney midnight, not UTC midnight.
+
+---
+
+### Reports — `getLiveReportsData(tenantId)`
+
+```
+  6-month window (current month − 5 months)
+           │
+           ▼
+  Monthly revenue bar chart
+  ──────────────────────────
+  Dec  ████████████  $1,240
+  Jan  ██████████████████  $1,860
+  Feb  ████████  $820
+  Mar  ██████████████  $1,420
+  Apr  ████████████████████  $2,050
+  May  ██████  $640  ← current month (partial)
+
+           │
+           ▼
+  Category revenue breakdown
+  ──────────────────────────
+  Winter    ████████████████  45%
+  Summer    ████████  22%
+  Sports    ██████  18%
+  Formal    ████  10%
+  Other     ██   5%
+
+           │
+           ▼
+  GST / payout summary (per month, newest first)
+  ──────────────────────────────────────────────────────
+  Period    Gross    GST     Net     Fees*   Payout
+  May 26    $640    $58.18  $581.82  $18.99  $562.83
+  Apr 26   $2,050  $186.36 $1,863.64 $60.58 $1,803.06
+  ...
+
+  * Stripe fee estimate: 2.9% + $0.13 per transaction (Aus domestic)
+    Formula: gross × 0.029 + 0.13
+```
+
+---
+
+## Going Live
+
+### Required environment variables
+
+```
+  .env.local (or Vercel / hosting env vars)
+  ──────────────────────────────────────────
+  STRIPE_SECRET_KEY=sk_live_...            # server only — never expose
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_...  # safe for browser
+```
+
+### Checklist
+
+```
+  [ ] Set STRIPE_SECRET_KEY (live key)
+  [ ] Set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY (live key)
+  [ ] Each school admin completes Stripe Connect onboarding
+        Admin → Settings → "Connect Stripe" button
+  [ ] Verify chargesEnabled = true for each school
+  [ ] Verify payoutsEnabled = true for each school
+  [ ] Test a $1.00 live payment end-to-end
+  [ ] Confirm order appears in Admin → Orders board
+  [ ] Confirm payment appears in Stripe dashboard
+```
+
+### Stripe dashboard links (live)
+
+| What | Where |
+|---|---|
+| All payments | Stripe Dashboard → Payments |
+| A specific order | Search by `pi_xxx` (the `stripePaymentIntentId` from DB) |
+| School payouts | Stripe Dashboard → Connect → Accounts → select school |
+| Refund a payment | Stripe Dashboard → Payments → find payment → Refund |


### PR DESCRIPTION
## Summary
- replace mock checkout payment UI with live Stripe Card Element flow
- create and confirm PaymentIntent before creating orders, and persist confirmed payment intent id
- add tenant-scoped live dashboard/report query helpers from Neon orders and order lines
- wire admin dashboard and reports pages to live data
- update feature audit documentation to reflect completed live-data work

## Verification
- pnpm check-types
- pnpm build:web
- pnpm dev:web smoke checks (local env currently missing DATABASE_URL, so admin pages return 500 without env setup)

## Notes
- Stripe fee values in reports remain estimated (no balance transaction ingestion in schema)
