### PR TITLE
PR C: Platform portal scaffold + tenant list + tenant detail (Phases 2/3/5)

### DIFF
--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -25,12 +25,13 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      # `@heroui-pro/react` runs a license-check on postinstall that fetches
-      # the gated `dist/`. HEROUI_AUTH_TOKEN is the explicit non-keychain
-      # credential the tool prompts for in CI environments.
-      - run: pnpm install --frozen-lockfile
-        env:
-          HEROUI_AUTH_TOKEN: ${{ secrets.HEROUI_AUTH_TOKEN }}
+      # `--ignore-scripts` skips postinstall hooks. Required because
+      # `@heroui-pro/react` runs a license check on postinstall that needs
+      # a CI-scoped HEROUI_AUTH_TOKEN (the local-keychain token is rejected
+      # in CI — see qiaohaojie/uniform_order#15 build attempt). tsc --noEmit
+      # only reads `.d.ts` files, so the runtime postinstall is irrelevant
+      # for type-checking. Drop this flag once a CI token is provisioned.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       # Generate Next.js route types (`.next/dev/types/routes.d.ts`) which
       # `next-env.d.ts` references for `PageProps`/`LayoutProps`. Without this,

--- a/.github/workflows/check-types.yml
+++ b/.github/workflows/check-types.yml
@@ -25,11 +25,12 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      # `--ignore-scripts` skips postinstall hooks. Required because
-      # `@heroui-pro/react` runs a license check on postinstall that needs
-      # HEROUI_AUTH_TOKEN + libsecret. tsc --noEmit only reads `.d.ts` files,
-      # so the package's runtime postinstall is irrelevant for type-checking.
-      - run: pnpm install --frozen-lockfile --ignore-scripts
+      # `@heroui-pro/react` runs a license-check on postinstall that fetches
+      # the gated `dist/`. HEROUI_AUTH_TOKEN is the explicit non-keychain
+      # credential the tool prompts for in CI environments.
+      - run: pnpm install --frozen-lockfile
+        env:
+          HEROUI_AUTH_TOKEN: ${{ secrets.HEROUI_AUTH_TOKEN }}
 
       # Generate Next.js route types (`.next/dev/types/routes.d.ts`) which
       # `next-env.d.ts` references for `PageProps`/`LayoutProps`. Without this,

--- a/apps/web/src/app/platform/layout.tsx
+++ b/apps/web/src/app/platform/layout.tsx
@@ -1,0 +1,21 @@
+import { redirect, notFound } from "next/navigation";
+import { getSessionUser, isPlatformAdminEmail } from "@/lib/auth/authorization";
+import { PlatformShell } from "@/components/platform-shell";
+
+export const dynamic = "force-dynamic";
+
+export default async function PlatformLayout({ children }: { children: React.ReactNode }) {
+  const user = await getSessionUser();
+  if (!user) {
+    redirect(`/auth/sign-in?callbackURL=${encodeURIComponent("/platform")}`);
+  }
+  if (!isPlatformAdminEmail(user.email)) {
+    notFound();
+  }
+
+  return (
+    <PlatformShell userName={user.name} userEmail={user.email}>
+      {children}
+    </PlatformShell>
+  );
+}

--- a/apps/web/src/app/platform/page.tsx
+++ b/apps/web/src/app/platform/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function PlatformIndex() {
+  redirect("/platform/tenants");
+}

--- a/apps/web/src/app/platform/tenants/[id]/actions.ts
+++ b/apps/web/src/app/platform/tenants/[id]/actions.ts
@@ -1,0 +1,66 @@
+"use server";
+import { db } from "@/db";
+import { tenants } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { getSessionUser, isPlatformAdminEmail } from "@/lib/auth/authorization";
+
+async function requirePlatformAdmin() {
+  const user = await getSessionUser();
+  if (!user || !isPlatformAdminEmail(user.email)) throw new Error("Forbidden");
+  return user;
+}
+
+export async function togglePublicListing(id: string, on: boolean) {
+  await requirePlatformAdmin();
+  await db.update(tenants).set({ isPubliclyListed: on, updatedAt: new Date() }).where(eq(tenants.id, id));
+  revalidatePath(`/platform/tenants/${id}`);
+  revalidatePath(`/${id}`, "layout");
+  return { ok: true as const };
+}
+
+export async function disableTenant(id: string) {
+  await requirePlatformAdmin();
+  await db
+    .update(tenants)
+    .set({ platformApprovalStatus: "rejected", isPubliclyListed: false, updatedAt: new Date() })
+    .where(eq(tenants.id, id));
+  revalidatePath(`/platform/tenants/${id}`);
+  revalidatePath("/platform/tenants");
+  revalidatePath(`/${id}`, "layout");
+  return { ok: true as const };
+}
+
+export async function reEnableTenant(id: string) {
+  await requirePlatformAdmin();
+  // Re-enable restores approval but leaves isPubliclyListed=false. Operator
+  // must explicitly toggle public listing back on so a parent isn't surprised
+  // by the tenant reappearing in the marketplace before catalog/pricing is
+  // reconfirmed.
+  await db
+    .update(tenants)
+    .set({ platformApprovalStatus: "approved", updatedAt: new Date() })
+    .where(eq(tenants.id, id));
+  revalidatePath(`/platform/tenants/${id}`);
+  revalidatePath("/platform/tenants");
+  return { ok: true as const };
+}
+
+export async function resyncStripeStatus(id: string) {
+  await requirePlatformAdmin();
+  const [tenant] = await db.select().from(tenants).where(eq(tenants.id, id)).limit(1);
+  if (!tenant?.stripeAccountId) return { ok: false as const, error: "No Stripe account" };
+
+  const { getStripe } = await import("@/lib/stripe");
+  const { updateTenantStripe } = await import("@/db/queries");
+  const stripe = getStripe();
+  const acct = await stripe.accounts.retrieve(tenant.stripeAccountId);
+
+  await updateTenantStripe(id, {
+    stripeAccountId: tenant.stripeAccountId,
+    stripeChargesEnabled: !!acct.charges_enabled,
+    stripePayoutsEnabled: !!acct.payouts_enabled,
+  });
+  revalidatePath(`/platform/tenants/${id}`);
+  return { ok: true as const };
+}

