### PR TITLE
chore(drizzle): exclude neon_auth.* from drizzle-kit migration scope

### DIFF
--- a/apps/web/drizzle/meta/0007_snapshot.json
+++ b/apps/web/drizzle/meta/0007_snapshot.json
@@ -154,61 +154,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "neon_auth.user": {
-      "name": "user",
-      "schema": "neon_auth",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "email_verified": {
-          "name": "email_verified",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "image": {
-          "name": "image",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.order_lines": {
       "name": "order_lines",
       "schema": "",
@@ -918,9 +863,7 @@
       ]
     }
   },
-  "schemas": {
-    "neon_auth": "neon_auth"
-  },
+  "schemas": {},
   "sequences": {},
   "roles": {},
   "policies": {},

--- a/apps/web/src/db/external-schema.ts
+++ b/apps/web/src/db/external-schema.ts
@@ -1,0 +1,18 @@
+// Foreign-managed schema (Neon Auth). Declared here, not in schema.ts,
+// so drizzle-kit doesn't track it for migrations — drizzle-kit only
+// enumerates exports of the file pointed to by drizzle.config.ts.
+// schema.ts imports neonAuthUsers for FK-reference type resolution
+// without re-exporting it. See docs/remaining_work.md §4.11.
+import { pgSchema, uuid, text, boolean, timestamp } from "drizzle-orm/pg-core";
+
+export const neonAuthSchema = pgSchema("neon_auth");
+
+export const neonAuthUsers = neonAuthSchema.table("user", {
+  id: uuid("id").primaryKey(),
+  name: text("name"),
+  email: text("email"),
+  emailVerified: boolean("email_verified"),
+  image: text("image"),
+  createdAt: timestamp("created_at"),
+  updatedAt: timestamp("updated_at"),
+});

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -1,7 +1,6 @@
 import { sql } from "drizzle-orm";
 import {
   pgTable,
-  pgSchema,
   text,
   integer,
   numeric,
@@ -13,19 +12,7 @@ import {
   uniqueIndex,
   index,
 } from "drizzle-orm/pg-core";
-
-// ─── Neon Auth schema reference ─────────────────────────────────────────────
-export const neonAuthSchema = pgSchema("neon_auth");
-
-export const neonAuthUsers = neonAuthSchema.table("user", {
-  id: uuid("id").primaryKey(),
-  name: text("name"),
-  email: text("email"),
-  emailVerified: boolean("email_verified"),
-  image: text("image"),
-  createdAt: timestamp("created_at"),
-  updatedAt: timestamp("updated_at"),
-});
+import { neonAuthUsers } from "./external-schema";
 
 // ─── Enums ───────────────────────────────────────────────────────────────────
 export const orderStatusEnum = pgEnum("order_status", [

--- a/docs/remaining_work.md
+++ b/docs/remaining_work.md
@@ -143,7 +143,7 @@ No automated a11y tests run today. At minimum: keyboard nav through the parent f
 | 4.8 | Drizzle migrations checked into the repo (currently schema is push-only) | Ops |
 | 4.9 | Implementation detail for §4.1 — replace hardcoded size hint (see below) | known_issues #1 |
 | 4.10 | Note: transactional-email webhook commit was not split as planned (`3ce98b1` collapsed Task 6 Steps 3 & 4). Functionality correct; history/bisect deviation only — not worth rewriting. | known_issues #3 |
-| 4.11 | Drizzle-kit `tablesFilter`/`schemaFilter` for `neon_auth.*` exclusion (see §4.11) | UUID drift cleanup (2026-05-08) |
+| 4.11 | ✅ Drizzle-kit `neon_auth.*` exclusion — DONE via schema-file split, not config | UUID drift cleanup (2026-05-08) |
 
 ### 4.9 ✅ Replace hardcoded "Riley wore size X last year" hint — DONE (smoke test pending Stripe Connect)
 
@@ -190,17 +190,22 @@ Add a `useEffect` that:
 
 ---
 
-### 4.11 Lock drizzle-kit out of `neon_auth.*` (post-uuid-drift follow-up)
+### 4.11 ✅ Lock drizzle-kit out of `neon_auth.*` — DONE
 
-After PR #6 was applied, a follow-up `0007_fix_user_id_uuid_drift` migration reconciled `schema.ts` with prod (`neon_auth.user.id` and three FK columns flipped from `text` → `uuid`). That fix kept `drizzle.config.ts` deliberately bare. Drizzle-kit will therefore continue to consider `neon_auth.user` on every future `generate` and may emit no-op ALTERs against it. Cleanup is exploratory — its safety depends on observed drizzle-kit behaviour:
+**Resolution:** schema-file split, not a `drizzle.config.ts` flag.
 
-1. On a clean tree, add `tablesFilter: ["public.*"]` (or `schemaFilter: ["public"]`) to `apps/web/drizzle.config.ts`.
-2. Run `pnpm exec drizzle-kit generate`.
-3. **Inspect output before applying anything:**
-   - If empty → ship it.
-   - If it tries to emit `DROP TABLE neon_auth.user` (because the prior snapshot tracked it but the current schema no longer does) → revert. Try an alternative: extract `neonAuthUsers` to a separate file marked as untracked, or replace FK targets with `sql\`\`` literals so schema.ts stops declaring `neonAuthUsers` as a `pgTable` at all.
+**Investigation finding:** both `tablesFilter` and `schemaFilter` only filter DB introspection during `pull`/`push`. Neither prevents `generate` from diffing a tracked table in the snapshot. Confirmed by probe: with `schemaFilter: ["public"]` set, adding a column to `neonAuthUsers` in `schema.ts` still emitted `ALTER TABLE "neon_auth"."user" ADD COLUMN ...`. Same with `tablesFilter: ["!neon_auth.*"]`.
 
-**Why deferred:** the upside is purely "less noise in future migrations"; the downside (if mishandled) is dropping the foreign-managed auth table. Worth a separate, carefully-verified PR.
+**Working approach:**
+
+1. Move `neonAuthUsers` + `neonAuthSchema` to `apps/web/src/db/external-schema.ts`.
+2. In `schema.ts`, import `neonAuthUsers` (do **not** re-export). The `references(() => neonAuthUsers.id, …)` callbacks still resolve at runtime.
+3. Hand-edit the latest snapshot (`apps/web/drizzle/meta/0007_snapshot.json`) to remove the `neon_auth.user` table entry and empty the `schemas` object.
+4. `drizzle.config.ts` stays unchanged — the filter flags don't help.
+
+**Why this works:** drizzle-kit enumerates exports of the file at `drizzle.config.ts:schema` (only `./src/db/schema.ts`). It does not traverse imports to discover `pgTable`/`pgSchema` symbols, so a table imported-but-not-re-exported is invisible to its diffing. FK SQL emission (`REFERENCES "neon_auth"."user"("id")`) still works because the `references()` callback returns the column object regardless of registration.
+
+**Verified:** clean-tree `drizzle-kit generate` produces "No schema changes." Probe of `neonAuthUsers` column add in `external-schema.ts` produces no migration. Sanity probe (column add in a public table) still emits the expected ALTER.
 
 **Reference:** spec for the original drift fix at `docs/superpowers/specs/2026-05-08-uuid-drift-fix-design.md`.
 


### PR DESCRIPTION
## Summary

Closes `docs/remaining_work.md` §4.11. Stops drizzle-kit from considering `neon_auth.*` (the foreign-managed Neon Auth schema) when generating migrations, so future schema edits don't silently emit DDL against `neon_auth.user`.

## Why not `tablesFilter`/`schemaFilter`?

Both options only filter DB introspection (`drizzle-kit pull`/`push`), **not** schema-vs-snapshot diffing during `generate`. Probe-tested both with `--name=tablesfilter_probe`:

| Config | Probe (add column to `neonAuthUsers`) |
|---|---|
| `schemaFilter: ["public"]` | ❌ emitted `ALTER TABLE "neon_auth"."user" ADD COLUMN "probe_column" text;` |
| `tablesFilter: ["!neon_auth.*"]` | ❌ same |

So `drizzle.config.ts` stays unchanged.

## What actually works

Structural file split:

1. Move `neonAuthUsers` + `neonAuthSchema` to `apps/web/src/db/external-schema.ts`.
2. `schema.ts` imports `neonAuthUsers` but does **not** re-export it. The `references(() => neonAuthUsers.id, …)` callbacks still resolve at runtime — drizzle-kit emits `REFERENCES "neon_auth"."user"("id")` SQL correctly because it walks the column reference, not the table registration.
3. Hand-trim `apps/web/drizzle/meta/0007_snapshot.json` to remove the `neon_auth.user` table entry and empty the `schemas` object. Without this step, drizzle-kit would see "snapshot has it, current schema doesn't" and emit `DROP TABLE "neon_auth"."user" CASCADE; DROP SCHEMA "neon_auth";` — exactly the failure mode §4.11 warned about.

**Why drizzle-kit ignores the imported table:** it only enumerates `pgTable`/`pgSchema` exports of the file at `drizzle.config.ts:schema` (only `./src/db/schema.ts`). It does not traverse imports. Imported-but-not-re-exported tables are invisible to its diffing.

## Verification

- ✅ Clean-tree `pnpm exec drizzle-kit generate` → `No schema changes, nothing to migrate 😴`
- ✅ Probe — add column to `neonAuthUsers` in `external-schema.ts` → no migration generated
- ✅ Sanity probe — add column to public-table `tenants` → expected `ALTER TABLE "tenants" ADD COLUMN ...` migration generated (proves diffing still works for tracked tables)
- ✅ `pnpm check-types:web` exits 0
- ✅ All 3 FK references (`orders.userId`, `orderRefunds.operatorUserId`, `parentChildren.parentId`) still resolve in TypeScript

## Files

- `apps/web/src/db/external-schema.ts` (new) — foreign-managed schema declaration with explanatory header comment
- `apps/web/src/db/schema.ts` — removed `pgSchema` import + `neonAuthSchema`/`neonAuthUsers` declarations; replaced with import from `./external-schema`
- `apps/web/drizzle/meta/0007_snapshot.json` — removed `neon_auth.user` table entry, emptied `schemas: {}`
- `docs/remaining_work.md` §4.11 — marked done; documented the working approach and why filter flags don't help

## Risk note

The hand-edited snapshot is unusual but stable: drizzle-kit's next generate from a clean tree will produce the same trimmed shape because schema.ts no longer exports `neonAuthUsers`. If a future drizzle-kit upgrade ever changes its discovery to traverse imports, this approach breaks silently and `neon_auth.user` re-enters the snapshot — at which point the §4.11 entry would need to be reopened. The alternative (raw SQL FK constraints, no `.references()` calls) was rejected as more invasive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)