### PR TITLE
feat(catalog): self-service catalog mgmt with approval gate, drawer form, image uploads

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -26,3 +26,7 @@ POSTHOG_HOST=https://us.i.posthog.com
 # Emailit (transactional email)
 EMAILIT_API_KEY=em_...
 FROM_EMAIL="Uniform Shop <noreply@example.com>"
+
+# UploadThing — image uploads for catalog items
+# Get from https://uploadthing.com/dashboard → API Keys
+UPLOADTHING_TOKEN=

--- a/apps/web/drizzle/0008_catalog_image_url.sql
+++ b/apps/web/drizzle/0008_catalog_image_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "catalog_items" ADD COLUMN "image_url" text;

--- a/apps/web/drizzle/meta/0008_snapshot.json
+++ b/apps/web/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,882 @@
+{
+  "id": "ed6ac75a-51ea-47e5-b988-64ee51f0222c",
+  "prevId": "7473c553-77ae-4525-a619-2dad701cc5f3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.catalog_items": {
+      "name": "catalog_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_guide": {
+          "name": "size_guide",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalog_items_tenant_id_tenants_id_fk": {
+          "name": "catalog_items_tenant_id_tenants_id_fk",
+          "tableFrom": "catalog_items",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_variants": {
+      "name": "catalog_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalog_variants_item_id_catalog_items_id_fk": {
+          "name": "catalog_variants_item_id_catalog_items_id_fk",
+          "tableFrom": "catalog_variants",
+          "tableTo": "catalog_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_lines": {
+      "name": "order_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_order_lines_order_id_item_id": {
+          "name": "idx_order_lines_order_id_item_id",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_lines_order_id_orders_id_fk": {
+          "name": "order_lines_order_id_orders_id_fk",
+          "tableFrom": "order_lines",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_refunds": {
+      "name": "order_refunds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_user_id": {
+          "name": "operator_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_refunds_stripe_refund_id_unique": {
+          "name": "order_refunds_stripe_refund_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_refund_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_refunds_order_id_orders_id_fk": {
+          "name": "order_refunds_order_id_orders_id_fk",
+          "tableFrom": "order_refunds",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_refunds_line_id_order_lines_id_fk": {
+          "name": "order_refunds_line_id_order_lines_id_fk",
+          "tableFrom": "order_refunds",
+          "tableTo": "order_lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "order_refunds_operator_user_id_user_id_fk": {
+          "name": "order_refunds_operator_user_id_user_id_fk",
+          "tableFrom": "order_refunds",
+          "tableTo": "user",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "operator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_name": {
+          "name": "parent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_email": {
+          "name": "parent_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_mobile": {
+          "name": "parent_mobile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_name": {
+          "name": "student_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_year": {
+          "name": "student_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_roll": {
+          "name": "student_roll",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery": {
+          "name": "delivery",
+          "type": "delivery_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pickup'"
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gst": {
+          "name": "gst",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_ref": {
+          "name": "stripe_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_policy_accepted_at": {
+          "name": "refund_policy_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_note": {
+          "name": "parent_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emails_sent": {
+          "name": "emails_sent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_payment'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "orders_stripe_payment_intent_id_unique": {
+          "name": "orders_stripe_payment_intent_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orders_tenant_parent_email": {
+          "name": "idx_orders_tenant_parent_email",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "orders_tenant_id_tenants_id_fk": {
+          "name": "orders_tenant_id_tenants_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_user_id_user_id_fk": {
+          "name": "orders_user_id_user_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "user",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_children": {
+      "name": "parent_children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roll_class": {
+          "name": "roll_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parent_children_parent_idx": {
+          "name": "parent_children_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parent_children_parent_id_user_id_fk": {
+          "name": "parent_children_parent_id_user_id_fk",
+          "tableFrom": "parent_children",
+          "tableTo": "user",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "parent_children_tenant_id_tenants_id_fk": {
+          "name": "parent_children_tenant_id_tenants_id_fk",
+          "tableFrom": "parent_children",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short": {
+          "name": "short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accent": {
+          "name": "accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#7A1F2B'"
+        },
+        "motto": {
+          "name": "motto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_hours": {
+          "name": "shop_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_email": {
+          "name": "shop_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_instructions": {
+          "name": "collection_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_publicly_listed": {
+          "name": "is_publicly_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payouts_enabled": {
+          "name": "stripe_payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "stripe_charges_enabled": {
+          "name": "stripe_charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "platform_approval_status": {
+          "name": "platform_approval_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "platform_approved_at": {
+          "name": "platform_approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_approved_by": {
+          "name": "platform_approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_rejection_reason": {
+          "name": "platform_rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.delivery_method": {
+      "name": "delivery_method",
+      "schema": "public",
+      "values": [
+        "pickup",
+        "ship"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "pending_payment",
+        "new",
+        "packing",
+        "ready",
+        "collected",
+        "partially_refunded",
+        "refunded"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1778211565161,
       "tag": "0007_fix_user_id_uuid_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1778233791425,
+      "tag": "0008_catalog_image_url",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -20,7 +20,7 @@ const scriptSrc = [
 const csp = [
   "default-src 'self'",
   `script-src ${scriptSrc}`,
-  "connect-src 'self' https://api.stripe.com https://*.posthog.com https://us-assets.i.posthog.com https://api.resend.com",
+  "connect-src 'self' https://api.stripe.com https://*.posthog.com https://us-assets.i.posthog.com https://api.resend.com https://utfs.io https://*.uploadthing.com",
   "worker-src 'self' blob:",
   "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
   "img-src 'self' data: blob: https:",
@@ -60,6 +60,13 @@ const nextConfig: NextConfig = {
     "*.sg1.manus.computer",
     "*.manus.computer",
   ],
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "utfs.io" },
+      { protocol: "https", hostname: "*.utfs.io" },
+      { protocol: "https", hostname: "*.ufs.sh" },
+    ],
+  },
   async headers() {
     return [
       {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@react-email/render": "^2.0.8",
     "@stripe/connect-js": "^3.3.39",
     "@stripe/stripe-js": "^9.4.0",
+    "@uploadthing/react": "^7.3.3",
     "drizzle-orm": "^0.45.2",
     "embla-carousel": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
@@ -36,6 +37,7 @@
     "stripe": "^22.1.0",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",
+    "uploadthing": "^7.7.4",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,7 +35,8 @@
     "recharts": "^3.8.1",
     "stripe": "^22.1.0",
     "tailwind-merge": "^3.5.0",
-    "tailwind-variants": "^3.2.2"
+    "tailwind-variants": "^3.2.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",

--- a/apps/web/src/app/[tenant]/item/[itemId]/page.tsx
+++ b/apps/web/src/app/[tenant]/item/[itemId]/page.tsx
@@ -31,9 +31,9 @@ export default async function ItemDetailPage({ params }: PageProps<"/[tenant]/it
         <div className="px-5 pt-4 pb-2.5">
           <Chip tone="info">{item.cat} Uniform</Chip>
           <h2 className="font-serif text-[22px] font-medium mt-2.5 mb-1.5 leading-[1.2]">{item.name}</h2>
-          {item.desc && (
+          {item.description && (
             <p className="text-[13px] leading-[1.5] m-0 mb-3.5" style={{ color: "var(--color-ink-dim)" }}>
-              {item.desc}
+              {item.description}
             </p>
           )}
         </div>

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -1,271 +1,23 @@
 "use client";
-import { useState, useEffect } from "react";
-import type { ItemCategory, Tenant } from "@/lib/data";
-import { Chip } from "@/components/chip";
 
-const CATEGORIES: ItemCategory[] = ["Summer", "Winter", "Sports", "Formal", "Bags", "Stationery"];
+import { useState } from "react";
+import Image from "next/image";
+import { GarmentVector } from "@/components/garment";
+import { ItemDrawer, type ItemDrawerInitial } from "./item-drawer";
+import type { Tenant, ItemCategory } from "@/lib/data";
 
-const CATEGORY_TONE: Record<ItemCategory, "info" | "success" | "warn" | "neutral"> = {
-  Summer: "warn",
-  Winter: "info",
-  Sports: "success",
-  Formal: "neutral",
-  Bags: "neutral",
-  Stationery: "neutral",
-};
-
-interface DbVariant {
-  id: string;
-  itemId: string;
-  label: string;
-  price: string;
-  active: boolean;
-}
-
-interface DbItem {
+type DbVariant = { id: string; itemId: string; label: string; price: string; active: boolean };
+type DbItem = {
   id: string;
   tenantId: string;
   name: string;
   category: string;
   description: string | null;
+  imageUrl: string | null;
   active: boolean;
   sortOrder: number;
   variants: DbVariant[];
-}
-
-function AddProductModal({
-  tenantId,
-  accent,
-  onClose,
-  onAdded,
-}: {
-  tenantId: string;
-  accent: string;
-  onClose: () => void;
-  onAdded: (item: DbItem) => void;
-}) {
-  const [name, setName] = useState("");
-  const [category, setCategory] = useState<ItemCategory>("Summer");
-  const [description, setDescription] = useState("");
-  const [variants, setVariants] = useState([{ label: "", price: "" }]);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState("");
-
-  const addVariant = () => setVariants((v) => [...v, { label: "", price: "" }]);
-  const removeVariant = (i: number) => setVariants((v) => v.filter((_, idx) => idx !== i));
-  const updateVariant = (i: number, field: "label" | "price", val: string) =>
-    setVariants((v) => v.map((vv, idx) => (idx === i ? { ...vv, [field]: val } : vv)));
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError("");
-    if (!name.trim()) { setError("Product name is required."); return; }
-    if (variants.some((v) => !v.label.trim() || !v.price.trim())) {
-      setError("All variant fields are required."); return;
-    }
-    if (variants.some((v) => !Number.isFinite(Number(v.price)) || Number(v.price) < 0)) {
-      setError("Variant prices must be valid positive numbers."); return;
-    }
-
-    setSaving(true);
-    try {
-      const res = await fetch("/api/catalog", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          tenantId,
-          name: name.trim(),
-          category,
-          description: description.trim() || undefined,
-          variants: variants.map((v) => ({
-            label: v.label.trim(),
-            price: parseFloat(v.price),
-          })),
-        }),
-      });
-      if (!res.ok) {
-        const data = await res.json();
-        setError(data.error ?? "Failed to add product.");
-        return;
-      }
-      const { id } = await res.json();
-      // Build a local DbItem to add to the table immediately
-      const newItem: DbItem = {
-        id,
-        tenantId,
-        name: name.trim(),
-        category,
-        description: description.trim() || null,
-        active: true,
-        sortOrder: 999,
-        variants: variants.map((v, i) => ({
-          id: `temp-${i}`,
-          itemId: id,
-          label: v.label.trim(),
-          price: v.price,
-          active: true,
-        })),
-      };
-      onAdded(newItem);
-      onClose();
-    } catch (err) {
-      setError("Network error. Please try again.");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: "rgba(0,0,0,0.4)" }}>
-      <div
-        className="bg-white rounded-xl border shadow-xl w-full max-w-lg mx-4 overflow-hidden"
-        style={{ borderColor: "var(--color-rule)" }}
-      >
-        {/* Modal header */}
-        <div
-          className="px-6 py-4 flex items-center justify-between"
-          style={{ borderBottom: "1px solid var(--color-rule)" }}
-        >
-          <h2 className="font-serif text-[18px] font-semibold" style={{ color: "var(--color-ink)" }}>
-            Add product
-          </h2>
-          <button
-            onClick={onClose}
-            className="w-8 h-8 flex items-center justify-center rounded-full text-[16px]"
-            style={{ color: "var(--color-ink-dim)", background: "var(--color-parchment)" }}
-          >
-            ✕
-          </button>
-        </div>
-
-        {/* Modal body */}
-        <form onSubmit={handleSubmit} className="p-6 space-y-4">
-          {error && (
-            <div className="text-[12.5px] px-3 py-2 rounded" style={{ background: "#FEF2F2", color: "#B91C1C" }}>
-              {error}
-            </div>
-          )}
-
-          <div>
-            <label className="type-label block mb-1" style={{ color: "var(--color-ink-dim)" }}>
-              Product name *
-            </label>
-            <input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g. Navy Shorts"
-              className="w-full h-9 border rounded-md px-3 text-[13px] outline-none"
-              style={{ borderColor: "var(--color-rule)", fontFamily: "var(--font-sans)", color: "var(--color-ink)" }}
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="type-label block mb-1" style={{ color: "var(--color-ink-dim)" }}>
-                Category *
-              </label>
-              <select
-                value={category}
-                onChange={(e) => setCategory(e.target.value as ItemCategory)}
-                className="w-full h-9 border rounded-md px-3 text-[13px] outline-none bg-white"
-                style={{ borderColor: "var(--color-rule)", fontFamily: "var(--font-sans)", color: "var(--color-ink)" }}
-              >
-                {CATEGORIES.map((c) => (
-                  <option key={c} value={c}>{c}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className="type-label block mb-1" style={{ color: "var(--color-ink-dim)" }}>
-                Description
-              </label>
-              <input
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Optional"
-                className="w-full h-9 border rounded-md px-3 text-[13px] outline-none"
-                style={{ borderColor: "var(--color-rule)", fontFamily: "var(--font-sans)", color: "var(--color-ink)" }}
-              />
-            </div>
-          </div>
-
-          {/* Variants */}
-          <div>
-            <div className="flex items-center justify-between mb-1.5">
-              <label className="type-label" style={{ color: "var(--color-ink-dim)" }}>
-                Variants (size / price) *
-              </label>
-              <button
-                type="button"
-                onClick={addVariant}
-                className="text-[11.5px] font-semibold"
-                style={{ color: accent }}
-              >
-                + Add variant
-              </button>
-            </div>
-            <div className="space-y-2">
-              {variants.map((v, i) => (
-                <div key={i} className="flex gap-2 items-center">
-                  <input
-                    value={v.label}
-                    onChange={(e) => updateVariant(i, "label", e.target.value)}
-                    placeholder="Label (e.g. Size 10–16)"
-                    className="flex-1 h-8 border rounded-md px-2.5 text-[12.5px] outline-none"
-                    style={{ borderColor: "var(--color-rule)", fontFamily: "var(--font-sans)" }}
-                  />
-                  <div className="relative w-24">
-                    <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[12px]" style={{ color: "var(--color-ink-dim)" }}>$</span>
-                    <input
-                      value={v.price}
-                      onChange={(e) => updateVariant(i, "price", e.target.value)}
-                      placeholder="0.00"
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      className="w-full h-8 border rounded-md pl-6 pr-2 text-[12.5px] outline-none"
-                      style={{ borderColor: "var(--color-rule)", fontFamily: "var(--font-sans)" }}
-                    />
-                  </div>
-                  {variants.length > 1 && (
-                    <button
-                      type="button"
-                      onClick={() => removeVariant(i)}
-                      className="w-7 h-7 flex items-center justify-center rounded text-[13px]"
-                      style={{ color: "#B23A2A", background: "#FEF2F2" }}
-                    >
-                      ✕
-                    </button>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Actions */}
-          <div className="flex gap-2 pt-1">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 h-9 text-[13px] font-semibold rounded-md border"
-              style={{ borderColor: "var(--color-rule)", color: "var(--color-ink)" }}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={saving}
-              className="flex-1 h-9 text-[13px] font-semibold rounded-md text-white disabled:opacity-60"
-              style={{ background: accent }}
-            >
-              {saving ? "Saving…" : "Add product"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
+};
 
 export function CatalogTable({
   tenantId,
@@ -277,55 +29,25 @@ export function CatalogTable({
   tenant: Tenant;
 }) {
   const [items, setItems] = useState<DbItem[]>(initialItems);
-  const [activeCategory, setActiveCategory] = useState<ItemCategory | "All">("All");
-  const [search, setSearch] = useState("");
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editingName, setEditingName] = useState("");
-  const [showAddModal, setShowAddModal] = useState(false);
   const [tableError, setTableError] = useState("");
+  const [drawer, setDrawer] = useState<
+    | { open: false }
+    | { open: true; mode: "create" }
+    | { open: true; mode: "edit"; item: DbItem }
+  >({ open: false });
 
-  const filtered = items.filter((it) => {
-    const matchCat = activeCategory === "All" || it.category === activeCategory;
-    const matchSearch =
-      !search ||
-      it.name.toLowerCase().includes(search.toLowerCase()) ||
-      it.id.toLowerCase().includes(search.toLowerCase());
-    return matchCat && matchSearch;
-  });
-
-  const handleEdit = (id: string, currentName: string) => {
-    setEditingId(id);
-    setEditingName(currentName);
-  };
-
-  const handleSaveEdit = async (id: string) => {
-    const trimmed = editingName.trim();
-    if (!trimmed) return;
-    const previousItems = items;
-    setTableError("");
-    // Optimistic update
-    setItems((prev) => prev.map((it) => (it.id === id ? { ...it, name: trimmed } : it)));
-    setEditingId(null);
+  const refresh = async () => {
     try {
-      const res = await fetch(`/api/catalog/${id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: trimmed }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => null);
-        throw new Error(data?.error ?? "Failed to update item.");
-      }
+      const res = await fetch(`/api/catalog?tenantId=${tenantId}`);
+      if (res.ok) setItems(await res.json());
     } catch (err) {
-      console.error("Failed to update item:", err);
-      setItems(previousItems);
-      setTableError(err instanceof Error ? err.message : "Failed to update item.");
+      console.error("Refresh failed:", err);
     }
   };
 
-  const handleDelete = async (id: string) => {
-    if (!confirm("Remove this product from the catalog?")) return;
-    const previousItems = items;
+  const handleDelete = async (id: string, name: string) => {
+    if (!confirm(`Remove "${name}" from the catalog?`)) return;
+    const previous = items;
     setTableError("");
     setItems((prev) => prev.filter((it) => it.id !== id));
     try {
@@ -335,210 +57,113 @@ export function CatalogTable({
         throw new Error(data?.error ?? "Failed to delete item.");
       }
     } catch (err) {
-      console.error("Failed to delete item:", err);
-      setItems(previousItems);
+      console.error("Delete failed:", err);
+      setItems(previous);
       setTableError(err instanceof Error ? err.message : "Failed to delete item.");
     }
   };
 
-  const handleAdded = (newItem: DbItem) => {
-    setTableError("");
-    setItems((prev) => [...prev, newItem]);
-  };
+  const initialFromItem = (it: DbItem): ItemDrawerInitial => ({
+    name: it.name,
+    category: it.category as ItemCategory,
+    description: it.description ?? undefined,
+    imageUrl: it.imageUrl ?? undefined,
+    active: it.active,
+    sortOrder: it.sortOrder,
+    variants: it.variants.map((v) => ({ label: v.label, price: v.price, active: v.active })),
+  });
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden p-6">
-      {showAddModal && (
-        <AddProductModal
-          tenantId={tenantId}
-          accent={tenant.accent}
-          onClose={() => setShowAddModal(false)}
-          onAdded={handleAdded}
-        />
-      )}
-
       {tableError && (
         <div className="mb-3 text-[12.5px] px-3 py-2 rounded" style={{ background: "#FEF2F2", color: "#B91C1C" }}>
           {tableError}
         </div>
       )}
 
-      {/* Filters */}
-      <div className="flex items-center gap-3 mb-4">
-        <div
-          className="h-9 border rounded-md px-2.5 flex items-center gap-2 bg-white flex-1 max-w-xs"
-          style={{ borderColor: "var(--color-rule)" }}
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--color-ink-dim)" strokeWidth="1.7" strokeLinecap="round">
-            <circle cx="11" cy="11" r="8" /><path d="M20 20 L16 16" />
-          </svg>
-          <input
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search products…"
-            className="flex-1 border-none outline-none text-[12.5px] bg-transparent"
-            style={{ fontFamily: "var(--font-sans)", color: "var(--color-ink)" }}
-          />
-        </div>
-        <div className="flex gap-1.5 flex-1">
-          {(["All", ...CATEGORIES] as const).map((c) => (
-            <button
-              key={c}
-              onClick={() => setActiveCategory(c as ItemCategory | "All")}
-              className="h-8 px-3 rounded-full text-[12px] font-semibold border transition-colors"
-              style={{
-                background: activeCategory === c ? tenant.accent : "#fff",
-                color: activeCategory === c ? "#fff" : "var(--color-ink)",
-                borderColor: activeCategory === c ? tenant.accent : "var(--color-rule)",
-              }}
-            >
-              {c}
-            </button>
-          ))}
-        </div>
-        <button
-          onClick={() => setShowAddModal(true)}
-          className="h-9 px-4 text-[12.5px] font-semibold rounded-md text-white flex items-center gap-1.5 flex-shrink-0"
-          style={{ background: tenant.accent }}
-        >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round">
-            <path d="M12 5v14M5 12h14" />
-          </svg>
-          Add product
-        </button>
+      <div className="flex-1 overflow-auto rounded-md border" style={{ borderColor: "var(--color-rule)" }}>
+        <table className="w-full text-[13px]">
+          <thead className="bg-white sticky top-0">
+            <tr className="text-left" style={{ color: "var(--color-ink-dim)" }}>
+              <th className="px-3 py-2 w-[60px]">Image</th>
+              <th className="px-3 py-2">Name</th>
+              <th className="px-3 py-2 w-[110px]">Category</th>
+              <th className="px-3 py-2 w-[100px]">Variants</th>
+              <th className="px-3 py-2 w-[80px]">Active</th>
+              <th className="px-3 py-2 w-[60px]"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((it) => (
+              <tr
+                key={it.id}
+                className="border-t cursor-pointer hover:bg-[var(--color-parchment)]"
+                style={{ borderColor: "var(--color-rule)" }}
+                onClick={() => setDrawer({ open: true, mode: "edit", item: it })}
+              >
+                <td className="px-3 py-2">
+                  {it.imageUrl ? (
+                    <Image
+                      src={it.imageUrl}
+                      alt={it.name}
+                      width={40}
+                      height={40}
+                      className="rounded-sm object-cover"
+                    />
+                  ) : (
+                    <GarmentVector itemId={it.id} category={it.category as ItemCategory} accent={tenant.accent} size={40} />
+                  )}
+                </td>
+                <td className="px-3 py-2 font-medium">{it.name}</td>
+                <td className="px-3 py-2">{it.category}</td>
+                <td className="px-3 py-2 tnum">{it.variants.length}</td>
+                <td className="px-3 py-2">
+                  {it.active ? (
+                    <span className="text-emerald-700">●</span>
+                  ) : (
+                    <span style={{ color: "var(--color-ink-dim)" }}>○</span>
+                  )}
+                </td>
+                <td
+                  className="px-3 py-2 text-right"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button
+                    type="button"
+                    className="text-[12px] underline"
+                    onClick={() => handleDelete(it.id, it.name)}
+                    style={{ color: tenant.accent }}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {items.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-3 py-6 text-center" style={{ color: "var(--color-ink-dim)" }}>
+                  No items yet. Click “Add item” to create one.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
       </div>
 
-      {/* Table */}
-      <div
-        className="flex-1 bg-white rounded-xl border overflow-hidden flex flex-col"
-        style={{ borderColor: "var(--color-rule)" }}
-      >
-        <div className="overflow-y-auto flex-1">
-          <table className="w-full border-collapse text-[13px]" style={{ fontFamily: "var(--font-sans)" }}>
-            <thead className="sticky top-0 z-10">
-              <tr style={{ background: "var(--color-parchment)" }}>
-                {["SKU", "Product", "Category", "Variants", "Price range", "Actions"].map((h, i) => (
-                  <th
-                    key={h}
-                    className="text-left py-2.5 px-3 text-[10.5px] font-bold uppercase tracking-[0.6px] border-b"
-                    style={{
-                      color: "var(--color-ink-dim)",
-                      borderColor: "var(--color-rule)",
-                      textAlign: i >= 4 ? "right" : "left",
-                    }}
-                  >
-                    {h}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map((it) => {
-                const prices = it.variants.map((v) => parseFloat(v.price));
-                const minP = Math.min(...prices);
-                const maxP = Math.max(...prices);
-                const isEditing = editingId === it.id;
-                const cat = it.category as ItemCategory;
-                return (
-                  <tr
-                    key={it.id}
-                    className="border-b transition-colors hover:bg-[#FDFBF6]"
-                    style={{
-                      borderColor: "var(--color-rule)",
-                      background: isEditing ? "#F0F7FF" : undefined,
-                    }}
-                  >
-                    <td className="py-2.5 px-3 font-mono text-[11.5px] font-semibold" style={{ color: "var(--color-ink)" }}>
-                      {it.id.length > 20 ? it.id.slice(0, 20) + "…" : it.id}
-                    </td>
-                    <td className="py-2.5 px-3 font-medium" style={{ color: "var(--color-ink)" }}>
-                      {isEditing ? (
-                        <input
-                          value={editingName}
-                          onChange={(e) => setEditingName(e.target.value)}
-                          className="border rounded px-2 py-1 text-[12.5px] w-full"
-                          style={{ borderColor: tenant.accent, outline: "none" }}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") handleSaveEdit(it.id);
-                            if (e.key === "Escape") setEditingId(null);
-                          }}
-                          autoFocus
-                        />
-                      ) : (
-                        it.name
-                      )}
-                    </td>
-                    <td className="py-2.5 px-3">
-                      <Chip tone={CATEGORY_TONE[cat] ?? "neutral"} size="sm">
-                        {it.category}
-                      </Chip>
-                    </td>
-                    <td className="py-2.5 px-3 text-[12px]" style={{ color: "var(--color-ink-dim)" }}>
-                      {it.variants.map((v) => v.label).join(", ")}
-                    </td>
-                    <td className="py-2.5 px-3 text-right font-semibold tnum" style={{ color: "var(--color-ink)" }}>
-                      {prices.length === 0 ? "—" : minP === maxP ? `$${minP}` : `$${minP} – $${maxP}`}
-                    </td>
-                    <td className="py-2.5 px-3">
-                      <div className="flex items-center justify-end gap-1.5">
-                        {isEditing ? (
-                          <>
-                            <button
-                              onClick={() => handleSaveEdit(it.id)}
-                              className="h-7 px-2.5 text-[11.5px] font-semibold rounded border"
-                              style={{ borderColor: tenant.accent, color: tenant.accent }}
-                            >
-                              Save
-                            </button>
-                            <button
-                              onClick={() => setEditingId(null)}
-                              className="h-7 px-2.5 text-[11.5px] font-semibold rounded border"
-                              style={{ borderColor: "var(--color-rule)", color: "var(--color-ink)" }}
-                            >
-                              Cancel
-                            </button>
-                          </>
-                        ) : (
-                          <>
-                            <button
-                              onClick={() => handleEdit(it.id, it.name)}
-                              className="h-7 px-2.5 text-[11.5px] font-semibold rounded border"
-                              style={{ borderColor: "var(--color-rule)", color: "var(--color-ink)" }}
-                            >
-                              Edit
-                            </button>
-                            <button
-                              onClick={() => handleDelete(it.id)}
-                              className="h-7 px-2.5 text-[11.5px] font-semibold rounded border"
-                              style={{ borderColor: "#E5BDB4", color: "#B23A2A" }}
-                            >
-                              Remove
-                            </button>
-                          </>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-              {filtered.length === 0 && (
-                <tr>
-                  <td colSpan={6} className="py-12 text-center text-[13px]" style={{ color: "var(--color-ink-dim)" }}>
-                    No products match your filter.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-        <div
-          className="px-4 py-2.5 flex items-center justify-between text-[11.5px] flex-shrink-0"
-          style={{ borderTop: "1px solid var(--color-rule)", color: "var(--color-ink-dim)" }}
-        >
-          <span>{filtered.length} products shown</span>
-          <span>{items.reduce((s, it) => s + it.variants.length, 0)} variants total</span>
-        </div>
-      </div>
+      {drawer.open && (
+        <ItemDrawer
+          tenant={tenant}
+          open={drawer.open}
+          mode={
+            drawer.mode === "create"
+              ? { kind: "create" }
+              : { kind: "edit", itemId: drawer.item.id }
+          }
+          initial={drawer.mode === "edit" ? initialFromItem(drawer.item) : undefined}
+          onClose={() => setDrawer({ open: false })}
+          onSaved={refresh}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -1,49 +1,28 @@
 "use client";
 
-import { useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import Image from "next/image";
 import { GarmentVector } from "@/components/garment";
 import { ItemDrawer, type ItemDrawerInitial } from "./item-drawer";
 import type { Tenant, ItemCategory } from "@/lib/data";
-
-type DbVariant = { id: string; itemId: string; label: string; price: string; active: boolean };
-type DbItem = {
-  id: string;
-  tenantId: string;
-  name: string;
-  category: string;
-  description: string | null;
-  imageUrl: string | null;
-  active: boolean;
-  sortOrder: number;
-  variants: DbVariant[];
-};
+import type { CatalogItemWithVariants } from "@/db/queries";
 
 export function CatalogTable({
-  tenantId,
-  initialItems,
+  items,
+  setItems,
+  refresh,
   tenant,
 }: {
-  tenantId: string;
-  initialItems: DbItem[];
+  items: CatalogItemWithVariants[];
+  setItems: Dispatch<SetStateAction<CatalogItemWithVariants[]>>;
+  refresh: () => Promise<void>;
   tenant: Tenant;
 }) {
-  const [items, setItems] = useState<DbItem[]>(initialItems);
   const [tableError, setTableError] = useState("");
   const [drawer, setDrawer] = useState<
     | { open: false }
-    | { open: true; mode: "create" }
-    | { open: true; mode: "edit"; item: DbItem }
+    | { open: true; mode: "edit"; item: CatalogItemWithVariants }
   >({ open: false });
-
-  const refresh = async () => {
-    try {
-      const res = await fetch(`/api/catalog?tenantId=${tenantId}`);
-      if (res.ok) setItems(await res.json());
-    } catch (err) {
-      console.error("Refresh failed:", err);
-    }
-  };
 
   const handleDelete = async (id: string, name: string) => {
     if (!confirm(`Remove "${name}" from the catalog?`)) return;
@@ -63,14 +42,19 @@ export function CatalogTable({
     }
   };
 
-  const initialFromItem = (it: DbItem): ItemDrawerInitial => ({
+  const initialFromItem = (it: CatalogItemWithVariants): ItemDrawerInitial => ({
     name: it.name,
     category: it.category as ItemCategory,
     description: it.description ?? undefined,
     imageUrl: it.imageUrl ?? undefined,
     active: it.active,
     sortOrder: it.sortOrder,
-    variants: it.variants.map((v) => ({ label: v.label, price: v.price, active: v.active })),
+    variants: it.variants.map((v) => ({
+      id: v.id,
+      label: v.label,
+      price: v.price,
+      active: v.active,
+    })),
   });
 
   return (
@@ -154,12 +138,8 @@ export function CatalogTable({
         <ItemDrawer
           tenant={tenant}
           open={drawer.open}
-          mode={
-            drawer.mode === "create"
-              ? { kind: "create" }
-              : { kind: "edit", itemId: drawer.item.id }
-          }
-          initial={drawer.mode === "edit" ? initialFromItem(drawer.item) : undefined}
+          mode={{ kind: "edit", itemId: drawer.item.id }}
+          initial={initialFromItem(drawer.item)}
           onClose={() => setDrawer({ open: false })}
           onSaved={refresh}
         />

--- a/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
@@ -81,11 +81,15 @@ export function ItemDrawer({
     setSubmitting(true);
     setError(null);
     try {
+      // Use explicit `null` for cleared fields — `undefined` is dropped by
+      // JSON.stringify, which makes "Remove image" or a cleared description
+      // a no-op on PATCH. The API schema accepts `null | string`.
+      const trimmedDesc = description.trim();
       const basePayload = {
         name: name.trim(),
         category,
-        description: description.trim() || undefined,
-        imageUrl,
+        description: trimmedDesc.length > 0 ? trimmedDesc : null,
+        imageUrl: imageUrl ?? null,
         active,
         sortOrder: initial?.sortOrder ?? 0,
         variants: variants.map((v) => ({

--- a/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
@@ -1,14 +1,37 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { UploadDropzone } from "@/components/uploadthing";
 import { GarmentVector } from "@/components/garment";
 import type { Tenant } from "@/lib/data";
 import { ITEM_CATEGORIES } from "@/lib/schemas/catalog";
 
-type Variant = { label: string; price: string; active?: boolean };
+type ZodFlatten = {
+  formErrors?: string[];
+  fieldErrors?: Record<string, string[] | undefined>;
+};
+
+function formatZodErrors(details: ZodFlatten | unknown): string {
+  if (!details || typeof details !== "object") return "Invalid input.";
+  const { formErrors, fieldErrors } = details as ZodFlatten;
+  const lines: string[] = [];
+  if (Array.isArray(formErrors)) lines.push(...formErrors);
+  if (fieldErrors) {
+    for (const [field, msgs] of Object.entries(fieldErrors)) {
+      if (msgs?.length) lines.push(`${field}: ${msgs[0]}`);
+    }
+  }
+  return lines.length > 0 ? lines.join("; ") : "Invalid input.";
+}
+
+type Variant = {
+  /** Server-assigned id; present only for variants loaded from DB. */
+  id?: string;
+  label: string;
+  price: string;
+  active?: boolean;
+};
 
 type Mode = { kind: "create" } | { kind: "edit"; itemId: string };
 
@@ -35,9 +58,8 @@ export function ItemDrawer({
   mode: Mode;
   initial?: ItemDrawerInitial;
   onClose: () => void;
-  onSaved: () => void;
+  onSaved: () => void | Promise<void>;
 }) {
-  const router = useRouter();
   const [name, setName] = useState("");
   const [category, setCategory] = useState<typeof ITEM_CATEGORIES[number]>("Summer");
   const [description, setDescription] = useState("");
@@ -57,7 +79,12 @@ export function ItemDrawer({
     setActive(initial?.active ?? true);
     setVariants(
       initial?.variants?.length
-        ? initial.variants.map((v) => ({ label: v.label, price: v.price, active: v.active }))
+        ? initial.variants.map((v) => ({
+            id: v.id,
+            label: v.label,
+            price: v.price,
+            active: v.active,
+          }))
         : [{ label: "", price: "" }]
     );
     setError(null);
@@ -93,6 +120,7 @@ export function ItemDrawer({
         active,
         sortOrder: initial?.sortOrder ?? 0,
         variants: variants.map((v) => ({
+          id: v.id,
           label: v.label.trim(),
           price: Number(v.price),
           active: v.active,
@@ -117,14 +145,17 @@ export function ItemDrawer({
         const body = await res.json().catch(() => null);
         if (res.status === 403 && body?.code === "tenant_not_approved") {
           setError("This school is not yet approved on the platform.");
+        } else if (body?.error === "validation_failed" && body?.details) {
+          setError(formatZodErrors(body.details));
+        } else if (res.status === 429) {
+          setError("Too many requests. Wait a moment and try again.");
         } else {
           setError(body?.error ?? `HTTP ${res.status}`);
         }
         return;
       }
 
-      onSaved();
-      router.refresh();
+      await Promise.resolve(onSaved());
       onClose();
     } catch (err) {
       console.error("Catalog save failed:", err);

--- a/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
@@ -224,6 +224,12 @@ export function ItemDrawer({
                 <UploadDropzone
                   endpoint="catalogImage"
                   input={{ tenantId: tenant.id }}
+                  // mode: "auto" uploads immediately on file pick/drop. The
+                  // default "manual" mode requires a second "Upload N file(s)"
+                  // click and its queue state has been observed to get stuck
+                  // after re-mount cycles (e.g. dev-mode HMR, or open→Remove
+                  // →pick within one drawer session).
+                  config={{ mode: "auto" }}
                   onClientUploadComplete={(res) => {
                     const url = res?.[0]?.serverData?.url;
                     if (url) setImageUrl(url);

--- a/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { UploadDropzone } from "@/components/uploadthing";
+import { GarmentVector } from "@/components/garment";
+import type { Tenant } from "@/lib/data";
+import { ITEM_CATEGORIES } from "@/lib/schemas/catalog";
+
+type Variant = { label: string; price: string; active?: boolean };
+
+type Mode = { kind: "create" } | { kind: "edit"; itemId: string };
+
+export type ItemDrawerInitial = {
+  name?: string;
+  category?: typeof ITEM_CATEGORIES[number];
+  description?: string;
+  imageUrl?: string;
+  active?: boolean;
+  sortOrder?: number;
+  variants?: Variant[];
+};
+
+export function ItemDrawer({
+  tenant,
+  open,
+  mode,
+  initial,
+  onClose,
+  onSaved,
+}: {
+  tenant: Tenant;
+  open: boolean;
+  mode: Mode;
+  initial?: ItemDrawerInitial;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [category, setCategory] = useState<typeof ITEM_CATEGORIES[number]>("Summer");
+  const [description, setDescription] = useState("");
+  const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
+  const [active, setActive] = useState(true);
+  const [variants, setVariants] = useState<Variant[]>([{ label: "", price: "" }]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Sync state with `initial` when drawer opens
+  useEffect(() => {
+    if (!open) return;
+    setName(initial?.name ?? "");
+    setCategory(initial?.category ?? "Summer");
+    setDescription(initial?.description ?? "");
+    setImageUrl(initial?.imageUrl);
+    setActive(initial?.active ?? true);
+    setVariants(
+      initial?.variants?.length
+        ? initial.variants.map((v) => ({ label: v.label, price: v.price, active: v.active }))
+        : [{ label: "", price: "" }]
+    );
+    setError(null);
+  }, [open, initial]);
+
+  const setVariant = (i: number, patch: Partial<Variant>) =>
+    setVariants((prev) => prev.map((v, idx) => (idx === i ? { ...v, ...patch } : v)));
+  const addVariant = () => setVariants((prev) => [...prev, { label: "", price: "" }]);
+  const removeVariant = (i: number) =>
+    setVariants((prev) => (prev.length === 1 ? prev : prev.filter((_, idx) => idx !== i)));
+
+  const isValid =
+    name.trim().length > 0 &&
+    name.length <= 80 &&
+    description.length <= 500 &&
+    variants.length >= 1 &&
+    variants.every((v) => v.label.trim().length > 0 && Number(v.price) > 0);
+
+  const handleSubmit = async () => {
+    if (!isValid || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const basePayload = {
+        name: name.trim(),
+        category,
+        description: description.trim() || undefined,
+        imageUrl,
+        active,
+        sortOrder: initial?.sortOrder ?? 0,
+        variants: variants.map((v) => ({
+          label: v.label.trim(),
+          price: Number(v.price),
+          active: v.active,
+        })),
+      };
+
+      const url =
+        mode.kind === "create" ? `/api/catalog` : `/api/catalog/${mode.itemId}`;
+      const method = mode.kind === "create" ? "POST" : "PATCH";
+
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          mode.kind === "create"
+            ? { tenantId: tenant.id, ...basePayload }
+            : basePayload
+        ),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        if (res.status === 403 && body?.code === "tenant_not_approved") {
+          setError("This school is not yet approved on the platform.");
+        } else {
+          setError(body?.error ?? `HTTP ${res.status}`);
+        }
+        return;
+      }
+
+      onSaved();
+      router.refresh();
+      onClose();
+    } catch (err) {
+      console.error("Catalog save failed:", err);
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={mode.kind === "create" ? "Add item" : "Edit item"}
+        className="relative w-[440px] max-w-full bg-white shadow-xl flex flex-col h-full"
+      >
+        <div className="px-5 pt-5 pb-3 border-b" style={{ borderColor: "var(--color-rule)" }}>
+          <div
+            className="text-[10.5px] font-bold uppercase tracking-[0.5px]"
+            style={{ color: tenant.accent }}
+          >
+            {mode.kind === "create" ? "Add item" : "Edit item"}
+          </div>
+          <h2 className="font-serif text-[20px] font-medium mt-1">
+            {mode.kind === "create" ? "New catalog item" : initial?.name ?? "Edit"}
+          </h2>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+          {/* Image */}
+          <section>
+            <label className="text-[11px] font-bold uppercase tracking-[0.4px] block mb-2">
+              Image
+            </label>
+            {imageUrl ? (
+              <div className="flex items-start gap-3">
+                <Image
+                  src={imageUrl}
+                  alt="Item preview"
+                  width={96}
+                  height={96}
+                  className="rounded-md border"
+                  style={{ borderColor: "var(--color-rule)" }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setImageUrl(undefined)}
+                  className="text-[12px] underline"
+                  style={{ color: tenant.accent }}
+                >
+                  Remove
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <UploadDropzone
+                  endpoint="catalogImage"
+                  input={{ tenantId: tenant.id }}
+                  onClientUploadComplete={(res) => {
+                    const url = res?.[0]?.serverData?.url;
+                    if (url) setImageUrl(url);
+                  }}
+                  onUploadError={(err) => {
+                    const msg = err.message;
+                    if (msg.includes("tenant_not_approved")) {
+                      setError("This school is not yet approved on the platform.");
+                    } else {
+                      setError(msg);
+                    }
+                  }}
+                />
+                <div className="flex items-center gap-2 text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+                  <span>No image? Parents will see this fallback:</span>
+                  <GarmentVector category={category} accent={tenant.accent} size={32} />
+                </div>
+              </div>
+            )}
+          </section>
+
+          {/* Name */}
+          <section>
+            <label className="text-[11px] font-bold uppercase tracking-[0.4px] block mb-1">
+              Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={80}
+              className="w-full h-9 px-3 text-[13px] rounded-md border"
+              style={{ borderColor: "var(--color-rule)" }}
+            />
+            <div className="text-[10.5px] mt-1" style={{ color: "var(--color-ink-dim)" }}>
+              {name.length} / 80
+            </div>
+          </section>
+
+          {/* Category */}
+          <section>
+            <label className="text-[11px] font-bold uppercase tracking-[0.4px] block mb-1">
+              Category
+            </label>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value as typeof ITEM_CATEGORIES[number])}
+              className="w-full h-9 px-3 text-[13px] rounded-md border"
+              style={{ borderColor: "var(--color-rule)" }}
+            >
+              {ITEM_CATEGORIES.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </section>
+
+          {/* Description */}
+          <section>
+            <label className="text-[11px] font-bold uppercase tracking-[0.4px] block mb-1">
+              Description
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={500}
+              rows={3}
+              placeholder="Short description shown on the item page"
+              className="w-full px-3 py-2 text-[13px] rounded-md border"
+              style={{ borderColor: "var(--color-rule)" }}
+            />
+            <div className="text-[10.5px] mt-1" style={{ color: "var(--color-ink-dim)" }}>
+              {description.length} / 500
+            </div>
+          </section>
+
+          {/* Variants */}
+          <section>
+            <label className="text-[11px] font-bold uppercase tracking-[0.4px] block mb-2">
+              Variants (size + price)
+            </label>
+            <div className="space-y-2">
+              {variants.map((v, i) => (
+                <div key={i} className="grid grid-cols-[1fr_120px_28px] gap-2">
+                  <input
+                    type="text"
+                    placeholder="Label e.g. Size 10"
+                    value={v.label}
+                    maxLength={40}
+                    onChange={(e) => setVariant(i, { label: e.target.value })}
+                    className="h-8 px-2 text-[12.5px] rounded-md border"
+                    style={{ borderColor: "var(--color-rule)" }}
+                  />
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0.01"
+                    placeholder="Price (AUD)"
+                    value={v.price}
+                    onChange={(e) => setVariant(i, { price: e.target.value })}
+                    className="h-8 px-2 text-[12.5px] rounded-md border tnum"
+                    style={{ borderColor: "var(--color-rule)" }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeVariant(i)}
+                    disabled={variants.length === 1}
+                    className="h-8 text-[16px] disabled:opacity-30"
+                    aria-label={`Remove variant ${i + 1}`}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={addVariant}
+              className="text-[12px] underline mt-2"
+              style={{ color: tenant.accent }}
+            >
+              + Add variant
+            </button>
+          </section>
+
+          {/* Active toggle */}
+          <section className="flex items-center gap-2">
+            <input
+              id="item-active"
+              type="checkbox"
+              checked={active}
+              onChange={(e) => setActive(e.target.checked)}
+            />
+            <label htmlFor="item-active" className="text-[13px]">
+              Active (visible to parents)
+            </label>
+          </section>
+
+          {error && (
+            <div className="text-[12.5px] px-3 py-2 rounded" style={{ background: "#FEF2F2", color: "#B91C1C" }}>
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="px-5 py-3 border-t flex items-center justify-end gap-2" style={{ borderColor: "var(--color-rule)" }}>
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-9 px-4 text-[12.5px] font-semibold rounded-md border"
+            style={{ borderColor: "var(--color-rule)" }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!isValid || submitting}
+            className="h-9 px-4 text-[12.5px] font-semibold rounded-md text-white disabled:opacity-50"
+            style={{ background: tenant.accent }}
+          >
+            {submitting ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/[tenant]/catalog/page-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/page-client.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { CatalogTable } from "./catalog-table";
+import { ItemDrawer } from "./item-drawer";
+import type { Tenant } from "@/lib/data";
+
+type DbVariant = { id: string; itemId: string; label: string; price: string; active: boolean };
+type DbItem = {
+  id: string;
+  tenantId: string;
+  name: string;
+  category: string;
+  description: string | null;
+  imageUrl: string | null;
+  active: boolean;
+  sortOrder: number;
+  variants: DbVariant[];
+};
+
+export function CatalogPageClient({
+  tenantId,
+  tenant,
+  initialItems,
+}: {
+  tenantId: string;
+  tenant: Tenant;
+  initialItems: DbItem[];
+}) {
+  const router = useRouter();
+  const [addOpen, setAddOpen] = useState(false);
+
+  return (
+    <>
+      <div className="flex items-center justify-end gap-2 px-6 pt-4">
+        <Link
+          href={`/admin/${tenantId}/upload`}
+          className="h-9 px-3.5 text-[12.5px] font-semibold rounded-md border flex items-center gap-1.5"
+          style={{ borderColor: "var(--color-rule)", color: "var(--color-ink)" }}
+        >
+          Bulk upload CSV
+        </Link>
+        <button
+          type="button"
+          onClick={() => setAddOpen(true)}
+          className="h-9 px-3.5 text-[12.5px] font-semibold rounded-md text-white"
+          style={{ background: tenant.accent }}
+        >
+          + Add item
+        </button>
+      </div>
+      <CatalogTable tenantId={tenantId} tenant={tenant} initialItems={initialItems} />
+      <ItemDrawer
+        tenant={tenant}
+        open={addOpen}
+        mode={{ kind: "create" }}
+        onClose={() => setAddOpen(false)}
+        onSaved={() => router.refresh()}
+      />
+    </>
+  );
+}

--- a/apps/web/src/app/admin/[tenant]/catalog/page-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/page-client.tsx
@@ -1,24 +1,11 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
 import Link from "next/link";
 import { CatalogTable } from "./catalog-table";
 import { ItemDrawer } from "./item-drawer";
 import type { Tenant } from "@/lib/data";
-
-type DbVariant = { id: string; itemId: string; label: string; price: string; active: boolean };
-type DbItem = {
-  id: string;
-  tenantId: string;
-  name: string;
-  category: string;
-  description: string | null;
-  imageUrl: string | null;
-  active: boolean;
-  sortOrder: number;
-  variants: DbVariant[];
-};
+import type { CatalogItemWithVariants } from "@/db/queries";
 
 export function CatalogPageClient({
   tenantId,
@@ -27,10 +14,19 @@ export function CatalogPageClient({
 }: {
   tenantId: string;
   tenant: Tenant;
-  initialItems: DbItem[];
+  initialItems: CatalogItemWithVariants[];
 }) {
-  const router = useRouter();
+  const [items, setItems] = useState<CatalogItemWithVariants[]>(initialItems);
   const [addOpen, setAddOpen] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/catalog?tenantId=${tenantId}`);
+      if (res.ok) setItems(await res.json());
+    } catch (err) {
+      console.error("Refresh failed:", err);
+    }
+  }, [tenantId]);
 
   return (
     <>
@@ -51,13 +47,21 @@ export function CatalogPageClient({
           + Add item
         </button>
       </div>
-      <CatalogTable tenantId={tenantId} tenant={tenant} initialItems={initialItems} />
+      <CatalogTable
+        tenant={tenant}
+        items={items}
+        setItems={setItems}
+        refresh={refresh}
+      />
       <ItemDrawer
         tenant={tenant}
         open={addOpen}
         mode={{ kind: "create" }}
         onClose={() => setAddOpen(false)}
-        onSaved={() => router.refresh()}
+        onSaved={async () => {
+          await refresh();
+          setAddOpen(false);
+        }}
       />
     </>
   );

--- a/apps/web/src/app/admin/[tenant]/catalog/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/page.tsx
@@ -1,41 +1,34 @@
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import { TENANTS, type TenantId } from "@/lib/data";
-import { getCatalogByTenant } from "@/db/queries";
+import { getCatalogByTenant, getTenant } from "@/db/queries";
 import { AdminTopbar } from "@/components/admin-shell";
-import { CatalogTable } from "./catalog-table";
+import { CatalogPageClient } from "./page-client";
+import { PendingApprovalEmptyState } from "./pending-approval-empty-state";
 
-export default async function AdminCatalogPage({ params }: { params: Promise<{ tenant: string }> }) {
+export default async function AdminCatalogPage({
+  params,
+}: {
+  params: Promise<{ tenant: string }>;
+}) {
   const { tenant: tid } = await params;
   if (!(tid in TENANTS)) notFound();
-  const tenant = TENANTS[tid as TenantId];
+  const staticTenant = TENANTS[tid as TenantId];
 
-  // Fetch live catalog from Neon DB
-  const items = await getCatalogByTenant(tid);
+  const dbTenant = await getTenant(tid);
+  if (!dbTenant) notFound();
 
   return (
     <>
-      <AdminTopbar
-        kicker={`${tenant.short} · Operator`}
-        title="Catalog"
-        right={
-          <div className="flex items-center gap-2">
-            <Link
-              href={`/admin/${tid}/upload`}
-              className="h-9 px-3.5 text-[12.5px] font-semibold rounded-md border flex items-center gap-1.5"
-              style={{ borderColor: "var(--color-rule)", color: "var(--color-ink)" }}
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
-                <path d="M21 15 V19 a2 2 0 0 1 -2 2 H5 a2 2 0 0 1 -2 -2 V15" />
-                <polyline points="17 8 12 3 7 8" />
-                <line x1="12" y1="3" x2="12" y2="15" />
-              </svg>
-              Bulk upload CSV
-            </Link>
-          </div>
-        }
-      />
-      <CatalogTable tenantId={tid} initialItems={items} tenant={tenant} />
+      <AdminTopbar kicker={`${staticTenant.short} · Operator`} title="Catalog" />
+      {dbTenant.platformApprovalStatus !== "approved" ? (
+        <PendingApprovalEmptyState tenant={staticTenant} />
+      ) : (
+        <CatalogPageClient
+          tenantId={tid}
+          tenant={staticTenant}
+          initialItems={await getCatalogByTenant(tid)}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/src/app/admin/[tenant]/catalog/pending-approval-empty-state.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/pending-approval-empty-state.tsx
@@ -1,0 +1,35 @@
+import type { Tenant } from "@/lib/data";
+
+export function PendingApprovalEmptyState({ tenant }: { tenant: Tenant }) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center p-12 text-center">
+      <div
+        className="w-16 h-16 rounded-full flex items-center justify-center mb-5"
+        style={{ background: "var(--color-parchment)", color: tenant.accent }}
+      >
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+          <circle cx="12" cy="12" r="9" />
+          <polyline points="12 7 12 13 16 15" />
+        </svg>
+      </div>
+      <h2 className="font-serif text-[22px] font-medium leading-[1.2] mb-2">
+        Awaiting platform approval
+      </h2>
+      <p className="text-[13.5px] leading-[1.5] max-w-md" style={{ color: "var(--color-ink-dim)" }}>
+        {tenant.short} hasn’t been approved on the platform yet. Once approved,
+        operators can add and edit catalog items here.
+      </p>
+      <p className="text-[12.5px] mt-3" style={{ color: "var(--color-ink-dim)" }}>
+        Need help? Email{" "}
+        <a
+          href="mailto:support@uniformorder.online"
+          className="underline"
+          style={{ color: tenant.accent }}
+        >
+          support@uniformorder.online
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/api/catalog/[itemId]/route.ts
+++ b/apps/web/src/app/api/catalog/[itemId]/route.ts
@@ -7,6 +7,7 @@ import {
 import { ensureTenantAccess, requireSessionUser } from "@/lib/auth/authorization";
 import { requireTenantApproved } from "@/lib/auth/require-tenant-approved";
 import { catalogItemPatchSchema } from "@/lib/schemas/catalog";
+import { applyRateLimit } from "@/lib/rate-limit";
 
 // PATCH /api/catalog/:itemId — partial update; if `variants` provided, replace.
 export async function PATCH(
@@ -15,9 +16,22 @@ export async function PATCH(
 ) {
   const { itemId } = await params;
   try {
+    const preAuthRl = applyRateLimit(req, "catalog:patch:anon", {
+      limit: 60,
+      windowMs: 60_000,
+    });
+    if (preAuthRl) return preAuthRl;
+
     // Auth first — never leak zod schema details to unauthenticated callers.
     const authResult = await requireSessionUser();
     if ("response" in authResult) return authResult.response;
+
+    const userRl = applyRateLimit(
+      req,
+      `catalog:patch:${authResult.user.id}`,
+      { limit: 30, windowMs: 60_000 },
+    );
+    if (userRl) return userRl;
 
     const item = await getCatalogItemById(itemId);
     if (!item) {
@@ -75,13 +89,26 @@ export async function PATCH(
 // DELETE /api/catalog/:itemId — hard delete; cascade variants. No 409 path:
 // order_lines does not FK catalog_items.
 export async function DELETE(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ itemId: string }> }
 ) {
   const { itemId } = await params;
   try {
+    const preAuthRl = applyRateLimit(req, "catalog:delete:anon", {
+      limit: 60,
+      windowMs: 60_000,
+    });
+    if (preAuthRl) return preAuthRl;
+
     const authResult = await requireSessionUser();
     if ("response" in authResult) return authResult.response;
+
+    const userRl = applyRateLimit(
+      req,
+      `catalog:delete:${authResult.user.id}`,
+      { limit: 30, windowMs: 60_000 },
+    );
+    if (userRl) return userRl;
 
     const item = await getCatalogItemById(itemId);
     if (!item) {

--- a/apps/web/src/app/api/catalog/[itemId]/route.ts
+++ b/apps/web/src/app/api/catalog/[itemId]/route.ts
@@ -2,49 +2,56 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   deleteCatalogItem,
   getCatalogItemById,
-  getTenant,
-  updateCatalogItemName,
+  updateCatalogItem,
 } from "@/db/queries";
 import { ensureTenantAccess, requireSessionUser } from "@/lib/auth/authorization";
+import { requireTenantApproved } from "@/lib/auth/require-tenant-approved";
+import { catalogItemPatchSchema } from "@/lib/schemas/catalog";
 
-// PATCH /api/catalog/:itemId — update item name
+// PATCH /api/catalog/:itemId — partial update; if `variants` provided, replace.
 export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ itemId: string }> }
 ) {
   const { itemId } = await params;
   try {
+    const body = await req.json();
+    const parsed = catalogItemPatchSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validation_failed", details: parsed.error.flatten() },
+        { status: 400 }
+      );
+    }
+    const input = parsed.data;
+
     const authResult = await requireSessionUser();
     if ("response" in authResult) return authResult.response;
-
-    const { name } = await req.json();
-    if (typeof name !== "string" || !name.trim()) {
-      return NextResponse.json({ error: "name required" }, { status: 400 });
-    }
 
     const item = await getCatalogItemById(itemId);
     if (!item) {
       return NextResponse.json({ error: "Item not found" }, { status: 404 });
     }
-    const tenant = await getTenant(item.tenantId);
-    if (!tenant) {
-      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
-    }
-    const tenantAccessResponse = ensureTenantAccess(authResult.user, tenant.shopEmail);
-    if (tenantAccessResponse) return tenantAccessResponse;
 
-    const updated = await updateCatalogItemName(itemId, name.trim());
-    if (updated.length === 0) {
-      return NextResponse.json({ error: "Item not found" }, { status: 404 });
-    }
-    return NextResponse.json({ ok: true });
+    const approval = await requireTenantApproved(item.tenantId);
+    if ("response" in approval) return approval.response;
+    const { tenant } = approval;
+
+    const accessDenied = ensureTenantAccess(authResult.user, tenant.shopEmail);
+    if (accessDenied) return accessDenied;
+
+    const { variants, ...fields } = input;
+    await updateCatalogItem(itemId, fields, variants);
+
+    return NextResponse.json({ id: itemId, ok: true }, { status: 200 });
   } catch (err) {
-    console.error("PATCH /api/catalog/[itemId] error:", err);
+    console.error(`PATCH /api/catalog/${itemId} error:`, err);
     return NextResponse.json({ error: "Failed to update item" }, { status: 500 });
   }
 }
 
-// DELETE /api/catalog/:itemId
+// DELETE /api/catalog/:itemId — hard delete; cascade variants. No 409 path:
+// order_lines does not FK catalog_items.
 export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ itemId: string }> }
@@ -58,20 +65,29 @@ export async function DELETE(
     if (!item) {
       return NextResponse.json({ error: "Item not found" }, { status: 404 });
     }
-    const tenant = await getTenant(item.tenantId);
-    if (!tenant) {
-      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
-    }
-    const tenantAccessResponse = ensureTenantAccess(authResult.user, tenant.shopEmail);
-    if (tenantAccessResponse) return tenantAccessResponse;
 
-    const deleted = await deleteCatalogItem(itemId);
-    if (deleted.length === 0) {
-      return NextResponse.json({ error: "Item not found" }, { status: 404 });
+    const approval = await requireTenantApproved(item.tenantId);
+    if ("response" in approval) return approval.response;
+    const { tenant } = approval;
+
+    const accessDenied = ensureTenantAccess(authResult.user, tenant.shopEmail);
+    if (accessDenied) return accessDenied;
+
+    const [deleted] = await deleteCatalogItem(itemId);
+
+    // Best-effort UploadThing file delete — see Task 8 for the helper.
+    if (deleted?.imageUrl) {
+      try {
+        const { deleteUploadthingFileByUrl } = await import("@/lib/uploadthing-cleanup");
+        await deleteUploadthingFileByUrl(deleted.imageUrl);
+      } catch (cleanupErr) {
+        console.warn(`UploadThing cleanup failed for ${deleted.imageUrl}:`, cleanupErr);
+      }
     }
-    return NextResponse.json({ ok: true });
+
+    return NextResponse.json({ ok: true }, { status: 200 });
   } catch (err) {
-    console.error("DELETE /api/catalog/[itemId] error:", err);
+    console.error(`DELETE /api/catalog/${itemId} error:`, err);
     return NextResponse.json({ error: "Failed to delete item" }, { status: 500 });
   }
 }

--- a/apps/web/src/app/api/catalog/[itemId]/route.ts
+++ b/apps/web/src/app/api/catalog/[itemId]/route.ts
@@ -15,16 +15,7 @@ export async function PATCH(
 ) {
   const { itemId } = await params;
   try {
-    const body = await req.json();
-    const parsed = catalogItemPatchSchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: "validation_failed", details: parsed.error.flatten() },
-        { status: 400 }
-      );
-    }
-    const input = parsed.data;
-
+    // Auth first — never leak zod schema details to unauthenticated callers.
     const authResult = await requireSessionUser();
     if ("response" in authResult) return authResult.response;
 
@@ -40,8 +31,39 @@ export async function PATCH(
     const accessDenied = ensureTenantAccess(authResult.user, tenant.shopEmail);
     if (accessDenied) return accessDenied;
 
+    const body = await req.json();
+    const parsed = catalogItemPatchSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validation_failed", details: parsed.error.flatten() },
+        { status: 400 }
+      );
+    }
+    const input = parsed.data;
+
     const { variants, ...fields } = input;
     await updateCatalogItem(itemId, fields, variants);
+
+    // H2: clean up old image when imageUrl changed (replace or clear).
+    const oldImageUrl = item.imageUrl;
+    const newImageUrl = input.imageUrl;
+    if (
+      newImageUrl !== undefined &&
+      oldImageUrl &&
+      newImageUrl !== oldImageUrl
+    ) {
+      try {
+        const { deleteUploadthingFileByUrl } = await import(
+          "@/lib/uploadthing-cleanup"
+        );
+        await deleteUploadthingFileByUrl(oldImageUrl);
+      } catch (cleanupErr) {
+        console.warn(
+          `UploadThing cleanup failed for ${oldImageUrl}:`,
+          cleanupErr
+        );
+      }
+    }
 
     return NextResponse.json({ id: itemId, ok: true }, { status: 200 });
   } catch (err) {

--- a/apps/web/src/app/api/catalog/route.ts
+++ b/apps/web/src/app/api/catalog/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getCatalogByTenant, addCatalogItem, getTenant } from "@/db/queries";
+import { addCatalogItem, getCatalogByTenant } from "@/db/queries";
 import { ensureTenantAccess, requireSessionUser } from "@/lib/auth/authorization";
+import { requireTenantApproved } from "@/lib/auth/require-tenant-approved";
+import { catalogItemInputSchema } from "@/lib/schemas/catalog";
 
 // GET /api/catalog?tenantId=nsbh
 export async function GET(req: NextRequest) {
@@ -20,73 +22,53 @@ export async function GET(req: NextRequest) {
   }
 }
 
-// POST /api/catalog — add a new item
+// POST /api/catalog — create a new item
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { tenantId, name, category, description, variants } = body;
-
-    if (!tenantId || !name || !category) {
+    const parsed = catalogItemInputSchema.safeParse(body);
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: "tenantId, name, and category are required" },
+        { error: "validation_failed", details: parsed.error.flatten() },
         { status: 400 }
       );
     }
+    const input = parsed.data;
 
     const authResult = await requireSessionUser();
     if ("response" in authResult) return authResult.response;
 
-    const tenant = await getTenant(tenantId);
-    if (!tenant) {
-      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
-    }
-    const tenantAccessResponse = ensureTenantAccess(authResult.user, tenant.shopEmail);
-    if (tenantAccessResponse) return tenantAccessResponse;
+    const approval = await requireTenantApproved(input.tenantId);
+    if ("response" in approval) return approval.response;
+    const { tenant } = approval;
 
-    if (!Array.isArray(variants) || variants.length === 0) {
-      return NextResponse.json(
-        { error: "At least one variant is required" },
-        { status: 400 }
-      );
-    }
-    if (
-      variants.some(
-        (variant) =>
-          !variant ||
-          typeof variant.label !== "string" ||
-          !variant.label.trim() ||
-          !Number.isFinite(Number(variant.price)) ||
-          Number(variant.price) < 0
-      )
-    ) {
-      return NextResponse.json(
-        { error: "Each variant requires a label and valid price" },
-        { status: 400 }
-      );
-    }
+    const accessDenied = ensureTenantAccess(authResult.user, tenant.shopEmail);
+    if (accessDenied) return accessDenied;
 
-    // Generate a slug ID from the name
-    const id = name
+    const slug = input.name
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "")
       .slice(0, 40);
-
-    const uniqueId = `${id}-${Date.now().toString(36)}`;
+    const id = `${input.tenantId}-${slug}-${Date.now().toString(36)}`;
 
     await addCatalogItem({
-      id: uniqueId,
-      tenantId,
-      name,
-      category,
-      description,
-      variants: variants.map((variant) => ({
-        label: variant.label.trim(),
-        price: Number(variant.price),
+      id,
+      tenantId: input.tenantId,
+      name: input.name,
+      category: input.category,
+      description: input.description,
+      imageUrl: input.imageUrl,
+      active: input.active,
+      sortOrder: input.sortOrder,
+      variants: input.variants.map((v) => ({
+        label: v.label,
+        price: v.price,
+        active: v.active,
       })),
     });
 
-    return NextResponse.json({ id: uniqueId }, { status: 201 });
+    return NextResponse.json({ id }, { status: 201 });
   } catch (err) {
     console.error("POST /api/catalog error:", err);
     return NextResponse.json({ error: "Failed to add item" }, { status: 500 });

--- a/apps/web/src/app/api/catalog/route.ts
+++ b/apps/web/src/app/api/catalog/route.ts
@@ -25,6 +25,10 @@ export async function GET(req: NextRequest) {
 // POST /api/catalog — create a new item
 export async function POST(req: NextRequest) {
   try {
+    // Auth first — never leak zod schema details to unauthenticated callers.
+    const authResult = await requireSessionUser();
+    if ("response" in authResult) return authResult.response;
+
     const body = await req.json();
     const parsed = catalogItemInputSchema.safeParse(body);
     if (!parsed.success) {
@@ -34,9 +38,6 @@ export async function POST(req: NextRequest) {
       );
     }
     const input = parsed.data;
-
-    const authResult = await requireSessionUser();
-    if ("response" in authResult) return authResult.response;
 
     const approval = await requireTenantApproved(input.tenantId);
     if ("response" in approval) return approval.response;

--- a/apps/web/src/app/api/catalog/route.ts
+++ b/apps/web/src/app/api/catalog/route.ts
@@ -3,6 +3,7 @@ import { addCatalogItem, getCatalogByTenant } from "@/db/queries";
 import { ensureTenantAccess, requireSessionUser } from "@/lib/auth/authorization";
 import { requireTenantApproved } from "@/lib/auth/require-tenant-approved";
 import { catalogItemInputSchema } from "@/lib/schemas/catalog";
+import { applyRateLimit } from "@/lib/rate-limit";
 
 // GET /api/catalog?tenantId=nsbh
 export async function GET(req: NextRequest) {
@@ -25,9 +26,24 @@ export async function GET(req: NextRequest) {
 // POST /api/catalog — create a new item
 export async function POST(req: NextRequest) {
   try {
+    // Pre-auth IP rate limit — generous, just probe-defence.
+    const preAuthRl = applyRateLimit(req, "catalog:post:anon", {
+      limit: 60,
+      windowMs: 60_000,
+    });
+    if (preAuthRl) return preAuthRl;
+
     // Auth first — never leak zod schema details to unauthenticated callers.
     const authResult = await requireSessionUser();
     if ("response" in authResult) return authResult.response;
+
+    // Post-auth per-user budget — admin bulk work fits comfortably.
+    const userRl = applyRateLimit(
+      req,
+      `catalog:post:${authResult.user.id}`,
+      { limit: 30, windowMs: 60_000 },
+    );
+    if (userRl) return userRl;
 
     const body = await req.json();
     const parsed = catalogItemInputSchema.safeParse(body);
@@ -46,12 +62,17 @@ export async function POST(req: NextRequest) {
     const accessDenied = ensureTenantAccess(authResult.user, tenant.shopEmail);
     if (accessDenied) return accessDenied;
 
-    const slug = input.name
+    const rawSlug = input.name
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "")
       .slice(0, 40);
-    const id = `${input.tenantId}-${slug}-${Date.now().toString(36)}`;
+    // Names with no a-z0-9 characters (e.g. CJK / Cyrillic) strip to "".
+    // Fall back to a stable token so the id stays parseable.
+    const slug = rawSlug.length > 0 ? rawSlug : "item";
+    // crypto.randomUUID avoids the same-millisecond collision risk that
+    // Date.now().toString(36) had under concurrent writes.
+    const id = `${input.tenantId}-${slug}-${crypto.randomUUID().slice(0, 8)}`;
 
     await addCatalogItem({
       id,

--- a/apps/web/src/app/api/uploadthing/route.ts
+++ b/apps/web/src/app/api/uploadthing/route.ts
@@ -1,0 +1,6 @@
+import { createRouteHandler } from "uploadthing/next";
+import { uploadRouter } from "@/lib/uploadthing";
+
+export const { GET, POST } = createRouteHandler({
+  router: uploadRouter,
+});

--- a/apps/web/src/components/garment-defaults.tsx
+++ b/apps/web/src/components/garment-defaults.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+
+type Props = { accent: string; stroke: string; size: number };
+
+const wrap = (props: Props, body: React.ReactNode) => (
+  <svg width={props.size} height={props.size} viewBox="0 0 120 120" aria-hidden="true">
+    <rect x="0" y="0" width="120" height="120" fill="#F1ECE0" />
+    {body}
+  </svg>
+);
+
+export function SummerDefault(p: Props) {
+  return wrap(p,
+    <g>
+      <path d="M30 26 L48 18 L60 24 L72 18 L90 26 L96 40 L86 46 L86 96 L34 96 L34 46 L24 40 Z" fill={p.accent} stroke={p.stroke} strokeWidth="1.4" />
+    </g>
+  );
+}
+
+export function WinterDefault(p: Props) {
+  return wrap(p,
+    <g>
+      <path d="M28 24 L48 16 Q60 30 72 16 L92 24 L100 44 L86 50 L86 102 L34 102 L34 50 L20 44 Z" fill={p.accent} stroke={p.stroke} strokeWidth="1.4" />
+    </g>
+  );
+}
+
+export function SportsDefault(p: Props) {
+  return wrap(p,
+    <g>
+      <circle cx="60" cy="60" r="34" fill={p.accent} stroke={p.stroke} strokeWidth="1.6" />
+      <path d="M26 60 H94 M60 26 V94 M40 36 Q60 60 80 36 M40 84 Q60 60 80 84" fill="none" stroke={p.stroke} strokeWidth="1.4" />
+    </g>
+  );
+}
+
+export function FormalDefault(p: Props) {
+  return wrap(p,
+    <g>
+      <path d="M24 22 L48 16 L60 28 L72 16 L96 22 L92 102 L68 102 L60 90 L52 102 L28 102 Z" fill={p.accent} stroke={p.stroke} strokeWidth="1.4" />
+      <path d="M48 16 L60 60 L72 16" stroke={p.stroke} strokeWidth="1" fill="none" />
+    </g>
+  );
+}
+
+export function BagsDefault(p: Props) {
+  return wrap(p,
+    <g>
+      <path d="M30 36 H90 V100 H30 Z" fill={p.accent} stroke={p.stroke} strokeWidth="1.4" />
+      <path d="M44 36 V24 Q60 14 76 24 V36" fill="none" stroke={p.stroke} strokeWidth="1.4" />
+    </g>
+  );
+}
+
+export function StationeryDefault(p: Props) {
+  return wrap(p,
+    <g>
+      <rect x="34" y="22" width="52" height="76" fill={p.accent} stroke={p.stroke} strokeWidth="1.4" />
+      <path d="M44 38 H76 M44 50 H76 M44 62 H76 M44 74 H66" stroke={p.stroke} strokeWidth="1.2" fill="none" />
+    </g>
+  );
+}

--- a/apps/web/src/components/garment.tsx
+++ b/apps/web/src/components/garment.tsx
@@ -1,7 +1,17 @@
 // Flat-vector silhouettes of uniform pieces, keyed by item id. Avoids stock
 // photography while keeping each item recognisable.
 
+import * as React from "react";
 import { shade } from "@/lib/ui";
+import {
+  SummerDefault,
+  WinterDefault,
+  SportsDefault,
+  FormalDefault,
+  BagsDefault,
+  StationeryDefault,
+} from "./garment-defaults";
+import type { ItemCategory } from "@/lib/data";
 
 const ITEM_TO_SHAPE: Record<string, string> = {
   "shirt-ss": "shirt", "shirt-ls": "shirt", polo: "shirt",
@@ -14,25 +24,50 @@ const ITEM_TO_SHAPE: Record<string, string> = {
   calc: "misc", mathset: "misc",
 };
 
+const CATEGORY_DEFAULT: Record<ItemCategory, React.FC<{ accent: string; stroke: string; size: number }>> = {
+  Summer: SummerDefault,
+  Winter: WinterDefault,
+  Sports: SportsDefault,
+  Formal: FormalDefault,
+  Bags: BagsDefault,
+  Stationery: StationeryDefault,
+};
+
 export function GarmentVector({
   itemId,
+  category,
   accent = "#1B3A5F",
   size = 120,
   className,
 }: {
-  itemId: string;
+  itemId?: string;
+  category?: ItemCategory;
   accent?: string;
   size?: number;
   className?: string;
 }) {
   const a = accent;
   const stroke = shade(a, -18);
-  const shape = ITEM_TO_SHAPE[itemId] ?? "misc";
+  const shape = itemId ? ITEM_TO_SHAPE[itemId] : undefined;
+
+  // Specific id-keyed illustration takes priority for the seeded items.
+  // Otherwise, if a category is supplied, render its default glyph.
+  if (!shape && category) {
+    const Default = CATEGORY_DEFAULT[category];
+    return (
+      <span className={className} aria-hidden>
+        <Default accent={a} stroke={stroke} size={size} />
+      </span>
+    );
+  }
+
+  // Fallback to legacy "misc" silhouette when neither id nor category matches.
+  const resolvedShape = shape ?? "misc";
 
   return (
     <svg width={size} height={size} viewBox="0 0 120 120" aria-hidden="true" className={className}>
       <rect x="0" y="0" width="120" height="120" fill="#F1ECE0" />
-      {shape === "shirt" && (
+      {resolvedShape === "shirt" && (
         <g>
           <path d="M30 22 L48 14 L60 20 L72 14 L90 22 L98 38 L86 44 L86 100 L34 100 L34 44 L22 38 Z" fill={a} stroke={stroke} strokeWidth="1.4" />
           <path d="M48 14 Q60 24 72 14" fill="none" stroke={stroke} strokeWidth="1.4" />
@@ -41,58 +76,58 @@ export function GarmentVector({
           <circle cx="60" cy="52" r="1.2" fill={stroke} />
         </g>
       )}
-      {shape === "jumper" && (
+      {resolvedShape === "jumper" && (
         <g>
           <path d="M28 24 L48 16 Q60 30 72 16 L92 24 L100 44 L86 50 L86 102 L34 102 L34 50 L20 44 Z" fill={a} stroke={stroke} strokeWidth="1.4" />
           <path d="M52 22 Q60 30 68 22" stroke={stroke} strokeWidth="1.2" fill="none" />
         </g>
       )}
-      {shape === "pants" && (
+      {resolvedShape === "pants" && (
         <g>
           <path d="M36 14 H84 L86 56 L78 104 L66 104 L62 60 L58 60 L54 104 L42 104 L34 56 Z" fill={a} stroke={stroke} strokeWidth="1.4" />
           <path d="M60 18 V58" stroke={stroke} strokeWidth="0.8" />
         </g>
       )}
-      {shape === "cap" && (
+      {resolvedShape === "cap" && (
         <g>
           <path d="M22 70 Q60 30 98 70 L98 78 L22 78 Z" fill={a} stroke={stroke} strokeWidth="1.4" />
           <path d="M22 78 Q60 92 98 78" stroke={stroke} strokeWidth="1.4" fill="none" />
           <circle cx="60" cy="46" r="3" fill={stroke} />
         </g>
       )}
-      {shape === "sock" && (
+      {resolvedShape === "sock" && (
         <g>
           <path d="M44 16 H76 V60 L66 100 H50 L40 60 Z" fill={a} stroke={stroke} strokeWidth="1.4" />
           <path d="M44 20 H76" stroke={stroke} strokeWidth="0.8" />
         </g>
       )}
-      {shape === "bag" && (
+      {resolvedShape === "bag" && (
         <g>
           <path d="M30 36 H90 V100 H30 Z" fill={a} stroke={stroke} strokeWidth="1.4" />
           <path d="M44 36 V24 Q60 14 76 24 V36" fill="none" stroke={stroke} strokeWidth="1.4" />
           <rect x="44" y="56" width="32" height="20" fill="none" stroke={stroke} strokeWidth="1" />
         </g>
       )}
-      {shape === "blazer" && (
+      {resolvedShape === "blazer" && (
         <g>
           <path d="M24 22 L48 16 L60 28 L72 16 L96 22 L92 102 L68 102 L60 90 L52 102 L28 102 Z" fill={a} stroke={stroke} strokeWidth="1.4" />
           <path d="M48 16 L60 60 L72 16" stroke={stroke} strokeWidth="1" fill="none" />
         </g>
       )}
-      {shape === "tie" && (
+      {resolvedShape === "tie" && (
         <g>
           <path d="M50 14 H70 L66 36 L78 90 L60 104 L42 90 L54 36 Z" fill={a} stroke={stroke} strokeWidth="1.4" />
           <path d="M54 36 H66" stroke={stroke} strokeWidth="0.8" />
         </g>
       )}
-      {shape === "belt" && (
+      {resolvedShape === "belt" && (
         <g>
           <path d="M14 54 H106 V70 H14 Z" fill={a} stroke={stroke} strokeWidth="1.4" />
           <rect x="48" y="50" width="24" height="24" fill={stroke} stroke={stroke} strokeWidth="1.4" />
           <rect x="54" y="58" width="12" height="8" fill={a} />
         </g>
       )}
-      {shape === "misc" && (
+      {resolvedShape === "misc" && (
         <g>
           <rect x="32" y="22" width="56" height="80" rx="4" fill={a} stroke={stroke} strokeWidth="1.4" />
           <path d="M40 42 H80 M40 56 H80 M40 70 H68" stroke={stroke} strokeWidth="1" />

--- a/apps/web/src/components/uploadthing.ts
+++ b/apps/web/src/components/uploadthing.ts
@@ -1,0 +1,8 @@
+import {
+  generateUploadButton,
+  generateUploadDropzone,
+} from "@uploadthing/react";
+import type { UploadRouter } from "@/lib/uploadthing";
+
+export const UploadButton = generateUploadButton<UploadRouter>();
+export const UploadDropzone = generateUploadDropzone<UploadRouter>();

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -557,8 +557,8 @@ export async function addCatalogItem(data: {
   tenantId: string;
   name: string;
   category: string;
-  description?: string;
-  imageUrl?: string;
+  description?: string | null;
+  imageUrl?: string | null;
   active?: boolean;
   sortOrder?: number;
   variants: { label: string; price: number; active?: boolean }[];

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -1,5 +1,6 @@
 import { db, orders, orderLines, catalogItems, catalogVariants, tenants, orderRefunds, parentChildren } from "./index";
 import { and, eq, desc, or, gte, inArray, lt, sql, sum, isNotNull } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
 
 export type LiveOrderStatus = "pending_payment" | "new" | "packing" | "ready" | "collected" | "partially_refunded" | "refunded";
 
@@ -569,27 +570,31 @@ export async function addCatalogItem(data: {
   sortOrder?: number;
   variants: { label: string; price: number; active?: boolean }[];
 }) {
-  await db.transaction(async (tx) => {
-    await tx.insert(catalogItems).values({
-      id: data.id,
-      tenantId: data.tenantId,
-      name: data.name,
-      category: data.category,
-      description: data.description ?? null,
-      imageUrl: data.imageUrl ?? null,
-      active: data.active ?? true,
-      sortOrder: data.sortOrder ?? 0,
-    });
-
-    for (const v of data.variants) {
-      await tx.insert(catalogVariants).values({
-        itemId: data.id,
-        label: v.label,
-        price: String(v.price),
-        active: v.active ?? true,
-      });
-    }
+  // neon-http driver doesn't support interactive db.transaction; use db.batch
+  // which runs all statements atomically in a single HTTP round-trip.
+  const itemInsert = db.insert(catalogItems).values({
+    id: data.id,
+    tenantId: data.tenantId,
+    name: data.name,
+    category: data.category,
+    description: data.description ?? null,
+    imageUrl: data.imageUrl ?? null,
+    active: data.active ?? true,
+    sortOrder: data.sortOrder ?? 0,
   });
+  const variantInserts = data.variants.map((v) =>
+    db.insert(catalogVariants).values({
+      itemId: data.id,
+      label: v.label,
+      price: String(v.price),
+      active: v.active ?? true,
+    })
+  );
+  const stmts: [BatchItem<"pg">, ...BatchItem<"pg">[]] = [
+    itemInsert,
+    ...variantInserts,
+  ];
+  await db.batch(stmts);
 }
 
 /**
@@ -620,54 +625,76 @@ export async function updateCatalogItem(
     active?: boolean;
   }[]
 ) {
-  await db.transaction(async (tx) => {
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (fields.name !== undefined) updates.name = fields.name;
-    if (fields.category !== undefined) updates.category = fields.category;
-    if (fields.description !== undefined) updates.description = fields.description;
-    if (fields.imageUrl !== undefined) updates.imageUrl = fields.imageUrl;
-    if (fields.active !== undefined) updates.active = fields.active;
-    if (fields.sortOrder !== undefined) updates.sortOrder = fields.sortOrder;
+  // neon-http driver doesn't support interactive db.transaction. We read
+  // existing variant ids first (one round-trip), then run all writes via
+  // db.batch (atomic HTTP-level transaction). Concurrent edits between the
+  // read and write are not protected — acceptable for the 1-2 ops/tenant
+  // catalog editor.
+  const updates: Record<string, unknown> = { updatedAt: new Date() };
+  if (fields.name !== undefined) updates.name = fields.name;
+  if (fields.category !== undefined) updates.category = fields.category;
+  if (fields.description !== undefined) updates.description = fields.description;
+  if (fields.imageUrl !== undefined) updates.imageUrl = fields.imageUrl;
+  if (fields.active !== undefined) updates.active = fields.active;
+  if (fields.sortOrder !== undefined) updates.sortOrder = fields.sortOrder;
 
-    await tx.update(catalogItems).set(updates).where(eq(catalogItems.id, itemId));
+  const itemUpdate = db
+    .update(catalogItems)
+    .set(updates)
+    .where(eq(catalogItems.id, itemId));
 
-    if (variants !== undefined) {
-      const existing = await tx
-        .select({ id: catalogVariants.id })
-        .from(catalogVariants)
-        .where(eq(catalogVariants.itemId, itemId));
-      const existingIds = new Set(existing.map((v) => v.id));
-      const keptIds = new Set<string>();
+  if (variants === undefined) {
+    const stmts: [BatchItem<"pg">] = [itemUpdate];
+    await db.batch(stmts);
+    return;
+  }
 
-      for (const v of variants) {
-        if (v.id && existingIds.has(v.id)) {
-          await tx
-            .update(catalogVariants)
-            .set({
-              label: v.label,
-              price: String(v.price),
-              active: v.active ?? true,
-            })
-            .where(eq(catalogVariants.id, v.id));
-          keptIds.add(v.id);
-        } else {
-          await tx.insert(catalogVariants).values({
-            itemId,
+  const existing = await db
+    .select({ id: catalogVariants.id })
+    .from(catalogVariants)
+    .where(eq(catalogVariants.itemId, itemId));
+  const existingIds = new Set(existing.map((v) => v.id));
+  const keptIds = new Set<string>();
+
+  const variantWrites: BatchItem<"pg">[] = [];
+
+  for (const v of variants) {
+    if (v.id && existingIds.has(v.id)) {
+      variantWrites.push(
+        db
+          .update(catalogVariants)
+          .set({
             label: v.label,
             price: String(v.price),
             active: v.active ?? true,
-          });
-        }
-      }
-
-      const toDelete = [...existingIds].filter((id) => !keptIds.has(id));
-      if (toDelete.length > 0) {
-        await tx
-          .delete(catalogVariants)
-          .where(inArray(catalogVariants.id, toDelete));
-      }
+          })
+          .where(eq(catalogVariants.id, v.id))
+      );
+      keptIds.add(v.id);
+    } else {
+      variantWrites.push(
+        db.insert(catalogVariants).values({
+          itemId,
+          label: v.label,
+          price: String(v.price),
+          active: v.active ?? true,
+        })
+      );
     }
-  });
+  }
+
+  const toDelete = [...existingIds].filter((id) => !keptIds.has(id));
+  if (toDelete.length > 0) {
+    variantWrites.push(
+      db.delete(catalogVariants).where(inArray(catalogVariants.id, toDelete))
+    );
+  }
+
+  const stmts: [BatchItem<"pg">, ...BatchItem<"pg">[]] = [
+    itemUpdate,
+    ...variantWrites,
+  ];
+  await db.batch(stmts);
 }
 
 export async function deleteCatalogItem(itemId: string) {

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -512,6 +512,12 @@ export async function addOrderRefund(data: {
 
 // ─── Catalog ─────────────────────────────────────────────────────────────────
 
+export type CatalogItemRow = typeof catalogItems.$inferSelect;
+export type CatalogVariantRow = typeof catalogVariants.$inferSelect;
+export type CatalogItemWithVariants = CatalogItemRow & {
+  variants: CatalogVariantRow[];
+};
+
 export async function getCatalogByTenant(tenantId: string) {
   const items = await db
     .select()
@@ -587,10 +593,15 @@ export async function addCatalogItem(data: {
 }
 
 /**
- * Partial item update with optional full-replace of variants.
- * If `variants` is provided, ALL existing variants are hard-deleted and the
- * supplied list is inserted. Order history is unaffected (order_lines holds
- * its own snapshots — no FK to catalog_variants).
+ * Partial item update with optional diff-based variant sync.
+ * If `variants` is provided, the variant list is reconciled by id:
+ *   - input variant with `id` matching an existing row → update that row
+ *   - input variant without `id` (or with unknown id) → insert new row
+ *   - existing rows whose id is not in the input → delete
+ * IDs are preserved across edits so cart entries keyed by variantId remain
+ * valid after a save that didn't actually change that variant. Order history
+ * is unaffected — order_lines holds its own snapshots and does not FK
+ * catalog_variants.
  */
 export async function updateCatalogItem(
   itemId: string,
@@ -602,7 +613,12 @@ export async function updateCatalogItem(
     active?: boolean;
     sortOrder?: number;
   },
-  variants?: { label: string; price: number; active?: boolean }[]
+  variants?: {
+    id?: string;
+    label: string;
+    price: number;
+    active?: boolean;
+  }[]
 ) {
   await db.transaction(async (tx) => {
     const updates: Record<string, unknown> = { updatedAt: new Date() };
@@ -616,14 +632,39 @@ export async function updateCatalogItem(
     await tx.update(catalogItems).set(updates).where(eq(catalogItems.id, itemId));
 
     if (variants !== undefined) {
-      await tx.delete(catalogVariants).where(eq(catalogVariants.itemId, itemId));
+      const existing = await tx
+        .select({ id: catalogVariants.id })
+        .from(catalogVariants)
+        .where(eq(catalogVariants.itemId, itemId));
+      const existingIds = new Set(existing.map((v) => v.id));
+      const keptIds = new Set<string>();
+
       for (const v of variants) {
-        await tx.insert(catalogVariants).values({
-          itemId,
-          label: v.label,
-          price: String(v.price),
-          active: v.active ?? true,
-        });
+        if (v.id && existingIds.has(v.id)) {
+          await tx
+            .update(catalogVariants)
+            .set({
+              label: v.label,
+              price: String(v.price),
+              active: v.active ?? true,
+            })
+            .where(eq(catalogVariants.id, v.id));
+          keptIds.add(v.id);
+        } else {
+          await tx.insert(catalogVariants).values({
+            itemId,
+            label: v.label,
+            price: String(v.price),
+            active: v.active ?? true,
+          });
+        }
+      }
+
+      const toDelete = [...existingIds].filter((id) => !keptIds.has(id));
+      if (toDelete.length > 0) {
+        await tx
+          .delete(catalogVariants)
+          .where(inArray(catalogVariants.id, toDelete));
       }
     }
   });

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -558,38 +558,82 @@ export async function addCatalogItem(data: {
   name: string;
   category: string;
   description?: string;
-  variants: { label: string; price: number }[];
+  imageUrl?: string;
+  active?: boolean;
+  sortOrder?: number;
+  variants: { label: string; price: number; active?: boolean }[];
 }) {
-  await db.insert(catalogItems).values({
-    id: data.id,
-    tenantId: data.tenantId,
-    name: data.name,
-    category: data.category,
-    description: data.description,
-  });
-
-  for (const v of data.variants) {
-    await db.insert(catalogVariants).values({
-      itemId: data.id,
-      label: v.label,
-      price: String(v.price),
+  await db.transaction(async (tx) => {
+    await tx.insert(catalogItems).values({
+      id: data.id,
+      tenantId: data.tenantId,
+      name: data.name,
+      category: data.category,
+      description: data.description ?? null,
+      imageUrl: data.imageUrl ?? null,
+      active: data.active ?? true,
+      sortOrder: data.sortOrder ?? 0,
     });
-  }
+
+    for (const v of data.variants) {
+      await tx.insert(catalogVariants).values({
+        itemId: data.id,
+        label: v.label,
+        price: String(v.price),
+        active: v.active ?? true,
+      });
+    }
+  });
 }
 
-export async function updateCatalogItemName(itemId: string, name: string) {
-  return db
-    .update(catalogItems)
-    .set({ name, updatedAt: new Date() })
-    .where(eq(catalogItems.id, itemId))
-    .returning({ id: catalogItems.id });
+/**
+ * Partial item update with optional full-replace of variants.
+ * If `variants` is provided, ALL existing variants are hard-deleted and the
+ * supplied list is inserted. Order history is unaffected (order_lines holds
+ * its own snapshots — no FK to catalog_variants).
+ */
+export async function updateCatalogItem(
+  itemId: string,
+  fields: {
+    name?: string;
+    category?: string;
+    description?: string | null;
+    imageUrl?: string | null;
+    active?: boolean;
+    sortOrder?: number;
+  },
+  variants?: { label: string; price: number; active?: boolean }[]
+) {
+  await db.transaction(async (tx) => {
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (fields.name !== undefined) updates.name = fields.name;
+    if (fields.category !== undefined) updates.category = fields.category;
+    if (fields.description !== undefined) updates.description = fields.description;
+    if (fields.imageUrl !== undefined) updates.imageUrl = fields.imageUrl;
+    if (fields.active !== undefined) updates.active = fields.active;
+    if (fields.sortOrder !== undefined) updates.sortOrder = fields.sortOrder;
+
+    await tx.update(catalogItems).set(updates).where(eq(catalogItems.id, itemId));
+
+    if (variants !== undefined) {
+      await tx.delete(catalogVariants).where(eq(catalogVariants.itemId, itemId));
+      for (const v of variants) {
+        await tx.insert(catalogVariants).values({
+          itemId,
+          label: v.label,
+          price: String(v.price),
+          active: v.active ?? true,
+        });
+      }
+    }
+  });
 }
 
 export async function deleteCatalogItem(itemId: string) {
   return db
     .delete(catalogItems)
     .where(eq(catalogItems.id, itemId))
-    .returning({ id: catalogItems.id });
+    .returning({ id: catalogItems.id, imageUrl: catalogItems.imageUrl });
 }
 
 // ─── Tenants ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -65,6 +65,7 @@ export const catalogItems = pgTable("catalog_items", {
   name: text("name").notNull(),
   category: text("category").notNull(), // "Winter" | "Summer" | "Sports" | "Formal" | "Bags" | "Stationery"
   description: text("description"),
+  imageUrl: text("image_url"),
   sizeGuide: jsonb("size_guide"), // array of {label, chest, waist, hip}
   active: boolean("active").notNull().default(true),
   sortOrder: integer("sort_order").notNull().default(0),

--- a/apps/web/src/lib/auth/require-tenant-approved.ts
+++ b/apps/web/src/lib/auth/require-tenant-approved.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getTenant } from "@/db/queries";
+
+export type LoadedTenant = NonNullable<Awaited<ReturnType<typeof getTenant>>>;
+
+/** For API routes — returns a 404/403 NextResponse on failure. */
+export async function requireTenantApproved(
+  tenantId: string
+): Promise<{ tenant: LoadedTenant } | { response: NextResponse }> {
+  const tenant = await getTenant(tenantId);
+  if (!tenant) {
+    return {
+      response: NextResponse.json({ code: "tenant_not_found" }, { status: 404 }),
+    };
+  }
+  if (tenant.platformApprovalStatus !== "approved") {
+    return {
+      response: NextResponse.json({ code: "tenant_not_approved" }, { status: 403 }),
+    };
+  }
+  return { tenant };
+}

--- a/apps/web/src/lib/data.ts
+++ b/apps/web/src/lib/data.ts
@@ -59,7 +59,8 @@ export interface CatalogItem {
   id: string;
   cat: ItemCategory;
   name: string;
-  desc?: string;
+  description?: string;
+  imageUrl?: string;
   variants: ItemVariant[];
   sizeGuide?: SizeGuide;
 }
@@ -71,7 +72,7 @@ export const CATALOG: CatalogItem[] = [
     id: "shirt-ss",
     cat: "Summer",
     name: "White Shirt — Short Sleeves",
-    desc: "Embroidered school crest. Poly-cotton blend, machine wash cold.",
+    description: "Embroidered school crest. Poly-cotton blend, machine wash cold.",
     variants: [
       { label: "Boys 10–26", price: 32, sizes: SIZES_GENERIC },
       { label: "Mens 4–8", price: 43, sizes: ["4", "5", "6", "7", "8"] },
@@ -90,14 +91,14 @@ export const CATALOG: CatalogItem[] = [
     id: "cap",
     cat: "Summer",
     name: "School Cap, Navy",
-    desc: "Embroidered NSBH crest. One size, adjustable strap.",
+    description: "Embroidered NSBH crest. One size, adjustable strap.",
     variants: [{ label: "One size", price: 17, sizes: ["OS"] }],
   },
   {
     id: "sock-white",
     cat: "Summer",
     name: "White Sport Socks (cotton blend, midi)",
-    desc: "Pack of one pair.",
+    description: "Pack of one pair.",
     variants: [
       { label: "3–9", price: 5, sizes: ["3-9"] },
       { label: "7–11", price: 5, sizes: ["7-11"] },
@@ -107,7 +108,7 @@ export const CATALOG: CatalogItem[] = [
     id: "shirt-ls",
     cat: "Winter",
     name: "White Shirt — Long Sleeves",
-    desc: "Embroidered school crest. Poly-cotton blend.",
+    description: "Embroidered school crest. Poly-cotton blend.",
     variants: [
       { label: "Boys 10–24", price: 28, sizes: ["10", "12", "14", "16", "18", "20", "22", "24"] },
       { label: "Mens 5–8", price: 59, sizes: ["5", "6", "7", "8"] },
@@ -125,7 +126,7 @@ export const CATALOG: CatalogItem[] = [
     id: "jumper",
     cat: "Winter",
     name: "Jumper — Wool Blend, Crested",
-    desc: "V-neck pullover with embroidered school crest.",
+    description: "V-neck pullover with embroidered school crest.",
     variants: [
       { label: "12–16", price: 75, sizes: ["12", "14", "16"] },
       { label: "18–22", price: 77, sizes: ["18", "20", "22"] },
@@ -136,7 +137,7 @@ export const CATALOG: CatalogItem[] = [
     id: "trousers",
     cat: "Winter",
     name: "Trousers — Mid Grey, Pleated Front",
-    desc: "Poly/viscose blend with adjustable waist.",
+    description: "Poly/viscose blend with adjustable waist.",
     variants: [
       { label: "Year 7–10 short (127cm)", price: 17, sizes: ["7-10S"] },
       { label: "Year 7–10 long (137cm)", price: 18, sizes: ["7-10L"] },
@@ -166,7 +167,7 @@ export const CATALOG: CatalogItem[] = [
     id: "polo",
     cat: "Sports",
     name: "Sports Polo Shirt",
-    desc: "Breathable mesh weave with embroidered crest.",
+    description: "Breathable mesh weave with embroidered crest.",
     variants: [{ label: "10–26", price: 40, sizes: SIZES_GENERIC }],
   },
   {
@@ -200,7 +201,7 @@ export const CATALOG: CatalogItem[] = [
     id: "blazer",
     cat: "Formal",
     name: "Blazer — Crested",
-    desc: "Wool-blend, fully lined, embroidered pocket crest.",
+    description: "Wool-blend, fully lined, embroidered pocket crest.",
     variants: [
       { label: "88–95cm chest", price: 185, sizes: ["88", "92", "95"] },
       { label: "100–115cm chest", price: 210, sizes: ["100", "105", "110", "115"] },

--- a/apps/web/src/lib/schemas/catalog.ts
+++ b/apps/web/src/lib/schemas/catalog.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export const ITEM_CATEGORIES = [
+  "Summer",
+  "Winter",
+  "Sports",
+  "Formal",
+  "Bags",
+  "Stationery",
+] as const;
+
+export const catalogVariantInputSchema = z.object({
+  label: z.string().trim().min(1).max(40),
+  price: z.number().positive().max(10000),
+  active: z.boolean().optional(),
+});
+
+export const catalogItemInputSchema = z.object({
+  tenantId: z.string().min(1),
+  name: z.string().trim().min(1).max(80),
+  category: z.enum(ITEM_CATEGORIES),
+  description: z.string().trim().max(500).optional(),
+  imageUrl: z.string().url().optional(),
+  active: z.boolean().default(true),
+  sortOrder: z.number().int().min(0).default(0),
+  variants: z.array(catalogVariantInputSchema).min(1),
+});
+
+export const catalogItemPatchSchema = catalogItemInputSchema
+  .omit({ tenantId: true })
+  .partial()
+  .extend({
+    variants: z.array(catalogVariantInputSchema).min(1).optional(),
+  });
+
+export type CatalogItemInput = z.infer<typeof catalogItemInputSchema>;
+export type CatalogItemPatch = z.infer<typeof catalogItemPatchSchema>;
+export type CatalogVariantInput = z.infer<typeof catalogVariantInputSchema>;

--- a/apps/web/src/lib/schemas/catalog.ts
+++ b/apps/web/src/lib/schemas/catalog.ts
@@ -23,6 +23,9 @@ export const catalogImageUrlSchema = z
   });
 
 export const catalogVariantInputSchema = z.object({
+  // Server-assigned id from a prior fetch — present means "update this row";
+  // absent means "insert new". Omitted variants on PATCH are deleted.
+  id: z.string().uuid().optional(),
   label: z.string().trim().min(1).max(40),
   price: z.number().positive().max(10000),
   active: z.boolean().optional(),

--- a/apps/web/src/lib/schemas/catalog.ts
+++ b/apps/web/src/lib/schemas/catalog.ts
@@ -9,6 +9,19 @@ export const ITEM_CATEGORIES = [
   "Stationery",
 ] as const;
 
+// Restrict catalog images to UploadThing-hosted URLs only.
+// Stored URLs that bypass our CSP allowlist would be unrenderable via
+// next/image and undeletable by uploadthing-cleanup (which extracts the
+// file key from the path). Enforce at the schema boundary.
+const UPLOADTHING_HOST_RE = /^https:\/\/([^/]*\.)?(utfs\.io|ufs\.sh)\/f\/[^/?#]+/;
+
+export const catalogImageUrlSchema = z
+  .string()
+  .url()
+  .refine((u) => UPLOADTHING_HOST_RE.test(u), {
+    message: "imageUrl must be an UploadThing-hosted URL",
+  });
+
 export const catalogVariantInputSchema = z.object({
   label: z.string().trim().min(1).max(40),
   price: z.number().positive().max(10000),
@@ -19,8 +32,8 @@ export const catalogItemInputSchema = z.object({
   tenantId: z.string().min(1),
   name: z.string().trim().min(1).max(80),
   category: z.enum(ITEM_CATEGORIES),
-  description: z.string().trim().max(500).optional(),
-  imageUrl: z.string().url().optional(),
+  description: z.string().trim().max(500).nullable().optional(),
+  imageUrl: catalogImageUrlSchema.nullable().optional(),
   active: z.boolean().default(true),
   sortOrder: z.number().int().min(0).default(0),
   variants: z.array(catalogVariantInputSchema).min(1),

--- a/apps/web/src/lib/uploadthing-cleanup.ts
+++ b/apps/web/src/lib/uploadthing-cleanup.ts
@@ -1,0 +1,19 @@
+import { UTApi } from "uploadthing/server";
+
+let cachedUtapi: UTApi | null = null;
+function getUtapi() {
+  if (!cachedUtapi) cachedUtapi = new UTApi();
+  return cachedUtapi;
+}
+
+/**
+ * Best-effort delete of an UploadThing file by its public URL.
+ * Throws on failure; callers should catch + log + continue.
+ */
+export async function deleteUploadthingFileByUrl(url: string): Promise<void> {
+  // UploadThing public URLs look like https://utfs.io/f/<fileKey>
+  const match = /https?:\/\/[^/]+\/f\/([^/?#]+)/.exec(url);
+  if (!match) throw new Error(`Unrecognized UploadThing URL: ${url}`);
+  const fileKey = match[1];
+  await getUtapi().deleteFiles(fileKey);
+}

--- a/apps/web/src/lib/uploadthing.ts
+++ b/apps/web/src/lib/uploadthing.ts
@@ -1,0 +1,40 @@
+import { createUploadthing, type FileRouter } from "uploadthing/next";
+import { UploadThingError } from "uploadthing/server";
+import { z } from "zod";
+import { ensureTenantAccess, requireSessionUser } from "@/lib/auth/authorization";
+import { getTenant } from "@/db/queries";
+
+const f = createUploadthing();
+
+export const uploadRouter = {
+  catalogImage: f({ image: { maxFileSize: "2MB", maxFileCount: 1 } })
+    .input(z.object({ tenantId: z.string().min(1) }))
+    .middleware(async ({ input }) => {
+      const tenant = await getTenant(input.tenantId);
+      if (!tenant) throw new UploadThingError("tenant_not_found");
+
+      const auth = await requireSessionUser();
+      if ("response" in auth) {
+        throw new UploadThingError("Authentication required");
+      }
+      const { user } = auth;
+
+      const denied = ensureTenantAccess(user, tenant.shopEmail);
+      if (denied) throw new UploadThingError("Forbidden");
+
+      if (tenant.platformApprovalStatus !== "approved") {
+        throw new UploadThingError("tenant_not_approved");
+      }
+
+      return { tenantId: input.tenantId, userId: user.id };
+    })
+    .onUploadComplete(async ({ metadata, file }) => {
+      // The drawer captures `file.url` via onClientUploadComplete and
+      // sends it in the catalog POST/PATCH body. UploadThing keeps the
+      // file regardless of whether the catalog save succeeds; orphaned
+      // files are GC'd by a future cleanup job.
+      return { url: file.url, tenantId: metadata.tenantId };
+    }),
+} satisfies FileRouter;
+
+export type UploadRouter = typeof uploadRouter;

--- a/docs/remaining_work.md
+++ b/docs/remaining_work.md
@@ -48,6 +48,20 @@ The code for §2.1, §2.3, §2.6, and §2.7 is done; the following ops/verificat
 - **Observability (from §2.7):** Verify PostHog project key is set in production Hostinger env vars (and confirm events are arriving from production after first deploy).
 - **Stripe webhook events (from §3.5):** Verify the production Stripe webhook endpoint subscribes to `account.updated` in addition to `payment_intent.succeeded` and `charge.refunded`.
 
+### 2.9 Catalog management — production deployment follow-ups
+
+The catalog management feature (PR #9 — self-service add/edit catalog items, image uploads via UploadThing, approval gate) is code-complete and smoke-tested on dev. Before / during the first production deploy that includes it, the following non-code actions need to happen on Hostinger:
+
+- [ ] **`UPLOADTHING_TOKEN` env var** — get the token from `https://uploadthing.com/dashboard → API Keys` (single combined v7 token, no separate key/app id). Add via hPanel → Advanced → Node.js → Environment Variables, then **restart the Node.js app** from the same panel. Without this, image uploads silently fail.
+- [ ] **CSP / `next/image` host allowlist** — already wired in `apps/web/next.config.ts` for `utfs.io`, `*.utfs.io`, `*.ufs.sh` (commit `dd35a70`). Just confirm the deployed build serves the same headers (curl `-I` the homepage and check `Content-Security-Policy`).
+- [ ] **End-to-end smoke in production** — log in as a platform admin → `/admin/<tenant>/catalog` → add an item with an image upload → confirm a `https://utfs.io/f/...` URL lands in `catalog_items.image_url` and the parent shop renders it. The dev-mode HMR caused some intermediate `UploadDropzone` glitches that don't repeat in production builds (no Fast Refresh) but worth one full-loop verification.
+- [x] **Migration 0008 (`catalog_image_url`)** — already applied to Neon prod (verified 2026-05-08; `__drizzle_migrations` row id=10 matches journal entry for `0008_catalog_image_url`). Nothing to do.
+- [ ] **(Optional) UploadThing free-tier monitoring** — current plan covers 2 GB storage / 100 GB bandwidth. With ~16 product photos × 2 schools × <2 MB each, usage is negligible. Re-evaluate at tenant #5 or any image-heavy redesign (e.g. high-res hero shots, multi-angle product photos).
+
+**Pre-existing landmine flagged during PR #9 smoke testing — not in this PR's scope:**
+
+- `apps/web/src/app/api/orders/route.ts:180` calls `db.transaction(async tx => …)` against the `neon-http` driver, which doesn't support interactive transactions. This was the same bug we fixed in `addCatalogItem` / `updateCatalogItem` (PR #9 commit `ac90e00` — switched to `db.batch`). The orders POST will throw `No transactions support in neon-http driver` → 500 the first time it's called in a real flow. Track as a separate follow-up before any non-Stripe-webhook order traffic hits this route.
+
 ---
 
 ## 3. 🟡 Medium — required by PDP/prototype, tolerable for soft launch

--- a/docs/remaining_work.md
+++ b/docs/remaining_work.md
@@ -58,9 +58,52 @@ The catalog management feature (PR #9 — self-service add/edit catalog items, i
 - [x] **Migration 0008 (`catalog_image_url`)** — already applied to Neon prod (verified 2026-05-08; `__drizzle_migrations` row id=10 matches journal entry for `0008_catalog_image_url`). Nothing to do.
 - [ ] **(Optional) UploadThing free-tier monitoring** — current plan covers 2 GB storage / 100 GB bandwidth. With ~16 product photos × 2 schools × <2 MB each, usage is negligible. Re-evaluate at tenant #5 or any image-heavy redesign (e.g. high-res hero shots, multi-angle product photos).
 
-**Pre-existing landmine flagged during PR #9 smoke testing — not in this PR's scope:**
+### 2.10 🔴 Latent bug — `db.transaction()` against `neon-http` driver in `/api/orders` POST
 
-- `apps/web/src/app/api/orders/route.ts:180` calls `db.transaction(async tx => …)` against the `neon-http` driver, which doesn't support interactive transactions. This was the same bug we fixed in `addCatalogItem` / `updateCatalogItem` (PR #9 commit `ac90e00` — switched to `db.batch`). The orders POST will throw `No transactions support in neon-http driver` → 500 the first time it's called in a real flow. Track as a separate follow-up before any non-Stripe-webhook order traffic hits this route.
+**Where:** `apps/web/src/app/api/orders/route.ts:180` (inside `insertOrder` helper).
+
+**Symptom (will fire on first real parent checkout post-deploy):** every POST to `/api/orders` throws `Error: No transactions support in neon-http driver` and returns 500. Parent never sees an order confirmation, the Stripe payment goes through but no `orders` row is written, refund cleanup is manual.
+
+**Root cause:** the codebase's DB client is `drizzle-orm/neon-http`, which is the HTTP-based serverless driver. It does **not** support drizzle's interactive `db.transaction(async (tx) => …)` API. Only `db.batch([stmt1, stmt2, …])` works on this driver, and it runs the listed statements atomically over a single HTTP round-trip.
+
+**Why it has never been observed in production:**
+
+- `db.transaction(...)` was added to this route in commit `1a6fa21` on 2026-05-05 (auth + idempotency + Stripe destination charges refactor).
+- The 3 orders currently in the `orders` table are all from 2026-05-01 — all pre-date the bug.
+- No parent has placed an order since 2026-05-05, so the bug has never fired in real traffic.
+
+**Why it surfaced now:** caught during PR #9 catalog-management smoke testing — the same `db.transaction(...)` pattern was used in `addCatalogItem` / `updateCatalogItem` and threw the identical error on the first Save in dev. PR #9 already fixed those two call sites (commit `ac90e00`, switched to `db.batch`). The orders POST has the same pattern but is **out of scope for that PR**.
+
+**Required fix (small, mechanical):**
+
+1. In `insertOrder` (`apps/web/src/app/api/orders/route.ts:179`) replace:
+
+   ```ts
+   await db.transaction(async (tx) => {
+     await tx.insert(orders).values({...});
+     for (const line of lines) {
+       await tx.insert(orderLines).values({...});
+     }
+   });
+   ```
+
+   with a `db.batch([...])` call mirroring the pattern in `addCatalogItem` (`apps/web/src/db/queries.ts` after commit `ac90e00`):
+
+   ```ts
+   import type { BatchItem } from "drizzle-orm/batch";
+   const orderInsert = db.insert(orders).values({...});
+   const lineInserts = lines.map((line) => db.insert(orderLines).values({...}));
+   const stmts: [BatchItem<"pg">, ...BatchItem<"pg">[]] = [orderInsert, ...lineInserts];
+   await db.batch(stmts);
+   ```
+
+2. Run `pnpm check-types` (`drizzle-orm` 0.45.2 batch typing requires a non-empty tuple; the cast above satisfies it).
+
+3. Smoke test: place a real test-mode order end-to-end after the change. The 5-attempt collision-retry loop wrapping `insertOrder` keeps working unchanged — it just retries on PK collision, not on the transaction error.
+
+**Priority:** 🔴 Blocker for any production parent-checkout traffic. Currently masked because (a) no real parents have checked out since May 5 and (b) Stripe webhook flows write to other tables, not `orders` directly. The first real checkout post-deploy will fail.
+
+**Suggested branching strategy:** stand-alone tiny PR (≤30 LOC change), can ship independently of PR #9 or be bundled with it as a safety net before NSBH go-live.
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@stripe/stripe-js':
         specifier: ^9.4.0
         version: 9.4.0
+      '@uploadthing/react':
+        specifier: ^7.3.3
+        version: 7.3.3(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(uploadthing@7.7.4(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tailwindcss@4.2.4))
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16)
@@ -91,6 +94,9 @@ importers:
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.5.0)(tailwindcss@4.2.4)
+      uploadthing:
+        specifier: ^7.7.4
+        version: 7.7.4(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tailwindcss@4.2.4)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -240,6 +246,11 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@effect/platform@0.90.3':
+    resolution: {integrity: sha512-XvQ37yzWQKih4Du2CYladd1i/MzqtgkTPNCaN6Ku6No4CK83hDtXIV/rP03nEoBg2R3Pqgz6gGWmE2id2G81HA==}
+    peerDependencies:
+      effect: ^3.17.7
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -975,6 +986,36 @@ packages:
     peerDependencies:
       react: ^17.0.2 || ^18.0.0 || ^19.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@neondatabase/auth-ui@0.2.0-beta':
     resolution: {integrity: sha512-cOLo6Xsa7mgidY9zVuA/I+XiGXDKZV2ZaJjAOAYz6AI//OW1cwGi9Gaka21WxrUvGKnTVleF8Tx77+PEpOZDwA==}
@@ -1919,6 +1960,9 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@standard-schema/spec@1.0.0-beta.4':
+    resolution: {integrity: sha512-d3IxtzLo7P1oZ8s8YNvxzBUXRXojSut8pbPrTYtzsc5sn4+53jVqbk66pQerSZbZSJZQux6LkclB/+8IDordHg==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2116,6 +2160,22 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@uploadthing/mime-types@0.3.6':
+    resolution: {integrity: sha512-t3tTzgwFV9+1D7lNDYc7Lr7kBwotHaX0ZsvoCGe7xGnXKo9z0jG2Sjl/msll12FeoLj77nyhsxevXyGpQDBvLg==}
+
+  '@uploadthing/react@7.3.3':
+    resolution: {integrity: sha512-GhKbK42jL2Qs7OhRd2Z6j0zTLsnJTRJH31nR7RZnUYVoRh2aS/NabMAnHBNqfunIAGXVaA717Pvzq7vtxuPTmQ==}
+    peerDependencies:
+      next: '*'
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      uploadthing: ^7.2.0
+    peerDependenciesMeta:
+      next:
+        optional: true
+
+  '@uploadthing/shared@7.1.10':
+    resolution: {integrity: sha512-R/XSA3SfCVnLIzFpXyGaKPfbwlYlWYSTuGjTFHuJhdAomuBuhopAHLh2Ois5fJibAHzi02uP1QCKbgTAdmArqg==}
 
   '@wojtekmaj/react-recaptcha-v3@0.1.4':
     resolution: {integrity: sha512-zszMOdgI+y1Dz3496pRFr3t68n9+OmX/puLQNnOBDC7WrjM+nOKGyjIMCTe+3J14KDvzcxETeiglyDMGl0Yh/Q==}
@@ -2450,6 +2510,9 @@ packages:
       sqlite3:
         optional: true
 
+  effect@3.17.7:
+    resolution: {integrity: sha512-dpt0ONUn3zzAuul6k4nC/coTTw27AL5nhkORXgTi6NfMPzqWYa1M05oKmOMTxpVSTKepqXVcW9vIwkuaaqx9zA==}
+
   elen@1.0.10:
     resolution: {integrity: sha512-ZL799/V/kzxYJ6Wlfktreq6qQWfGc3VkGUQJW5lZQ8/MhsQiKTAwERPfhEwIsV2movRGe2DfV7H2MjRw76Z7Wg==}
 
@@ -2506,6 +2569,10 @@ packages:
     resolution: {integrity: sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==}
     engines: {node: '>=20.0.0'}
 
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
@@ -2513,6 +2580,13 @@ packages:
     resolution: {integrity: sha512-EEx3OS/l2bFqcUNN2NM9FPJp8vAMrgbCxsbl2hbcJNNxOEwVe3mEzrhan7TbJQViZa8mMqhihlbCaqD+LyYKTQ==}
     engines: {node: '>= 17.0.0'}
     hasBin: true
+
+  file-selector@0.6.0:
+    resolution: {integrity: sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==}
+    engines: {node: '>= 12'}
+
+  find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
   find-up@7.0.0:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
@@ -2752,6 +2826,16 @@ packages:
       react-dom:
         optional: true
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.12:
+    resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
+
+  multipasta@0.2.7:
+    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
+
   mutative@1.3.0:
     resolution: {integrity: sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ==}
     engines: {node: '>=14.0'}
@@ -2796,6 +2880,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   number-flow@0.6.0:
     resolution: {integrity: sha512-K8flNq2Wqus53vjp/btVo3qXFkagF8dIdYavreBfE7hlvFFG/b1HMGEH6nZL+mlrJ+4lbLP9OmPv3t2rmRkpSQ==}
@@ -2871,6 +2959,9 @@ packages:
   protobufjs@7.5.6:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
@@ -3067,6 +3158,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  sqids@0.3.0:
+    resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
+
   stripe@22.1.0:
     resolution: {integrity: sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==}
     engines: {node: '>=18'}
@@ -3162,6 +3256,27 @@ packages:
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
+
+  uploadthing@7.7.4:
+    resolution: {integrity: sha512-rlK/4JWHW5jP30syzWGBFDDXv3WJDdT8gn9OoxRJmXLoXi94hBmyyjxihGlNrKhBc81czyv8TkzMioe/OuKGfA==}
+    engines: {node: '>=18.13.0'}
+    peerDependencies:
+      express: '*'
+      fastify: '*'
+      h3: '*'
+      next: '*'
+      tailwindcss: ^3.0.0 || ^4.0.0-beta.0
+    peerDependenciesMeta:
+      express:
+        optional: true
+      fastify:
+        optional: true
+      h3:
+        optional: true
+      next:
+        optional: true
+      tailwindcss:
+        optional: true
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -3369,6 +3484,14 @@ snapshots:
       - '@types/react-dom'
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@effect/platform@0.90.3(effect@3.17.7)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.40.0
+      effect: 3.17.7
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.12
+      multipasta: 0.2.7
 
   '@emnapi/runtime@1.10.0':
     dependencies:
@@ -3880,6 +4003,24 @@ snapshots:
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
 
   '@neondatabase/auth-ui@0.2.0-beta(33386455b16518fcd4055647d83c7d7a)':
     dependencies:
@@ -4884,6 +5025,8 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
+  '@standard-schema/spec@1.0.0-beta.4': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -5059,6 +5202,23 @@ snapshots:
     optional: true
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@uploadthing/mime-types@0.3.6': {}
+
+  '@uploadthing/react@7.3.3(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(uploadthing@7.7.4(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tailwindcss@4.2.4))':
+    dependencies:
+      '@uploadthing/shared': 7.1.10
+      file-selector: 0.6.0
+      react: 19.2.5
+      uploadthing: 7.7.4(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tailwindcss@4.2.4)
+    optionalDependencies:
+      next: 16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  '@uploadthing/shared@7.1.10':
+    dependencies:
+      '@uploadthing/mime-types': 0.3.6
+      effect: 3.17.7
+      sqids: 0.3.0
 
   '@wojtekmaj/react-recaptcha-v3@0.1.4(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -5246,6 +5406,11 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       kysely: 0.28.16
 
+  effect@3.17.7:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   elen@1.0.10: {}
 
   embla-carousel-react@8.6.0(react@19.2.5):
@@ -5362,11 +5527,21 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.8
 
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
   fflate@0.4.8: {}
 
   figlet@1.11.0:
     dependencies:
       commander: 14.0.3
+
+  file-selector@0.6.0:
+    dependencies:
+      tslib: 2.8.1
+
+  find-my-way-ts@0.1.6: {}
 
   find-up@7.0.0:
     dependencies:
@@ -5563,6 +5738,24 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.12:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
+  multipasta@0.2.7: {}
+
   mutative@1.3.0: {}
 
   nanoid@3.3.11: {}
@@ -5600,6 +5793,11 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   number-flow@0.6.0:
     dependencies:
@@ -5695,6 +5893,8 @@ snapshots:
       '@protobufjs/utf8': 1.1.1
       '@types/node': 25.6.0
       long: 5.3.2
+
+  pure-rand@6.1.0: {}
 
   pvtsutils@1.3.6:
     dependencies:
@@ -5921,6 +6121,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  sqids@0.3.0: {}
+
   stripe@22.1.0(@types/node@25.6.0):
     optionalDependencies:
       '@types/node': 25.6.0
@@ -5996,6 +6198,17 @@ snapshots:
   undici-types@7.19.2: {}
 
   unicorn-magic@0.1.0: {}
+
+  uploadthing@7.7.4(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tailwindcss@4.2.4):
+    dependencies:
+      '@effect/platform': 0.90.3(effect@3.17.7)
+      '@standard-schema/spec': 1.0.0-beta.4
+      '@uploadthing/mime-types': 0.3.6
+      '@uploadthing/shared': 7.1.10
+      effect: 3.17.7
+    optionalDependencies:
+      next: 16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tailwindcss: 4.2.4
 
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         version: 3.0.3(tailwind-merge@3.5.0)(tailwindcss@4.2.4)
       '@neondatabase/auth':
         specifier: 0.3.0-beta
-        version: 0.3.0-beta(8f23069669f3e8b1888ffe43cc2abaa1)
+        version: 0.3.0-beta(a494993e2e77aa203ca2d7bf0abe3a62)
       '@neondatabase/serverless':
         specifier: ^1.1.0
         version: 1.1.0
@@ -91,6 +91,9 @@ importers:
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.5.0)(tailwindcss@4.2.4)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.2.4
@@ -3222,6 +3225,9 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@adobe/react-spectrum-ui@1.2.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
@@ -3255,32 +3261,32 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0)':
+  '@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.4.3))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@standard-schema/spec': 1.1.0
-      better-call: 1.1.7(zod@4.3.6)
+      better-call: 1.1.7(zod@4.4.3)
       jose: 6.1.2
       kysely: 0.28.16
       nanostores: 1.3.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@better-auth/passkey@1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.1.7(zod@4.3.6))(nanostores@1.3.0)':
+  '@better-auth/passkey@1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.4.3))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.1.7(zod@4.4.3))(nanostores@1.3.0)':
     dependencies:
-      '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.4.3))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
       better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      better-call: 1.1.7(zod@4.3.6)
+      better-call: 1.1.7(zod@4.4.3)
       nanostores: 1.3.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@better-auth/telemetry@1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0))':
+  '@better-auth/telemetry@1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.4.3))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0))':
     dependencies:
-      '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.4.3))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
 
@@ -3313,9 +3319,9 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@daveyplate/better-auth-ui@3.3.9(20ec11d117d1e22ca89563c71abb7a68)':
+  '@daveyplate/better-auth-ui@3.3.9(c57c2c1456fca5d725a11256b3682231)':
     dependencies:
-      '@better-auth/passkey': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.1.7(zod@4.3.6))(nanostores@1.3.0)
+      '@better-auth/passkey': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.4.3))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.1.7(zod@4.4.3))(nanostores@1.3.0)
       '@better-fetch/fetch': 1.1.21
       '@captchafox/react': 1.12.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.100.7)(@tanstack/react-query@5.100.7(react@19.2.5))(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3357,7 +3363,7 @@ snapshots:
       tailwindcss: 4.2.1
       ua-parser-js: 2.0.9
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -3875,15 +3881,15 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@neondatabase/auth-ui@0.2.0-beta(feb07f1ff68ab8dd0962f7658da8dd25)':
+  '@neondatabase/auth-ui@0.2.0-beta(33386455b16518fcd4055647d83c7d7a)':
     dependencies:
-      '@better-auth/passkey': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.1.7(zod@4.3.6))(nanostores@1.3.0)
+      '@better-auth/passkey': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.4.3))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(better-call@1.1.7(zod@4.4.3))(nanostores@1.3.0)
       '@captchafox/react': 1.12.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@daveyplate/better-auth-ui': 3.3.9(20ec11d117d1e22ca89563c71abb7a68)
+      '@daveyplate/better-auth-ui': 3.3.9(c57c2c1456fca5d725a11256b3682231)
       '@hcaptcha/react-hcaptcha': 1.17.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@hookform/resolvers': 5.2.2(react-hook-form@7.74.0(react@19.2.5))
       '@marsidev/react-turnstile': 1.5.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@neondatabase/auth': 0.3.0-beta(8f23069669f3e8b1888ffe43cc2abaa1)
+      '@neondatabase/auth': 0.3.0-beta(a494993e2e77aa203ca2d7bf0abe3a62)
       '@radix-ui/react-avatar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.5)
@@ -3915,7 +3921,7 @@ snapshots:
       tw-animate-css: 1.4.0
       ua-parser-js: 2.0.9
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@better-auth/core'
       - '@better-auth/utils'
@@ -3946,10 +3952,10 @@ snapshots:
       - vitest
       - vue
 
-  '@neondatabase/auth@0.3.0-beta(8f23069669f3e8b1888ffe43cc2abaa1)':
+  '@neondatabase/auth@0.3.0-beta(a494993e2e77aa203ca2d7bf0abe3a62)':
     dependencies:
       '@better-fetch/fetch': 1.1.21
-      '@neondatabase/auth-ui': 0.2.0-beta(feb07f1ff68ab8dd0962f7658da8dd25)
+      '@neondatabase/auth-ui': 0.2.0-beta(33386455b16518fcd4055647d83c7d7a)
       '@supabase/auth-js': 2.79.0
       better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       jose: 6.1.2
@@ -5079,18 +5085,18 @@ snapshots:
 
   better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16))(next@16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0)
-      '@better-auth/telemetry': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0))
+      '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.4.3))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/telemetry': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.4.3))(jose@6.1.2)(kysely@0.28.16)(nanostores@1.3.0))
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.1.7(zod@4.3.6)
+      better-call: 1.1.7(zod@4.4.3)
       defu: 6.1.7
       jose: 6.1.2
       kysely: 0.28.16
       nanostores: 1.3.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(kysely@0.28.16)
@@ -5098,14 +5104,14 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  better-call@1.1.7(zod@4.3.6):
+  better-call@1.1.7(zod@4.4.3):
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   buffer-from@1.1.2: {}
 
@@ -6056,3 +6062,5 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
## Summary
- Self-service catalog management for approved tenants: side-drawer create/edit form on `/admin/[tenant]/catalog` behind a platform-approval gate
- Image uploads via UploadThing (typed App Router handler at `/api/uploadthing`); `image_url` column added in migration `0008`
- Parent shop now reads catalog live from DB (`getCatalogByTenant` / `getCatalogItemById`) and renders `<Image>` from `image_url`, falling back to category-keyed `GarmentVector`
- `desc` → `description` rename across static seed + item-detail renderer (aligned with DB column)
- Zod validation on all mutating routes; `requireTenantApproved` auth helper; CSP allowlist for `utfs.io` + `uploadthing.com`

## Commits (13)
- 3504449 mig 0008 image_url
- 5a84ad7 requireTenantApproved helper
- 41c7f9c zod schemas (item create/patch)
- 2240b54 POST/PATCH/DELETE /api/catalog rewrite (approval gate, validation)
- 4f3087e + d516cab uploadthing deps + router/handler/cleanup
- dd35a70 CSP allow utfs.io
- a4e6250 pending-approval empty state
- fba8296 item drawer (upload, variants, validation)
- 5d5a36d category-keyed GarmentVector fallback
- 0de3056 catalog table refactor (image col, row-click drawer, drop legacy modal)
- c080659 approval gate + add-item button
- c723e03 desc → description rename

## Stats
26 files changed (+2140 / -666). `pnpm check-types` ✓ clean.

## Test plan
- [ ] `/ultrareview` multi-agent review
- [ ] Apply migration 0008 to Neon prod
- [ ] Set `UPLOADTHING_*` env vars in Vercel
- [ ] Smoke: approval gate (unapproved tenant → editor blocked, gate empty state)
- [ ] Smoke: add item via drawer (image upload, variants, save → DB row + image_url)
- [ ] Smoke: edit item (drawer pre-fills, PATCH updates, image swap cleans old asset)
- [ ] Smoke: delete item (image cleanup fires)
- [ ] Smoke: parent shop renders live catalog with image OR category fallback
- [ ] Verify CSP doesn't block utfs.io image loads on parent shop

## Spec / plan
- Spec: `docs/superpowers/specs/2026-05-08-catalog-management-design.md`
- Plan: `docs/superpowers/plans/2026-05-08-catalog-management.md` (main has newer plan-review patches; merge takes main's version — branch never modified the plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)