--- a/apps/web/src/app/platform/tenants/[id]/cards/branding-card.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/cards/branding-card.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { Crest } from "@/components/crest";
 import { togglePublicListing } from "../actions";
 import type { tenants } from "@/db/schema";
@@ -8,15 +8,24 @@ type TenantRow = typeof tenants.$inferSelect;
 
 export function BrandingCard({ tenant }: { tenant: TenantRow }) {
   const [listed, setListed] = useState(tenant.isPubliclyListed);
+  const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
+  // Resync local state when the RSC re-renders with a fresh tenant prop
+  // (e.g. after revalidatePath from any sibling action).
+  useEffect(() => {
+    setListed(tenant.isPubliclyListed);
+  }, [tenant.isPubliclyListed]);
+
   const onToggle = (next: boolean) => {
+    setError(null);
     setListed(next);
     startTransition(async () => {
       try {
         await togglePublicListing(tenant.id, next);
-      } catch {
+      } catch (e) {
         setListed(!next);
+        setError(e instanceof Error ? e.message : "Failed to update");
       }
     });
   };
@@ -46,6 +55,7 @@ export function BrandingCard({ tenant }: { tenant: TenantRow }) {
           <div className="text-xs text-ink-dim mt-0.5">
             When on, this tenant appears on the public school picker at uniformorder.online.
           </div>
+          {error ? <div className="text-xs text-alert mt-1">{error}</div> : null}
         </div>
         <button
           type="button"

--- a/apps/web/src/app/platform/tenants/[id]/cards/branding-card.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/cards/branding-card.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { useState, useTransition } from "react";
+import { Crest } from "@/components/crest";
+import { togglePublicListing } from "../actions";
+import type { tenants } from "@/db/schema";
+
+type TenantRow = typeof tenants.$inferSelect;
+
+export function BrandingCard({ tenant }: { tenant: TenantRow }) {
+  const [listed, setListed] = useState(tenant.isPubliclyListed);
+  const [pending, startTransition] = useTransition();
+
+  const onToggle = (next: boolean) => {
+    setListed(next);
+    startTransition(async () => {
+      try {
+        await togglePublicListing(tenant.id, next);
+      } catch {
+        setListed(!next);
+      }
+    });
+  };
+
+  return (
+    <section className="bg-paper rounded-[10px] border border-rule p-5">
+      <header className="flex items-start justify-between mb-4">
+        <h2 className="font-serif text-lg font-semibold">Branding</h2>
+      </header>
+
+      <div className="flex items-center gap-4">
+        {tenant.logoUrl ? (
+          <img src={tenant.logoUrl} alt="" className="w-14 h-14 rounded-md object-cover border border-rule" />
+        ) : (
+          <Crest tenant={{ id: tenant.id, accent: tenant.accent, short: tenant.short }} size={56} />
+        )}
+        <div>
+          <div className="font-serif text-base font-semibold">{tenant.name}</div>
+          <div className="text-sm text-ink-dim">{tenant.short} · {tenant.accent}</div>
+          {tenant.motto ? <div className="text-xs text-ink-dim italic mt-0.5">{tenant.motto}</div> : null}
+        </div>
+      </div>
+
+      <div className="mt-5 pt-4 border-t border-rule flex items-center justify-between">
+        <div>
+          <div className="text-sm font-semibold">Publicly listed</div>
+          <div className="text-xs text-ink-dim mt-0.5">
+            When on, this tenant appears on the public school picker at uniformorder.online.
+          </div>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={listed}
+          disabled={pending}
+          onClick={() => onToggle(!listed)}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition ${
+            listed ? "bg-navy-deep" : "bg-rule"
+          } ${pending ? "opacity-60" : ""}`}
+        >
+          <span
+            className={`inline-block h-5 w-5 transform rounded-full bg-white transition ${
+              listed ? "translate-x-5" : "translate-x-0.5"
+            }`}
+          />
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/platform/tenants/[id]/cards/danger-card.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/cards/danger-card.tsx
@@ -2,21 +2,25 @@
 import { useState, useTransition } from "react";
 import { disableTenant, reEnableTenant } from "../actions";
 import type { tenants } from "@/db/schema";
+import type { TenantStatus } from "@/lib/platform/queries";
 
 type TenantRow = typeof tenants.$inferSelect;
 
-export function DangerCard({ tenant, status }: { tenant: TenantRow; status: string }) {
-  const isDisabled = status === "Disabled";
+export function DangerCard({ tenant, status }: { tenant: TenantRow; status: TenantStatus }) {
+  const isDisabled = status === "disabled";
   const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
   const run = (fn: () => Promise<unknown>) => {
+    setError(null);
     startTransition(async () => {
       try {
         await fn();
         setConfirming(false);
-      } catch {
+      } catch (e) {
         setConfirming(false);
+        setError(e instanceof Error ? e.message : "Failed");
       }
     });
   };
@@ -77,6 +81,8 @@ export function DangerCard({ tenant, status }: { tenant: TenantRow; status: stri
           )}
         </div>
       )}
+
+      {error ? <div className="mt-3 text-xs text-alert">{error}</div> : null}
     </section>
   );
 }

--- a/apps/web/src/app/platform/tenants/[id]/cards/danger-card.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/cards/danger-card.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useState, useTransition } from "react";
+import { disableTenant, reEnableTenant } from "../actions";
+import type { tenants } from "@/db/schema";
+
+type TenantRow = typeof tenants.$inferSelect;
+
+export function DangerCard({ tenant, status }: { tenant: TenantRow; status: string }) {
+  const isDisabled = status === "Disabled";
+  const [confirming, setConfirming] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const run = (fn: () => Promise<unknown>) => {
+    startTransition(async () => {
+      try {
+        await fn();
+        setConfirming(false);
+      } catch {
+        setConfirming(false);
+      }
+    });
+  };
+
+  return (
+    <section className="bg-paper rounded-[10px] border border-rule p-5">
+      <header className="mb-2">
+        <h2 className="font-serif text-lg font-semibold text-alert">Danger zone</h2>
+      </header>
+
+      {isDisabled ? (
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm text-ink-dim">
+            This tenant is disabled. Parents see a 404 at <span className="font-mono">/{tenant.id}</span>.
+            Re-enabling restores approval but keeps the public listing off until you flip it.
+          </p>
+          <button
+            type="button"
+            onClick={() => run(() => reEnableTenant(tenant.id))}
+            disabled={pending}
+            className="h-9 px-4 rounded-md bg-navy-deep text-white text-sm font-semibold whitespace-nowrap disabled:opacity-50"
+          >
+            {pending ? "Working…" : "Re-enable tenant"}
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm text-ink-dim">
+            Disable hides the parent shop, blocks new orders, and removes this tenant from the public listing. Existing orders are preserved.
+          </p>
+          {confirming ? (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirming(false)}
+                disabled={pending}
+                className="h-9 px-3 rounded-md border border-rule text-sm font-semibold"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => run(() => disableTenant(tenant.id))}
+                disabled={pending}
+                className="h-9 px-4 rounded-md bg-alert text-white text-sm font-semibold disabled:opacity-50"
+              >
+                {pending ? "Disabling…" : "Confirm disable"}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirming(true)}
+              className="h-9 px-4 rounded-md border border-alert text-alert text-sm font-semibold whitespace-nowrap"
+            >
+              Disable tenant
+            </button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/app/platform/tenants/[id]/cards/operator-card.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/cards/operator-card.tsx
@@ -1,0 +1,27 @@
+import type { tenants } from "@/db/schema";
+
+type TenantRow = typeof tenants.$inferSelect;
+
+export function OperatorCard({ tenant }: { tenant: TenantRow }) {
+  return (
+    <section className="bg-paper rounded-[10px] border border-rule p-5">
+      <header className="flex items-start justify-between mb-4">
+        <h2 className="font-serif text-lg font-semibold">Operator & shop contact</h2>
+      </header>
+
+      <dl className="grid grid-cols-[140px_1fr] gap-y-2.5 text-sm">
+        <dt className="text-ink-dim">Operator email</dt>
+        <dd className="font-mono">{tenant.shopEmail ?? "—"}</dd>
+
+        <dt className="text-ink-dim">Address</dt>
+        <dd>{tenant.address ?? "—"}</dd>
+
+        <dt className="text-ink-dim">Shop hours</dt>
+        <dd>{tenant.shopHours ?? "—"}</dd>
+
+        <dt className="text-ink-dim">Pickup instructions</dt>
+        <dd className="whitespace-pre-line">{tenant.collectionInstructions ?? "—"}</dd>
+      </dl>
+    </section>
+  );
+}

--- a/apps/web/src/app/platform/tenants/[id]/cards/stripe-card.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/cards/stripe-card.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { useState, useTransition } from "react";
+import { resyncStripeStatus } from "../actions";
+import type { tenants } from "@/db/schema";
+
+type TenantRow = typeof tenants.$inferSelect;
+
+export function StripeCard({ tenant }: { tenant: TenantRow }) {
+  const [msg, setMsg] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onResync = () => {
+    setMsg(null);
+    startTransition(async () => {
+      try {
+        const r = await resyncStripeStatus(tenant.id);
+        setMsg(r.ok ? "Synced." : (r.error ?? "Failed"));
+      } catch {
+        setMsg("Failed");
+      }
+    });
+  };
+
+  const stripeDashUrl = tenant.stripeAccountId
+    ? `https://dashboard.stripe.com/connect/accounts/${tenant.stripeAccountId}`
+    : null;
+
+  return (
+    <section className="bg-paper rounded-[10px] border border-rule p-5">
+      <header className="flex items-start justify-between mb-4">
+        <h2 className="font-serif text-lg font-semibold">Stripe Connect</h2>
+        {stripeDashUrl ? (
+          <a
+            href={stripeDashUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs font-semibold text-navy-deep underline"
+          >
+            Open Stripe ↗
+          </a>
+        ) : null}
+      </header>
+
+      <dl className="grid grid-cols-[140px_1fr] gap-y-2.5 text-sm">
+        <dt className="text-ink-dim">Account ID</dt>
+        <dd className="font-mono text-xs">{tenant.stripeAccountId ?? "—"}</dd>
+
+        <dt className="text-ink-dim">Charges</dt>
+        <dd>
+          <Badge ok={!!tenant.stripeChargesEnabled} />
+        </dd>
+
+        <dt className="text-ink-dim">Payouts</dt>
+        <dd>
+          <Badge ok={!!tenant.stripePayoutsEnabled} />
+        </dd>
+      </dl>
+
+      <div className="mt-5 pt-4 border-t border-rule flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onResync}
+          disabled={pending || !tenant.stripeAccountId}
+          className="h-8 px-3 rounded-md border border-rule text-xs font-semibold disabled:opacity-50"
+        >
+          {pending ? "Syncing…" : "Resync from Stripe"}
+        </button>
+        {msg ? <span className="text-xs text-ink-dim">{msg}</span> : null}
+      </div>
+    </section>
+  );
+}
+
+function Badge({ ok }: { ok: boolean }) {
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 text-[11px] font-semibold rounded-full ${
+        ok ? "bg-green-100 text-green-800" : "bg-amber-100 text-amber-800"
+      }`}
+    >
+      {ok ? "Enabled" : "Pending"}
+    </span>
+  );
+}

--- a/apps/web/src/app/platform/tenants/[id]/page.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/page.tsx
@@ -1,0 +1,75 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getTenant } from "@/db/queries";
+import { BrandingCard } from "./cards/branding-card";
+import { OperatorCard } from "./cards/operator-card";
+import { StripeCard } from "./cards/stripe-card";
+import { DangerCard } from "./cards/danger-card";
+
+export default async function TenantDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const tenant = await getTenant(id);
+  if (!tenant) notFound();
+
+  const status =
+    tenant.platformApprovalStatus === "rejected"
+      ? "Disabled"
+      : tenant.platformApprovalStatus !== "approved" || !tenant.stripeChargesEnabled
+        ? "Setup"
+        : tenant.isPubliclyListed
+          ? "Active"
+          : "Hidden";
+
+  return (
+    <>
+      <header className="px-7 py-5 border-b border-rule flex items-start justify-between">
+        <div>
+          <h1 className="font-serif text-2xl font-semibold">{tenant.name}</h1>
+          <div className="text-sm text-ink-dim mt-1">
+            <span className="font-mono">{tenant.id}.uniformorder.online</span> · Status: <strong>{status}</strong>
+          </div>
+        </div>
+        <Link href={`/${tenant.id}`} className="text-sm font-semibold text-navy-deep underline">
+          Open parent shop ↗
+        </Link>
+      </header>
+
+      <div className="flex-1 px-7 py-6 overflow-auto space-y-4 max-w-4xl">
+        {status === "Setup" ? (
+          <ResumeOnboarding tenant={tenant} />
+        ) : (
+          <>
+            <BrandingCard tenant={tenant} />
+            <OperatorCard tenant={tenant} />
+            <StripeCard tenant={tenant} />
+            <DangerCard tenant={tenant} status={status} />
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+function ResumeOnboarding({ tenant }: { tenant: { id: string; accent: string | null; stripeAccountId: string | null; shopEmail: string | null; stripeChargesEnabled: boolean | null } }) {
+  const step = !tenant.accent
+    ? 2
+    : !tenant.stripeAccountId
+      ? 3
+      : !tenant.shopEmail
+        ? 4
+        : !tenant.stripeChargesEnabled
+          ? 3
+          : 6;
+  return (
+    <div className="bg-paper rounded-[10px] border border-rule p-6">
+      <h2 className="font-serif text-lg font-semibold">Resume onboarding</h2>
+      <p className="text-sm text-ink-dim mt-2">This tenant is pending. Complete onboarding to take it live.</p>
+      <Link
+        href={`/platform/tenants/new?id=${tenant.id}&step=${step}`}
+        className="inline-block mt-4 h-10 px-5 rounded-md bg-navy-deep text-white font-semibold leading-10"
+      >
+        Resume at step {step} →
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/platform/tenants/[id]/page.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/page.tsx
@@ -1,24 +1,35 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getTenant } from "@/db/queries";
+import type { TenantStatus } from "@/lib/platform/queries";
 import { BrandingCard } from "./cards/branding-card";
 import { OperatorCard } from "./cards/operator-card";
 import { StripeCard } from "./cards/stripe-card";
 import { DangerCard } from "./cards/danger-card";
+
+const STATUS_LABEL: Record<TenantStatus, string> = {
+  setup: "Setup",
+  active: "Active",
+  hidden: "Hidden",
+  disabled: "Disabled",
+};
+
+function deriveStatus(tenant: {
+  platformApprovalStatus: string;
+  stripeChargesEnabled: boolean | null;
+  isPubliclyListed: boolean;
+}): TenantStatus {
+  if (tenant.platformApprovalStatus === "rejected") return "disabled";
+  if (tenant.platformApprovalStatus !== "approved" || !tenant.stripeChargesEnabled) return "setup";
+  return tenant.isPubliclyListed ? "active" : "hidden";
+}
 
 export default async function TenantDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const tenant = await getTenant(id);
   if (!tenant) notFound();
 
-  const status =
-    tenant.platformApprovalStatus === "rejected"
-      ? "Disabled"
-      : tenant.platformApprovalStatus !== "approved" || !tenant.stripeChargesEnabled
-        ? "Setup"
-        : tenant.isPubliclyListed
-          ? "Active"
-          : "Hidden";
+  const status = deriveStatus(tenant);
 
   return (
     <>
@@ -26,7 +37,7 @@ export default async function TenantDetailPage({ params }: { params: Promise<{ i
         <div>
           <h1 className="font-serif text-2xl font-semibold">{tenant.name}</h1>
           <div className="text-sm text-ink-dim mt-1">
-            <span className="font-mono">{tenant.id}.uniformorder.online</span> · Status: <strong>{status}</strong>
+            <span className="font-mono">{tenant.id}.uniformorder.online</span> · Status: <strong>{STATUS_LABEL[status]}</strong>
           </div>
         </div>
         <Link href={`/${tenant.id}`} className="text-sm font-semibold text-navy-deep underline">
@@ -35,7 +46,7 @@ export default async function TenantDetailPage({ params }: { params: Promise<{ i
       </header>
 
       <div className="flex-1 px-7 py-6 overflow-auto space-y-4 max-w-4xl">
-        {status === "Setup" ? (
+        {status === "setup" ? (
           <ResumeOnboarding tenant={tenant} />
         ) : (
           <>

--- a/apps/web/src/app/platform/tenants/page.tsx
+++ b/apps/web/src/app/platform/tenants/page.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { listTenantsWithStats, getPlatformKpis } from "@/lib/platform/queries";
+import { TenantsTable } from "./tenants-table";
+
+export default async function PlatformTenantsPage() {
+  const [list, kpis] = await Promise.all([listTenantsWithStats(), getPlatformKpis()]);
+
+  return (
+    <>
+      <header className="flex items-center justify-between px-7 py-5 border-b border-rule">
+        <div>
+          <div className="text-[10.5px] uppercase tracking-[0.6px] font-bold text-ink-dim">
+            UniformOrder Platform
+          </div>
+          <h1 className="font-serif text-2xl font-semibold mt-1">Tenant schools</h1>
+        </div>
+        <Link
+          href="/platform/tenants/new"
+          className="inline-flex items-center gap-2 h-9 px-4 rounded-md bg-navy-deep text-white text-sm font-semibold"
+        >
+          + Provision new tenant
+        </Link>
+      </header>
+
+      <div className="flex-1 px-7 py-6 overflow-auto">
+        <KpiTiles kpis={kpis} />
+        <div className="mt-6">
+          <TenantsTable rows={list} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+function KpiTiles({ kpis }: { kpis: Awaited<ReturnType<typeof getPlatformKpis>> }) {
+  const tiles = [
+    {
+      label: "Tenants",
+      value: kpis.tenants.total,
+      sub: `${kpis.tenants.active} active · ${kpis.tenants.setup} setup`,
+    },
+    {
+      label: "Parents",
+      value: kpis.parents.toLocaleString(),
+      sub: "Across all schools",
+    },
+    {
+      label: "Orders · 30d",
+      value: kpis.orders30d.count,
+      sub:
+        kpis.orders30d.deltaMom == null
+          ? "—"
+          : `${kpis.orders30d.deltaMom > 0 ? "+" : ""}${(kpis.orders30d.deltaMom * 100).toFixed(0)}% MoM`,
+    },
+    {
+      label: "Revenue · 30d",
+      value: `$${Number(kpis.revenue30d).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`,
+      sub: "Gross — net of refunds",
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-4 gap-3.5">
+      {tiles.map((t) => (
+        <div key={t.label} className="bg-paper rounded-[10px] border border-rule p-4">
+          <div className="text-[11px] font-bold uppercase tracking-[0.4px] text-ink-dim">
+            {t.label}
+          </div>
+          <div className="font-serif text-[26px] font-semibold mt-1.5 tnum">{t.value}</div>
+          <div className="text-[11px] text-ink-dim mt-1">{t.sub}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/platform/tenants/tenants-table.tsx
+++ b/apps/web/src/app/platform/tenants/tenants-table.tsx
@@ -1,0 +1,118 @@
+"use client";
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import type { TenantStatsRow, TenantStatus } from "@/lib/platform/queries";
+
+const FILTERS: Array<{ id: TenantStatus | "all"; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "active", label: "Active" },
+  { id: "setup", label: "Setup" },
+  { id: "hidden", label: "Hidden" },
+];
+
+export function TenantsTable({ rows }: { rows: TenantStatsRow[] }) {
+  const [filter, setFilter] = useState<TenantStatus | "all">("all");
+  const [q, setQ] = useState("");
+
+  const filtered = useMemo(() => {
+    const ql = q.trim().toLowerCase();
+    return rows.filter((r) => {
+      if (filter !== "all" && r.status !== filter) return false;
+      if (ql && !(r.name.toLowerCase().includes(ql) || r.id.toLowerCase().includes(ql)))
+        return false;
+      return true;
+    });
+  }, [rows, filter, q]);
+
+  return (
+    <div className="bg-paper rounded-[10px] border border-rule overflow-hidden">
+      <div className="px-4 py-3 border-b border-rule flex items-center gap-2.5">
+        <div className="flex gap-1.5">
+          {FILTERS.map((f) => (
+            <button
+              key={f.id}
+              type="button"
+              onClick={() => setFilter(f.id)}
+              className={`h-7 px-3 rounded-md text-xs font-semibold ${
+                filter === f.id ? "bg-navy-deep text-white" : "text-ink-dim"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <div className="flex-1" />
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search by name or code"
+          className="h-8 w-60 border border-rule rounded-md px-2.5 text-xs"
+        />
+      </div>
+      <table className="w-full text-[13px] border-collapse">
+        <thead>
+          <tr className="bg-parchment">
+            {["School", "Parents", "Orders·30d", "Revenue·30d", "Since", "Status", ""].map((h, i) => (
+              <th
+                key={h}
+                className={`px-4 py-2.5 text-[10.5px] font-bold uppercase tracking-[0.6px] text-ink-dim border-b border-rule ${
+                  i >= 1 && i <= 3 ? "text-right" : i === 6 ? "text-right" : "text-left"
+                }`}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((r) => (
+            <tr key={r.id} className="border-b border-rule last:border-0">
+              <td className="px-4 py-3">
+                <div className="font-semibold text-[13.5px] font-serif">{r.name}</div>
+                <div className="font-mono text-[10.5px] text-ink-dim mt-0.5">
+                  {r.id}.uniformorder.online
+                </div>
+              </td>
+              <td className="px-4 py-3 text-right tnum">{r.parents.toLocaleString()}</td>
+              <td className="px-4 py-3 text-right tnum">{r.orders30d}</td>
+              <td className="px-4 py-3 text-right tnum">${Number(r.revenue30d).toFixed(0)}</td>
+              <td className="px-4 py-3 text-ink-dim">
+                {r.createdAt?.toLocaleDateString("en-AU", { month: "short", year: "numeric" }) ?? "—"}
+              </td>
+              <td className="px-4 py-3">
+                <StatusChip status={r.status} />
+              </td>
+              <td className="px-4 py-3 text-right">
+                <Link href={`/platform/tenants/${r.id}`} className="text-xs font-semibold text-navy-deep underline">
+                  Open →
+                </Link>
+              </td>
+            </tr>
+          ))}
+          {filtered.length === 0 && (
+            <tr>
+              <td colSpan={7} className="px-4 py-8 text-center text-sm text-ink-dim">
+                No tenants match.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StatusChip({ status }: { status: TenantStatus }) {
+  const map = {
+    active: { label: "Active", cls: "bg-green-100 text-green-800" },
+    setup: { label: "Setup", cls: "bg-amber-100 text-amber-800" },
+    hidden: { label: "Hidden", cls: "bg-blue-100 text-blue-800" },
+    disabled: { label: "Disabled", cls: "bg-red-100 text-red-800" },
+  } as const;
+  const m = map[status];
+  return (
+    <span className={`inline-block px-2 py-0.5 text-[11px] font-semibold rounded-full ${m.cls}`}>
+      {m.label}
+    </span>
+  );
+}

--- a/apps/web/src/components/platform-shell.tsx
+++ b/apps/web/src/components/platform-shell.tsx
@@ -1,0 +1,60 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+const NAV = [
+  { href: "/platform/tenants", label: "Tenants" },
+  { href: "/platform/billing", label: "Billing" },
+] as const;
+
+export function PlatformShell({
+  userName,
+  userEmail,
+  children,
+}: {
+  userName: string | null;
+  userEmail: string | null;
+  children: ReactNode;
+}) {
+  const pathname = usePathname() ?? "";
+  const active: "tenants" | "billing" = pathname.startsWith("/platform/billing") ? "billing" : "tenants";
+  return (
+    <div className="flex min-h-screen bg-parchment text-ink font-sans">
+      <aside className="w-[220px] shrink-0 bg-[#0A1726] text-[#E8E0CF] flex flex-col">
+        <div className="px-[18px] py-[20px] border-b border-white/[0.08]">
+          <div className="font-serif text-[22px] font-semibold text-white">UniformOrder</div>
+          <div className="mt-1.5 text-[10.5px] uppercase tracking-[0.6px] font-semibold text-[#A3B0C2]">
+            Platform Console
+          </div>
+        </div>
+        <nav className="flex-1 px-2 py-3.5">
+          {NAV.map((n) => {
+            const on = active === n.href.split("/").pop();
+            return (
+              <Link
+                key={n.href}
+                href={n.href}
+                className={`flex items-center gap-2.5 px-3 py-2 my-0.5 rounded-md text-[13px] ${
+                  on ? "bg-white/[0.07] text-white font-semibold" : "text-[#B6C0CE] font-medium"
+                }`}
+              >
+                {n.label}
+              </Link>
+            );
+          })}
+        </nav>
+        <div className="p-3 border-t border-white/[0.08] flex items-center gap-2.5">
+          <div className="w-8 h-8 rounded-full bg-gold text-navy-deep flex items-center justify-center text-xs font-bold">
+            {(userName ?? "?").slice(0, 2).toUpperCase()}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-semibold text-white truncate">{userName ?? "—"}</div>
+            <div className="text-[10.5px] text-[#A3B0C2] truncate">Platform admin</div>
+          </div>
+        </div>
+      </aside>
+      <main className="flex-1 min-w-0 flex flex-col">{children}</main>
+    </div>
+  );
+}

--- a/apps/web/src/lib/platform/queries.ts
+++ b/apps/web/src/lib/platform/queries.ts
@@ -1,0 +1,102 @@
+import { db } from "@/db";
+import { sql } from "drizzle-orm";
+
+export type TenantStatus = "setup" | "active" | "hidden" | "disabled";
+
+export type TenantStatsRow = {
+  id: string;
+  name: string;
+  short: string;
+  accent: string;
+  createdAt: Date | null;
+  status: TenantStatus;
+  parents: number;
+  orders30d: number;
+  revenue30d: string;
+};
+
+function deriveStatus(t: {
+  platformApprovalStatus: string;
+  stripeChargesEnabled: boolean | null;
+  isPubliclyListed: boolean;
+}): TenantStatus {
+  if (t.platformApprovalStatus === "rejected") return "disabled";
+  if (t.platformApprovalStatus !== "approved" || !t.stripeChargesEnabled) return "setup";
+  return t.isPubliclyListed ? "active" : "hidden";
+}
+
+export async function listTenantsWithStats(): Promise<TenantStatsRow[]> {
+  const rows = await db.execute(sql`
+    SELECT
+      t.id, t.name, t.short, t.accent, t.created_at,
+      t.platform_approval_status, t.stripe_charges_enabled, t.is_publicly_listed,
+      COALESCE(stats.parents, 0)       AS parents,
+      COALESCE(stats.orders30d, 0)     AS orders_30d,
+      COALESCE(stats.revenue30d, 0)::text AS revenue_30d
+    FROM tenants t
+    LEFT JOIN (
+      SELECT
+        o.tenant_id,
+        COUNT(DISTINCT COALESCE(o.user_id::text, lower(o.parent_email))) AS parents,
+        COUNT(*) FILTER (
+          WHERE o.status != 'pending_payment'
+            AND o.created_at > now() - interval '30 days'
+        ) AS orders30d,
+        SUM(o.total) FILTER (WHERE o.created_at > now() - interval '30 days')
+          - COALESCE(SUM(r.amount) FILTER (WHERE r.created_at > now() - interval '30 days'), 0) AS revenue30d
+      FROM orders o
+      LEFT JOIN order_refunds r ON r.order_id = o.id
+      GROUP BY o.tenant_id
+    ) stats ON stats.tenant_id = t.id
+    ORDER BY t.created_at DESC
+  `);
+
+  return rows.rows.map((r) => ({
+    id: r.id as string,
+    name: r.name as string,
+    short: r.short as string,
+    accent: r.accent as string,
+    createdAt: r.created_at as Date | null,
+    status: deriveStatus({
+      platformApprovalStatus: r.platform_approval_status as string,
+      stripeChargesEnabled: r.stripe_charges_enabled as boolean | null,
+      isPubliclyListed: r.is_publicly_listed as boolean,
+    }),
+    parents: Number(r.parents),
+    orders30d: Number(r.orders_30d),
+    revenue30d: String(r.revenue_30d),
+  }));
+}
+
+export type PlatformKpis = {
+  tenants: { total: number; active: number; setup: number };
+  parents: number;
+  orders30d: { count: number; deltaMom: number | null };
+  revenue30d: string;
+};
+
+export async function getPlatformKpis(): Promise<PlatformKpis> {
+  const list = await listTenantsWithStats();
+
+  const orders30d = list.reduce((s, t) => s + t.orders30d, 0);
+
+  const priorRow = await db.execute(sql`
+    SELECT COUNT(*) AS n FROM orders
+    WHERE status != 'pending_payment'
+      AND created_at > now() - interval '60 days'
+      AND created_at <= now() - interval '30 days'
+  `);
+  const prior = Number(priorRow.rows[0]?.n ?? 0);
+  const deltaMom = prior > 0 ? (orders30d - prior) / prior : null;
+
+  return {
+    tenants: {
+      total: list.length,
+      active: list.filter((t) => t.status === "active").length,
+      setup: list.filter((t) => t.status === "setup").length,
+    },
+    parents: list.reduce((s, t) => s + t.parents, 0),
+    orders30d: { count: orders30d, deltaMom },
+    revenue30d: list.reduce((s, t) => s + Number(t.revenue30d), 0).toFixed(2),
+  };
+}


### PR DESCRIPTION
## Summary

Third PR in the platform-portal series (after PR #14, which shipped Phases 0+1).
Covers PR C in the plan's 5-PR breakdown: phases 2 (auth gate), 3 (tenant list),
and 5 (tenant detail — read-only paths).

- **Phase 2** — `/platform` shell + auth gate. `PlatformShell` (client, reads `usePathname()` for active-nav highlight); `app/platform/layout.tsx` is an RSC that calls `getSessionUser()` + `isPlatformAdminEmail()` and either redirects unauthenticated users to sign-in or 404s authenticated non-admins. `app/platform/page.tsx` redirects to `/platform/tenants`.
- **Phase 3** — `lib/platform/queries.ts` (`listTenantsWithStats`, `getPlatformKpis`) computes per-tenant 30d order count, 30d revenue net of refunds, and distinct-parent count via one LEFT JOIN; status is derived from `platformApprovalStatus + stripeChargesEnabled + isPubliclyListed`. `app/platform/tenants/page.tsx` renders KPI tiles + a client `TenantsTable` with status filter and name/code search.
- **Phase 5** — `app/platform/tenants/[id]/` displays read-only branding, operator/shop, Stripe Connect, and danger cards. Self-contained server actions: `togglePublicListing`, `disableTenant`, `reEnableTenant`, `resyncStripeStatus`. `Setup` tenants get a `Resume onboarding` deep-link to the wizard (built in PR D). Edit drawers reusing the wizard's Step-2/4 forms are deferred to PR D so this PR has no Phase-4 dependency.

## Plan & spec

- Plan: `docs/superpowers/plans/2026-05-09-platform-portal.md`
- Spec: `docs/superpowers/specs/2026-05-09-platform-portal-design.md`

## Test plan

- [ ] `pnpm check-types` clean (verified locally)
- [ ] Sign out, visit `/platform` → redirects to `/auth/sign-in?callbackURL=/platform`
- [ ] Sign in as a non-allowlisted account, visit `/platform` → 404 (no leak)
- [ ] Sign in as a `PLATFORM_ADMIN_EMAILS` account, visit `/platform` → lands on `/platform/tenants` with KPI tiles + NSBH/RGSH rows
- [ ] Filter chips (All / Active / Setup / Hidden) and the search input narrow the table client-side
- [ ] Click `Open →` on a row → tenant detail loads with branding/operator/stripe/danger cards
- [ ] Toggle "Publicly listed" → DB row updates, parent shop visibility flips
- [ ] Click "Disable tenant" → status flips to Disabled, `/<id>` 404s for parents
- [ ] Click "Re-enable tenant" → restores `approved` (public listing stays off until operator flips it)
- [ ] Click "Resync from Stripe" on a tenant with a Stripe account → `stripeChargesEnabled` / `stripePayoutsEnabled` reflect Stripe API state

🤖 Generated with [Claude Code](https://claude.com/claude-code)