### PR TITLE
feat(catalog): seed 8 missing NSBH paper-form items (9 SKUs)

### DIFF
--- a/apps/web/scripts/seed.mjs
+++ b/apps/web/scripts/seed.mjs
@@ -65,6 +65,16 @@ import("@neondatabase/serverless").then(async ({ neon }) => {
     // Stationery
     { id: "calc", tenantId: "nsbh", name: "Scientific Calculator", category: "Stationery", description: null, sortOrder: 18 },
     { id: "mathset", tenantId: "nsbh", name: "Math Set", category: "Stationery", description: null, sortOrder: 19 },
+    // Paper-form items not previously seeded (PDP §4)
+    { id: "shorts-navy", tenantId: "nsbh", name: "Navy Shorts — Adjustable Side Tabs", category: "Summer", description: "Mid-grey poly/viscose with adjustable side tabs.", sortOrder: 20 },
+    { id: "sock-grey", tenantId: "nsbh", name: "Grey Socks (cotton blend, midi)", category: "Winter", description: "Pack of one pair.", sortOrder: 21 },
+    { id: "scarf", tenantId: "nsbh", name: "School Scarf", category: "Winter", description: null, sortOrder: 22 },
+    { id: "prefect-tie", tenantId: "nsbh", name: "Prefect Tie", category: "Winter", description: null, sortOrder: 23 },
+    { id: "soccer-jersey", tenantId: "nsbh", name: "Soccer Jersey", category: "Sports", description: null, sortOrder: 24 },
+    { id: "swimming-briefs", tenantId: "nsbh", name: "Swimming Briefs", category: "Sports", description: null, sortOrder: 25 },
+    { id: "exercise-book-a4", tenantId: "nsbh", name: "A4 Exercise Book — 128 pages, plastic cover", category: "Stationery", description: null, sortOrder: 26 },
+    { id: "exercise-book-math", tenantId: "nsbh", name: "Math Exercise Book — 128 pages, plastic cover", category: "Stationery", description: null, sortOrder: 27 },
+    { id: "ring-binder", tenantId: "nsbh", name: "Ring Binder — Crested", category: "Stationery", description: null, sortOrder: 28 },
   ];
 
   for (const item of items) {
@@ -130,6 +140,26 @@ import("@neondatabase/serverless").then(async ({ neon }) => {
     { itemId: "calc", label: "N/A", price: 33 },
     // mathset
     { itemId: "mathset", label: "N/A", price: 7 },
+    // shorts-navy
+    { itemId: "shorts-navy", label: "Boys 10–16", price: 43 },
+    { itemId: "shorts-navy", label: "Mens 4–8", price: 45 },
+    // sock-grey
+    { itemId: "sock-grey", label: "3–9", price: 5 },
+    { itemId: "sock-grey", label: "7–11", price: 5 },
+    // scarf
+    { itemId: "scarf", label: "One size", price: 20 },
+    // prefect-tie
+    { itemId: "prefect-tie", label: "147cm", price: 22 },
+    // soccer-jersey
+    { itemId: "soccer-jersey", label: "12–22", price: 40 },
+    // swimming-briefs
+    { itemId: "swimming-briefs", label: "XS–XXL", price: 45 },
+    // exercise-book-a4
+    { itemId: "exercise-book-a4", label: "N/A", price: 2 },
+    // exercise-book-math
+    { itemId: "exercise-book-math", label: "N/A", price: 2 },
+    // ring-binder
+    { itemId: "ring-binder", label: "N/A", price: 5 },
   ];
 
   // Delete existing variants for these items first (to avoid duplicates on re-seed)

--- a/apps/web/scripts/seed.mjs
+++ b/apps/web/scripts/seed.mjs
@@ -66,7 +66,7 @@ import("@neondatabase/serverless").then(async ({ neon }) => {
     { id: "calc", tenantId: "nsbh", name: "Scientific Calculator", category: "Stationery", description: null, sortOrder: 18 },
     { id: "mathset", tenantId: "nsbh", name: "Math Set", category: "Stationery", description: null, sortOrder: 19 },
     // Paper-form items not previously seeded (PDP §4)
-    { id: "shorts-navy", tenantId: "nsbh", name: "Navy Shorts — Adjustable Side Tabs", category: "Summer", description: "Mid-grey poly/viscose with adjustable side tabs.", sortOrder: 20 },
+    { id: "shorts-navy", tenantId: "nsbh", name: "Navy Shorts — Adjustable Side Tabs", category: "Summer", description: "Navy poly/viscose with adjustable side tabs.", sortOrder: 20 },
     { id: "sock-grey", tenantId: "nsbh", name: "Grey Socks (cotton blend, midi)", category: "Winter", description: "Pack of one pair.", sortOrder: 21 },
     { id: "scarf", tenantId: "nsbh", name: "School Scarf", category: "Winter", description: null, sortOrder: 22 },
     { id: "prefect-tie", tenantId: "nsbh", name: "Prefect Tie", category: "Winter", description: null, sortOrder: 23 },

--- a/apps/web/src/components/garment.tsx
+++ b/apps/web/src/components/garment.tsx
@@ -14,14 +14,16 @@ import {
 import type { ItemCategory } from "@/lib/data";
 
 const ITEM_TO_SHAPE: Record<string, string> = {
-  "shirt-ss": "shirt", "shirt-ls": "shirt", polo: "shirt",
+  "shirt-ss": "shirt", "shirt-ls": "shirt", polo: "shirt", "soccer-jersey": "shirt",
   jumper: "jumper", hoodie: "jumper", jacket: "jumper",
   trousers: "pants", "shorts-sport": "pants", tracks: "pants",
+  "shorts-navy": "pants", "swimming-briefs": "pants",
   cap: "cap",
-  "sock-white": "sock", "sock-sport": "sock",
+  "sock-white": "sock", "sock-sport": "sock", "sock-grey": "sock",
   backpack: "bag", sportsbag: "bag",
-  blazer: "blazer", tie: "tie", belt: "belt",
+  blazer: "blazer", tie: "tie", "prefect-tie": "tie", scarf: "tie", belt: "belt",
   calc: "misc", mathset: "misc",
+  "exercise-book-a4": "misc", "exercise-book-math": "misc", "ring-binder": "misc",
 };
 
 const CATEGORY_DEFAULT: Record<ItemCategory, React.FC<{ accent: string; stroke: string; size: number }>> = {

--- a/apps/web/src/lib/data.ts
+++ b/apps/web/src/lib/data.ts
@@ -234,6 +234,68 @@ export const CATALOG: CatalogItem[] = [
     name: "Math Set",
     variants: [{ label: "N/A", price: 7, sizes: ["OS"] }],
   },
+  {
+    id: "shorts-navy",
+    cat: "Summer",
+    name: "Navy Shorts — Adjustable Side Tabs",
+    description: "Mid-grey poly/viscose with adjustable side tabs.",
+    variants: [
+      { label: "Boys 10–16", price: 43, sizes: ["10", "12", "14", "16"] },
+      { label: "Mens 4–8", price: 45, sizes: ["4", "5", "6", "7", "8"] },
+    ],
+  },
+  {
+    id: "sock-grey",
+    cat: "Winter",
+    name: "Grey Socks (cotton blend, midi)",
+    description: "Pack of one pair.",
+    variants: [
+      { label: "3–9", price: 5, sizes: ["3-9"] },
+      { label: "7–11", price: 5, sizes: ["7-11"] },
+    ],
+  },
+  {
+    id: "scarf",
+    cat: "Winter",
+    name: "School Scarf",
+    variants: [{ label: "One size", price: 20, sizes: ["OS"] }],
+  },
+  {
+    id: "prefect-tie",
+    cat: "Winter",
+    name: "Prefect Tie",
+    variants: [{ label: "147cm", price: 22, sizes: ["147"] }],
+  },
+  {
+    id: "soccer-jersey",
+    cat: "Sports",
+    name: "Soccer Jersey",
+    variants: [{ label: "12–22", price: 40, sizes: ["12", "14", "16", "18", "20", "22"] }],
+  },
+  {
+    id: "swimming-briefs",
+    cat: "Sports",
+    name: "Swimming Briefs",
+    variants: [{ label: "XS–XXL", price: 45, sizes: ["XS", "S", "M", "L", "XL", "XXL"] }],
+  },
+  {
+    id: "exercise-book-a4",
+    cat: "Stationery",
+    name: "A4 Exercise Book — 128 pages, plastic cover",
+    variants: [{ label: "N/A", price: 2, sizes: ["OS"] }],
+  },
+  {
+    id: "exercise-book-math",
+    cat: "Stationery",
+    name: "Math Exercise Book — 128 pages, plastic cover",
+    variants: [{ label: "N/A", price: 2, sizes: ["OS"] }],
+  },
+  {
+    id: "ring-binder",
+    cat: "Stationery",
+    name: "Ring Binder — Crested",
+    variants: [{ label: "N/A", price: 5, sizes: ["OS"] }],
+  },
 ];
 
 export const CATEGORIES: ItemCategory[] = ["Summer", "Winter", "Sports", "Formal", "Bags", "Stationery"];

--- a/apps/web/src/lib/data.ts
+++ b/apps/web/src/lib/data.ts
@@ -238,7 +238,7 @@ export const CATALOG: CatalogItem[] = [
     id: "shorts-navy",
     cat: "Summer",
     name: "Navy Shorts — Adjustable Side Tabs",
-    description: "Mid-grey poly/viscose with adjustable side tabs.",
+    description: "Navy poly/viscose with adjustable side tabs.",
     variants: [
       { label: "Boys 10–16", price: 43, sizes: ["10", "12", "14", "16"] },
       { label: "Mens 4–8", price: 45, sizes: ["4", "5", "6", "7", "8"] },

--- a/docs/remaining_work.md
+++ b/docs/remaining_work.md
@@ -79,11 +79,15 @@ The parent-account / "add another child" feature shipped via PR #6 (squash-merge
 
 ### 3.1 Missing catalog items from the paper form
 
-**Where:** `apps/web/src/db/queries.ts` seed data; audit §4.
+**Where:** `apps/web/scripts/seed.mjs` (DB seed) and `apps/web/src/lib/data.ts` (`CATALOG`, the parent shop's source-of-truth today).
 
-NSBH paper form items missing from the seed: Navy Shorts (Summer), Grey Socks (Winter), School Scarf, Swimming Briefs, Soccer Jersey, Exercise Books, Ring Binders, Prefect Tie. PDP §4 lists these explicitly.
+**Status (NSBH):** code complete. The 8 PDP-listed missing items now exist as 9 SKUs (Exercise Books split into A4 + Math, both on the paper form): `shorts-navy`, `sock-grey`, `scarf`, `prefect-tie`, `soccer-jersey`, `swimming-briefs`, `exercise-book-a4`, `exercise-book-math`, `ring-binder`. Variants/prices match the paper form (`my_doc/UI_prototypes/project/uploads/Uniform_Online_Order_Form.pdf`). `GarmentVector` shape map updated so each new ID renders the closest silhouette instead of the generic "misc" fallback. Smoke-tested on `pnpm dev:web` — all 9 items appear in the correct category on `/nsbh` and the item detail pages render with correct names + prices.
 
-**Required:** Update seed + run a one-off insert against production for both NSBH and RGSH (RGSH catalog needs review with the school).
+**Remaining:**
+
+- [ ] **Run prod NSBH seed.** `apps/web/scripts/seed.mjs` is idempotent (`ON CONFLICT DO UPDATE` for items, `DELETE + INSERT` for variants). Run against the production Neon DB once these changes ship: `cd apps/web && node scripts/seed.mjs` with the prod `DATABASE_URL`. (Note: today the parent shop reads `CATALOG` from `lib/data.ts`, not the DB — the seed run only matters for the admin catalog table and once parent-shop DB-reads land.)
+- [ ] **RGSH catalog (separate task).** Needs school sign-off on the catalog list — RGSH currently inherits NSBH-only seed entries. Capture as a school-onboarding sub-task once §2.2 super-admin portal exists.
+- [ ] **Out-of-scope discrepancies flagged for follow-up:** the paper form has a third White-Shirt-SS row (`men 4–8 → $45`) and a middle White-Shirt-LS variant (`10,12,…,18 → $57`) that the existing seed never captured. Track separately so this PR stays focused.
 
 ### 3.2 Refund-policy *page* (the actual content)
 


### PR DESCRIPTION
## Summary

Closes the NSBH portion of `docs/remaining_work.md` §3.1. Adds the 8 PDP-listed missing items as 9 SKUs (Exercise Books split into A4 + Math because the paper form lists them as two distinct rows):

| ID | Category | Variants | Price |
|---|---|---|---|
| `shorts-navy` | Summer | Boys 10–16 / Mens 4–8 | \$43 / \$45 |
| `sock-grey` | Winter | 3–9 / 7–11 | \$5 |
| `scarf` | Winter | One size | \$20 |
| `prefect-tie` | Winter | 147cm | \$22 |
| `soccer-jersey` | Sports | 12–22 | \$40 |
| `swimming-briefs` | Sports | XS–XXL | \$45 |
| `exercise-book-a4` | Stationery | N/A | \$2 |
| `exercise-book-math` | Stationery | N/A | \$2 |
| `ring-binder` | Stationery | N/A | \$5 |

All variants/prices come from `my_doc/UI_prototypes/project/uploads/Uniform_Online_Order_Form.pdf`.

## Why two files

The parent shop renders from `CATALOG` in `apps/web/src/lib/data.ts`, not the DB. `apps/web/scripts/seed.mjs` writes to Neon (used by the admin catalog table and any future parent-shop DB-reads). Both are updated to keep them in lockstep. `GarmentVector` (`apps/web/src/components/garment.tsx`) gets shape-map entries for the new IDs so the new tiles render the closest silhouette instead of the generic "misc" fallback.

## Test plan

- [x] `pnpm check-types:web` passes
- [x] `pnpm dev:web` smoke test — all 9 items appear in correct categories on `/nsbh`
  - Summer 4 (was 3) — Navy Shorts visible
  - Winter 9 (was 6) — Grey Socks, School Scarf, Prefect Tie visible
  - Sports 7 (was 5) — Soccer Jersey, Swimming Briefs visible
  - Stationery 5 (was 2) — A4 Book, Math Book, Ring Binder visible
- [x] Item detail pages return HTTP 200 with correct names + prices for spot-checked SKUs (`shorts-navy` $43/$45, `scarf` $20, `swimming-briefs` $45, `ring-binder` $5, `exercise-book-a4` $2, `soccer-jersey` $40, `prefect-tie` $22, `sock-grey` $5)
- [ ] (Post-merge) Run `node apps/web/scripts/seed.mjs` against prod Neon to upsert new rows. Idempotent — re-runs are safe.

## Out of scope (flagged for follow-up)

- **RGSH catalog** — needs school sign-off; will become a school-onboarding sub-task under §2.2 super-admin portal.
- **Pre-existing seed gaps** — paper form has a third White-Shirt-SS row (`men 4–8 → $45`) and a middle White-Shirt-LS variant (`10, 12, …, 18 → $57`) the existing seed never captured. Tracked in `remaining_work.md` §3.1 follow-ups so this PR stays focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)