### PR TITLE
fix(orders): use db.batch for neon-http driver in POST /api/orders

### DIFF
--- a/apps/web/src/app/api/orders/route.ts
+++ b/apps/web/src/app/api/orders/route.ts
@@ -6,7 +6,6 @@ import {
   getTenant,
 } from "@/db/queries";
 import { eq } from "drizzle-orm";
-import type { BatchItem } from "drizzle-orm/batch";
 import { customAlphabet } from "nanoid";
 import {
   ensureParentEmailAccess,
@@ -200,8 +199,8 @@ export async function POST(req: NextRequest) {
         userId: authResult.user.id,
         parentNote: normalizedParentNote,
       });
-      const lineInserts = lines.map((line) =>
-        db.insert(orderLines).values({
+      const linesInsert = db.insert(orderLines).values(
+        lines.map((line) => ({
           orderId,
           itemId: line.itemId,
           itemName: line.itemName,
@@ -210,13 +209,9 @@ export async function POST(req: NextRequest) {
           qty: line.qty,
           unitPrice: String(line.unitPrice),
           lineTotal: String(line.lineTotal),
-        })
+        }))
       );
-      const stmts: [BatchItem<"pg">, ...BatchItem<"pg">[]] = [
-        orderInsert,
-        ...lineInserts,
-      ];
-      await db.batch(stmts);
+      await db.batch([orderInsert, linesInsert]);
     };
 
     let createdOrderId: string | null = null;

--- a/apps/web/src/app/api/orders/route.ts
+++ b/apps/web/src/app/api/orders/route.ts
@@ -6,6 +6,7 @@ import {
   getTenant,
 } from "@/db/queries";
 import { eq } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
 import { customAlphabet } from "nanoid";
 import {
   ensureParentEmailAccess,
@@ -177,41 +178,45 @@ export async function POST(req: NextRequest) {
 
     const prefix = tenantId.toUpperCase();
     const insertOrder = async (orderId: string) => {
-      await db.transaction(async (tx) => {
-        await tx.insert(orders).values({
-          id: orderId,
-          tenantId,
-          parentName,
-          parentEmail: normalizedParentEmail,
-          parentMobile,
-          studentName,
-          studentYear,
-          studentRoll,
-          delivery: delivery ?? "pickup",
-          deliveryFee: String(deliveryFee ?? 0),
-          subtotal: String(subtotal),
-          gst: String(gst),
-          total: String(total),
-          stripePaymentIntentId: normalizedStripePaymentIntentId,
-          stripeRef: normalizedStripePaymentIntentId,
-          refundPolicyAcceptedAt: new Date(),
-          userId: authResult.user.id,
-          parentNote: normalizedParentNote,
-        });
-
-        for (const line of lines) {
-          await tx.insert(orderLines).values({
-            orderId,
-            itemId: line.itemId,
-            itemName: line.itemName,
-            variantLabel: line.variantLabel,
-            size: line.size?.trim() || null,
-            qty: line.qty,
-            unitPrice: String(line.unitPrice),
-            lineTotal: String(line.lineTotal),
-          });
-        }
+      // neon-http driver doesn't support interactive db.transaction; use db.batch
+      // which runs all statements atomically in a single HTTP round-trip.
+      const orderInsert = db.insert(orders).values({
+        id: orderId,
+        tenantId,
+        parentName,
+        parentEmail: normalizedParentEmail,
+        parentMobile,
+        studentName,
+        studentYear,
+        studentRoll,
+        delivery: delivery ?? "pickup",
+        deliveryFee: String(deliveryFee ?? 0),
+        subtotal: String(subtotal),
+        gst: String(gst),
+        total: String(total),
+        stripePaymentIntentId: normalizedStripePaymentIntentId,
+        stripeRef: normalizedStripePaymentIntentId,
+        refundPolicyAcceptedAt: new Date(),
+        userId: authResult.user.id,
+        parentNote: normalizedParentNote,
       });
+      const lineInserts = lines.map((line) =>
+        db.insert(orderLines).values({
+          orderId,
+          itemId: line.itemId,
+          itemName: line.itemName,
+          variantLabel: line.variantLabel,
+          size: line.size?.trim() || null,
+          qty: line.qty,
+          unitPrice: String(line.unitPrice),
+          lineTotal: String(line.lineTotal),
+        })
+      );
+      const stmts: [BatchItem<"pg">, ...BatchItem<"pg">[]] = [
+        orderInsert,
+        ...lineInserts,
+      ];
+      await db.batch(stmts);
     };
 
     let createdOrderId: string | null = null;


### PR DESCRIPTION
## Summary

- `POST /api/orders` called `db.transaction(async tx => ...)`, which throws `Error: No transactions support in neon-http driver` on the HTTP-based serverless driver. Only `db.batch([...])` is supported for atomic multi-statement writes on this driver.
- Replaced with `db.batch([orderInsert, ...lineInserts])`, mirroring the pattern in `addCatalogItem` (`apps/web/src/db/queries.ts:573`) introduced in PR #9.
- 🔴 Blocker for go-live. Latent because no parent has checked out since the bug was introduced (commit `1a6fa21`, 2026-05-05). The first real production checkout would 500 with the Stripe payment captured but no `orders` row written.
- Tracked as `docs/remaining_work.md` §2.10 — moved to `docs/completed.md` §4.11.

## Test plan

- [x] `pnpm check-types:web` — clean
- [ ] End-to-end smoke (real Stripe test-mode checkout → `orders` row + `order_lines` rows written) — gated on NSBH Stripe Express onboarding (same gate as `remaining_work.md` §5 checklist item 3)
- [ ] Confirm the 5-attempt PK-collision retry still works: `orders_pkey` `23505` errors continue to surface from the batch, the loop catches them and retries with a fresh ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)