### PR TITLE
Platform approval gate, order emails, privacy page, and Vercel cleanup

### DIFF
--- a/apps/web/drizzle/0002_rapid_donald_blake.sql
+++ b/apps/web/drizzle/0002_rapid_donald_blake.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "tenants" ADD COLUMN "platform_approval_status" text DEFAULT 'pending' NOT NULL;--> statement-breakpoint
+ALTER TABLE "tenants" ADD COLUMN "platform_approved_at" timestamp;--> statement-breakpoint
+ALTER TABLE "tenants" ADD COLUMN "platform_approved_by" text;--> statement-breakpoint
+ALTER TABLE "tenants" ADD COLUMN "platform_rejection_reason" text;

--- a/apps/web/drizzle/meta/0002_snapshot.json
+++ b/apps/web/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,641 @@
+{
+  "id": "a8a8a7ba-2ae3-44cf-a658-e8ec8d85d513",
+  "prevId": "e02cad9c-5b8c-413e-b5b1-3a2c8a8a783e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.catalog_items": {
+      "name": "catalog_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_guide": {
+          "name": "size_guide",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalog_items_tenant_id_tenants_id_fk": {
+          "name": "catalog_items_tenant_id_tenants_id_fk",
+          "tableFrom": "catalog_items",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_variants": {
+      "name": "catalog_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalog_variants_item_id_catalog_items_id_fk": {
+          "name": "catalog_variants_item_id_catalog_items_id_fk",
+          "tableFrom": "catalog_variants",
+          "tableTo": "catalog_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "neon_auth.user": {
+      "name": "user",
+      "schema": "neon_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_lines": {
+      "name": "order_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_lines_order_id_orders_id_fk": {
+          "name": "order_lines_order_id_orders_id_fk",
+          "tableFrom": "order_lines",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_name": {
+          "name": "parent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_email": {
+          "name": "parent_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_mobile": {
+          "name": "parent_mobile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_name": {
+          "name": "student_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_year": {
+          "name": "student_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_roll": {
+          "name": "student_roll",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery": {
+          "name": "delivery",
+          "type": "delivery_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pickup'"
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gst": {
+          "name": "gst",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_ref": {
+          "name": "stripe_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_policy_accepted_at": {
+          "name": "refund_policy_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emails_sent": {
+          "name": "emails_sent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_payment'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "orders_stripe_payment_intent_id_unique": {
+          "name": "orders_stripe_payment_intent_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "orders_tenant_id_tenants_id_fk": {
+          "name": "orders_tenant_id_tenants_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_user_id_user_id_fk": {
+          "name": "orders_user_id_user_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "user",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short": {
+          "name": "short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accent": {
+          "name": "accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#7A1F2B'"
+        },
+        "motto": {
+          "name": "motto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_hours": {
+          "name": "shop_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_email": {
+          "name": "shop_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_instructions": {
+          "name": "collection_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payouts_enabled": {
+          "name": "stripe_payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "stripe_charges_enabled": {
+          "name": "stripe_charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "platform_approval_status": {
+          "name": "platform_approval_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "platform_approved_at": {
+          "name": "platform_approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_approved_by": {
+          "name": "platform_approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_rejection_reason": {
+          "name": "platform_rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.delivery_method": {
+      "name": "delivery_method",
+      "schema": "public",
+      "values": [
+        "pickup",
+        "ship"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "pending_payment",
+        "new",
+        "packing",
+        "ready",
+        "collected"
+      ]
+    }
+  },
+  "schemas": {
+    "neon_auth": "neon_auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777983556209,
       "tag": "0001_youthful_purifiers",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1778047004407,
+      "tag": "0002_rapid_donald_blake",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/app/api/orders/route.ts
+++ b/apps/web/src/app/api/orders/route.ts
@@ -13,6 +13,7 @@ import {
   requireSessionUser,
 } from "@/lib/auth/authorization";
 import { applyRateLimit } from "@/lib/rate-limit";
+import { sendOrderConfirmationEmail } from "@/lib/email";
 
 const ORDER_ID_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
 const generateOrderSuffix = customAlphabet(ORDER_ID_ALPHABET, 10);
@@ -230,6 +231,13 @@ export async function POST(req: NextRequest) {
 
     if (!createdOrderId) {
       throw new Error("Unable to generate a unique order ID");
+    }
+
+    // Send order confirmation email (best-effort; do not fail the request)
+    try {
+      await sendOrderConfirmationEmail(createdOrderId);
+    } catch (err) {
+      console.error("Order confirmation email failed for order", createdOrderId, err);
     }
 
     return NextResponse.json({ orderId: createdOrderId }, { status: 201 });

--- a/apps/web/src/app/api/stripe/payment-intent/route.ts
+++ b/apps/web/src/app/api/stripe/payment-intent/route.ts
@@ -35,6 +35,12 @@ export async function POST(req: NextRequest) {
     if (!tenant) {
       return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
     }
+    if (tenant.platformApprovalStatus !== "approved") {
+      return NextResponse.json(
+        { error: "Tenant not yet approved by platform" },
+        { status: 409 }
+      );
+    }
     if (!tenant.stripeAccountId) {
       return NextResponse.json(
         { error: "Tenant has no connected Stripe account" },
@@ -44,12 +50,6 @@ export async function POST(req: NextRequest) {
     if (tenant.stripeChargesEnabled !== true) {
       return NextResponse.json(
         { error: "Tenant Stripe account is not ready to accept charges" },
-        { status: 409 }
-      );
-    }
-    if (tenant.platformApprovalStatus !== "approved") {
-      return NextResponse.json(
-        { error: "Tenant not yet approved by platform" },
         { status: 409 }
       );
     }

--- a/apps/web/src/app/api/stripe/payment-intent/route.ts
+++ b/apps/web/src/app/api/stripe/payment-intent/route.ts
@@ -47,6 +47,12 @@ export async function POST(req: NextRequest) {
         { status: 409 }
       );
     }
+    if (tenant.platformApprovalStatus !== "approved") {
+      return NextResponse.json(
+        { error: "Tenant not yet approved by platform" },
+        { status: 409 }
+      );
+    }
 
     const amountInCents = Math.round(amountNumber * 100);
     const feeBps = Number(process.env.STRIPE_APPLICATION_FEE_BPS ?? 0);

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Global error:", error);
+  }, [error]);
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center px-6" style={{ background: "var(--color-parchment)" }}>
+      <h1 className="font-serif text-3xl font-semibold mb-2" style={{ color: "var(--color-ink)" }}>
+        Something went wrong
+      </h1>
+      <p className="text-[14px] mb-6 max-w-md text-center" style={{ color: "var(--color-ink-dim)" }}>
+        We encountered an unexpected error. Please try again or return to the home page.
+      </p>
+      <div className="flex gap-3">
+        <button
+          onClick={reset}
+          className="px-4 py-2 rounded-md text-[13px] font-semibold text-white"
+          style={{ background: "var(--color-navy-deep)" }}
+        >
+          Try again
+        </button>
+        <Link
+          href="/"
+          className="px-4 py-2 rounded-md text-[13px] font-semibold border"
+          style={{ borderColor: "var(--color-rule)", color: "var(--color-ink)" }}
+        >
+          Back to home
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export default function NotFoundPage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center px-6" style={{ background: "var(--color-parchment)" }}>
+      <h1 className="font-serif text-3xl font-semibold mb-2" style={{ color: "var(--color-ink)" }}>
+        Page not found
+      </h1>
+      <p className="text-[14px] mb-6 max-w-md text-center" style={{ color: "var(--color-ink-dim)" }}>
+        The page you are looking for does not exist or has been moved.
+      </p>
+      <Link
+        href="/"
+        className="px-4 py-2 rounded-md text-[13px] font-semibold text-white"
+        style={{ background: "var(--color-navy-deep)" }}
+      >
+        Back to home
+      </Link>
+    </main>
+  );
+}

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -5,10 +5,23 @@ export default function PrivacyPage() {
     <main className="mx-auto max-w-3xl px-6 py-10">
       <h1 className="font-serif text-3xl font-semibold mb-4">Privacy policy</h1>
       <div className="space-y-3 text-[14px]" style={{ color: "var(--color-ink)" }}>
-        <p>We collect parent and student information required to process uniform orders and provide support.</p>
-        <p>Payment details are processed by Stripe; card numbers are not stored in this application.</p>
-        <p>Order records are retained for operations, reporting, and compliance obligations.</p>
-        <p>You can request access or correction of personal information by contacting the school uniform shop.</p>
+        <p>
+          We collect student and parent information solely to process and fulfil uniform orders.
+        </p>
+        <p>
+          Personal data (name, email, phone, student year and class) is stored securely and is only
+          shared with the school uniform shop responsible for your order.
+        </p>
+        <p>
+          Payment details are handled directly by Stripe; we do not store card numbers.
+        </p>
+        <p>
+          We comply with the Australian Privacy Principles under the Privacy Act 1988. You may
+          request access to or deletion of your data by contacting the school uniform shop.
+        </p>
+        <p>
+          Order history is retained for reporting and audit purposes for up to seven years.
+        </p>
       </div>
       <div className="mt-6">
         <Link href="/" className="underline text-[13px]">

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -55,6 +55,11 @@ export const tenants = pgTable("tenants", {
   stripeAccountId: text("stripe_account_id"),
   stripePayoutsEnabled: boolean("stripe_payouts_enabled").default(false),
   stripeChargesEnabled: boolean("stripe_charges_enabled").default(false),
+  // Platform approval gate (Stripe Connect compliance)
+  platformApprovalStatus: text("platform_approval_status").notNull().default("pending"),
+  platformApprovedAt: timestamp("platform_approved_at"),
+  platformApprovedBy: text("platform_approved_by"),
+  platformRejectionReason: text("platform_rejection_reason"),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
 });

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -20,27 +20,15 @@ function getClientAddress(req: NextRequest) {
     return requestIp.trim();
   }
 
-  const trustedProxyIpHeaders = [
-    req.headers.get("x-real-ip"),
-    req.headers.get("cf-connecting-ip"),
-    req.headers.get("x-forwarded-for"),
-  ];
-
-  const trustedProxyIp = trustedProxyIpHeaders.find((value) => value && value.trim().length > 0);
-  if (trustedProxyIp) {
-    return trustedProxyIp.split(",")[0]?.trim() ?? "unknown";
+  const trustedProxyIp =
+    req.headers.get("x-real-ip") ?? req.headers.get("cf-connecting-ip");
+  if (trustedProxyIp && trustedProxyIp.trim().length > 0) {
+    return trustedProxyIp.trim();
   }
 
-  // x-forwarded-for can be client-controlled unless set by a trusted proxy.
-  // Only trust it if x-real-ip or cf-connecting-ip was also present,
-  // indicating we're behind a known proxy layer.
-  if (trustedProxyIp) {
-    const forwardedFor = req.headers.get("x-forwarded-for");
-    if (forwardedFor) {
-      return forwardedFor.split(",")[0]?.trim() ?? null;
-    }
-  }
-
+  // x-forwarded-for can be spoofed by the client on untrusted networks.
+  // We intentionally do not fall back to it here; only x-real-ip and
+  // cf-connecting-ip from known proxy layers are accepted.
   return null;
 }
 

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -23,7 +23,7 @@ function getClientAddress(req: NextRequest) {
   const trustedProxyIpHeaders = [
     req.headers.get("x-real-ip"),
     req.headers.get("cf-connecting-ip"),
-    req.headers.get("x-vercel-forwarded-for"),
+    req.headers.get("x-forwarded-for"),
   ];
 
   const trustedProxyIp = trustedProxyIpHeaders.find((value) => value && value.trim().length > 0);
@@ -32,7 +32,9 @@ function getClientAddress(req: NextRequest) {
   }
 
   // x-forwarded-for can be client-controlled unless set by a trusted proxy.
-  if (req.headers.has("x-vercel-id")) {
+  // Only trust it if x-real-ip or cf-connecting-ip was also present,
+  // indicating we're behind a known proxy layer.
+  if (trustedProxyIp) {
     const forwardedFor = req.headers.get("x-forwarded-for");
     if (forwardedFor) {
       return forwardedFor.split(",")[0]?.trim() ?? null;


### PR DESCRIPTION
## Changes

### Platform approval gate
- Adds , , , and  columns to the  table.
- Gates Stripe payment-intent creation: returns  if the tenant is not yet approved by the platform.

### Order confirmation email
- Sends an order confirmation email (best-effort) after a successful order is created via .
- Email failure is logged but does not block the request.

### Privacy policy
- Rewrites the privacy policy page with Australian Privacy Act 1988 compliance wording.
- Clarifies data retention (7 years), Stripe payment handling, and access/deletion rights.

### Error pages
- Adds  (global error boundary with retry + home navigation).
- Adds  (404 page with home navigation).

### Deployment cleanup
- Removes Vercel-specific .
- Replaces Vercel-only proxy headers (, ) in the rate limiter with generic headers (, , ).

## Checklist
- [ ] Code review
- [ ] Type check (
> uniform-order@ check-types /Volumes/T7/georgeqiao/dev/uniform_order
> pnpm -r check-types


> web@0.0.0 check-types /Volumes/T7/georgeqiao/dev/uniform_order/apps/web
> tsc --noEmit)
- [ ] Test on staging