### PR TITLE
PR E: Platform portal billing tab (Phase 6)

### DIFF
--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -6,6 +6,7 @@ import { orders, tenants, orderRefunds } from "@/db/schema";
 import { sendOrderConfirmationEmail } from "@/lib/email";
 import { serverCapture, serverCaptureException } from "@/lib/analytics/server";
 import { getStripe } from "@/lib/stripe";
+import { revalidateTag } from "next/cache";
 
 export const runtime = "nodejs"; // required: edge runtime can't read raw body for Stripe sig
 
@@ -115,6 +116,7 @@ export async function POST(req: NextRequest) {
             details_submitted: account.details_submitted ?? false,
           });
         }
+        revalidateTag("platform-billing");
       } catch (err) {
         console.error("stripe webhook: account.updated DB write failed", err);
         await serverCaptureException(

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -7,6 +7,7 @@ import { sendOrderConfirmationEmail } from "@/lib/email";
 import { serverCapture, serverCaptureException } from "@/lib/analytics/server";
 import { getStripe } from "@/lib/stripe";
 import { revalidateTag } from "next/cache";
+import { tenantBillingTag } from "@/lib/platform/stripe-billing";
 
 export const runtime = "nodejs"; // required: edge runtime can't read raw body for Stripe sig
 
@@ -115,8 +116,8 @@ export async function POST(req: NextRequest) {
             charges_enabled: account.charges_enabled ?? false,
             details_submitted: account.details_submitted ?? false,
           });
+          revalidateTag(tenantBillingTag(updated[0].id), "max");
         }
-        revalidateTag("platform-billing", "max");
       } catch (err) {
         console.error("stripe webhook: account.updated DB write failed", err);
         await serverCaptureException(

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -116,7 +116,7 @@ export async function POST(req: NextRequest) {
             details_submitted: account.details_submitted ?? false,
           });
         }
-        revalidateTag("platform-billing", "seconds");
+        revalidateTag("platform-billing", "max");
       } catch (err) {
         console.error("stripe webhook: account.updated DB write failed", err);
         await serverCaptureException(

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -116,7 +116,7 @@ export async function POST(req: NextRequest) {
             details_submitted: account.details_submitted ?? false,
           });
         }
-        revalidateTag("platform-billing");
+        revalidateTag("platform-billing", "seconds");
       } catch (err) {
         console.error("stripe webhook: account.updated DB write failed", err);
         await serverCaptureException(

--- a/apps/web/src/app/platform/billing/billing-table.tsx
+++ b/apps/web/src/app/platform/billing/billing-table.tsx
@@ -1,7 +1,9 @@
-"use client";
 import type { TenantBilling } from "@/lib/platform/stripe-billing";
 
 type Row = TenantBilling & { id: string; name: string };
+
+const fmtMoney = (amount: number, currency: string) =>
+  `${currency.toUpperCase()} ${amount.toFixed(0)}`;
 
 export function BillingTable({ rows }: { rows: Row[] }) {
   return (
@@ -21,19 +23,23 @@ export function BillingTable({ rows }: { rows: Row[] }) {
             <tr key={r.id} className="border-b border-rule last:border-0">
               <td className="px-4 py-3 font-semibold">{r.name}</td>
               <td className="px-4 py-3 font-mono text-xs">{r.accountId ?? "—"}</td>
-              <td className="px-4 py-3">{r.chargesEnabled === null ? "—" : r.chargesEnabled ? "✓" : "—"}</td>
-              <td className="px-4 py-3">{r.payoutsEnabled === null ? "—" : r.payoutsEnabled ? "✓" : "—"}</td>
-              <td className="px-4 py-3 tnum">{r.balance ? `$${(r.balance.available + r.balance.pending).toFixed(0)}` : "—"}</td>
-              <td className="px-4 py-3 tnum">{r.gross30d ? `$${r.gross30d.toFixed(0)}` : "—"}</td>
+              <td className="px-4 py-3">{r.chargesEnabled === null ? "—" : r.chargesEnabled ? "✓" : "✗"}</td>
+              <td className="px-4 py-3">{r.payoutsEnabled === null ? "—" : r.payoutsEnabled ? "✓" : "✗"}</td>
               <td className="px-4 py-3 tnum">
-                {r.lastPayout ? `$${r.lastPayout.amount.toFixed(0)} · ${r.lastPayout.date.toLocaleDateString("en-AU", { month: "short", day: "numeric" })}` : "—"}
+                {r.balance ? fmtMoney(r.balance.available + r.balance.pending, r.balance.currency) : "—"}
+              </td>
+              <td className="px-4 py-3 tnum">{r.gross30d ? fmtMoney(r.gross30d, r.currency) : "—"}</td>
+              <td className="px-4 py-3 tnum">
+                {r.lastPayout
+                  ? `${fmtMoney(r.lastPayout.amount, r.lastPayout.currency)} · ${r.lastPayout.date.toLocaleDateString("en-AU", { month: "short", day: "numeric" })}`
+                  : "—"}
               </td>
               <td className="px-4 py-3 text-right">
                 {r.accountId && (
                   <a
                     href={`https://dashboard.stripe.com/connect/accounts/${r.accountId}`}
                     target="_blank"
-                    rel="noopener"
+                    rel="noopener noreferrer"
                     className="text-xs font-semibold text-navy-deep underline"
                   >
                     Open ↗

--- a/apps/web/src/app/platform/billing/billing-table.tsx
+++ b/apps/web/src/app/platform/billing/billing-table.tsx
@@ -1,0 +1,50 @@
+"use client";
+import type { TenantBilling } from "@/lib/platform/stripe-billing";
+
+type Row = TenantBilling & { id: string; name: string };
+
+export function BillingTable({ rows }: { rows: Row[] }) {
+  return (
+    <div className="bg-paper rounded-[10px] border border-rule overflow-hidden">
+      <table className="w-full text-[13px] border-collapse">
+        <thead>
+          <tr className="bg-parchment">
+            {["School", "Acct", "Charges", "Payouts", "Balance", "30d gross", "Last payout", ""].map((h) => (
+              <th key={h} className="px-4 py-2.5 text-[10.5px] font-bold uppercase tracking-[0.6px] text-ink-dim border-b border-rule text-left">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id} className="border-b border-rule last:border-0">
+              <td className="px-4 py-3 font-semibold">{r.name}</td>
+              <td className="px-4 py-3 font-mono text-xs">{r.accountId ?? "—"}</td>
+              <td className="px-4 py-3">{r.chargesEnabled === null ? "—" : r.chargesEnabled ? "✓" : "—"}</td>
+              <td className="px-4 py-3">{r.payoutsEnabled === null ? "—" : r.payoutsEnabled ? "✓" : "—"}</td>
+              <td className="px-4 py-3 tnum">{r.balance ? `$${(r.balance.available + r.balance.pending).toFixed(0)}` : "—"}</td>
+              <td className="px-4 py-3 tnum">{r.gross30d ? `$${r.gross30d.toFixed(0)}` : "—"}</td>
+              <td className="px-4 py-3 tnum">
+                {r.lastPayout ? `$${r.lastPayout.amount.toFixed(0)} · ${r.lastPayout.date.toLocaleDateString("en-AU", { month: "short", day: "numeric" })}` : "—"}
+              </td>
+              <td className="px-4 py-3 text-right">
+                {r.accountId && (
+                  <a
+                    href={`https://dashboard.stripe.com/connect/accounts/${r.accountId}`}
+                    target="_blank"
+                    rel="noopener"
+                    className="text-xs font-semibold text-navy-deep underline"
+                  >
+                    Open ↗
+                  </a>
+                )}
+                {r.error && <span className="text-xs text-red-700 ml-2">{r.error}</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/app/platform/billing/billing-table.tsx
+++ b/apps/web/src/app/platform/billing/billing-table.tsx
@@ -3,7 +3,7 @@ import type { TenantBilling } from "@/lib/platform/stripe-billing";
 type Row = TenantBilling & { id: string; name: string };
 
 const fmtMoney = (amount: number, currency: string) =>
-  `${currency.toUpperCase()} ${amount.toFixed(0)}`;
+  `${currency.toUpperCase()} ${amount.toFixed(2)}`;
 
 export function BillingTable({ rows }: { rows: Row[] }) {
   return (

--- a/apps/web/src/app/platform/billing/billing-table.tsx
+++ b/apps/web/src/app/platform/billing/billing-table.tsx
@@ -2,8 +2,12 @@ import type { TenantBilling } from "@/lib/platform/stripe-billing";
 
 type Row = TenantBilling & { id: string; name: string };
 
+const moneyFormatter = new Intl.NumberFormat("en-AU", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
 const fmtMoney = (amount: number, currency: string) =>
-  `${currency.toUpperCase()} ${amount.toFixed(2)}`;
+  `${currency.toUpperCase()} ${moneyFormatter.format(amount)}`;
 
 export function BillingTable({ rows }: { rows: Row[] }) {
   return (

--- a/apps/web/src/app/platform/billing/page.tsx
+++ b/apps/web/src/app/platform/billing/page.tsx
@@ -1,13 +1,13 @@
 import { db } from "@/db";
 import { tenants } from "@/db/schema";
-import { getTenantBilling } from "@/lib/platform/stripe-billing";
+import { getTenantBilling, mapTenantBilling, PLATFORM_CURRENCY } from "@/lib/platform/stripe-billing";
 import { BillingTable } from "./billing-table";
 
 export default async function BillingPage() {
   const list = await db
     .select({ id: tenants.id, name: tenants.name, accountId: tenants.stripeAccountId })
     .from(tenants);
-  const billing = await Promise.all(list.map((t) => getTenantBilling(t.id, t.accountId)));
+  const billing = await mapTenantBilling(list, (t) => getTenantBilling(t.id, t.accountId));
   const merged = list.map((t, i) => ({ ...t, ...billing[i] }));
 
   const enabled = merged.filter((m) => m.chargesEnabled).length;
@@ -23,9 +23,9 @@ export default async function BillingPage() {
       <div className="flex-1 px-7 py-6 overflow-auto">
         <div className="grid grid-cols-4 gap-3.5">
           <Tile label="Connected accounts" value={`${enabled} / ${list.length}`} sub="enabled" />
-          <Tile label="Total balance" value={`AUD ${totalBalance.toFixed(0)}`} sub="across tenants" />
-          <Tile label="Payouts · 30d" value={`AUD ${totalNet30.toFixed(0)}`} sub="net" />
-          <Tile label="Gross · 30d" value={`AUD ${totalGross30.toFixed(0)}`} sub="pre-fee" />
+          <Tile label="Total balance" value={`${PLATFORM_CURRENCY} ${totalBalance.toFixed(0)}`} sub="across tenants" />
+          <Tile label="Payouts · 30d" value={`${PLATFORM_CURRENCY} ${totalNet30.toFixed(0)}`} sub="net" />
+          <Tile label="Gross · 30d" value={`${PLATFORM_CURRENCY} ${totalGross30.toFixed(0)}`} sub="pre-fee" />
         </div>
         <div className="mt-6">
           <BillingTable rows={merged} />

--- a/apps/web/src/app/platform/billing/page.tsx
+++ b/apps/web/src/app/platform/billing/page.tsx
@@ -1,0 +1,46 @@
+import { db } from "@/db";
+import { tenants } from "@/db/schema";
+import { getTenantBilling } from "@/lib/platform/stripe-billing";
+import { BillingTable } from "./billing-table";
+
+export default async function BillingPage() {
+  const list = await db
+    .select({ id: tenants.id, name: tenants.name, accountId: tenants.stripeAccountId })
+    .from(tenants);
+  const billing = await Promise.all(list.map((t) => getTenantBilling(t.id, t.accountId)));
+  const merged = list.map((t, i) => ({ ...t, ...billing[i] }));
+
+  const enabled = merged.filter((m) => m.chargesEnabled).length;
+  const totalBalance = merged.reduce((s, m) => s + (m.balance?.available ?? 0) + (m.balance?.pending ?? 0), 0);
+  const totalNet30 = merged.reduce((s, m) => s + m.net30d, 0);
+  const totalGross30 = merged.reduce((s, m) => s + m.gross30d, 0);
+
+  return (
+    <>
+      <header className="px-7 py-5 border-b border-rule">
+        <h1 className="font-serif text-2xl font-semibold">Billing & payouts</h1>
+      </header>
+      <div className="flex-1 px-7 py-6 overflow-auto">
+        <div className="grid grid-cols-4 gap-3.5">
+          <Tile label="Connected accounts" value={`${enabled} / ${list.length}`} sub="enabled" />
+          <Tile label="Total balance" value={`$${totalBalance.toFixed(0)}`} sub="across tenants" />
+          <Tile label="Payouts · 30d" value={`$${totalNet30.toFixed(0)}`} sub="net" />
+          <Tile label="Gross · 30d" value={`$${totalGross30.toFixed(0)}`} sub="pre-fee" />
+        </div>
+        <div className="mt-6">
+          <BillingTable rows={merged} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+function Tile({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <div className="bg-paper rounded-[10px] border border-rule p-4">
+      <div className="text-[11px] font-bold uppercase tracking-[0.4px] text-ink-dim">{label}</div>
+      <div className="font-serif text-[26px] font-semibold mt-1.5 tnum">{value}</div>
+      <div className="text-[11px] text-ink-dim mt-1">{sub}</div>
+    </div>
+  );
+}

--- a/apps/web/src/app/platform/billing/page.tsx
+++ b/apps/web/src/app/platform/billing/page.tsx
@@ -15,6 +15,8 @@ export default async function BillingPage() {
   const totalNet30 = merged.reduce((s, m) => s + m.net30d, 0);
   const totalGross30 = merged.reduce((s, m) => s + m.gross30d, 0);
 
+  const fmtKpi = (n: number) => new Intl.NumberFormat("en-AU").format(Math.round(n));
+
   return (
     <>
       <header className="px-7 py-5 border-b border-rule">
@@ -23,9 +25,9 @@ export default async function BillingPage() {
       <div className="flex-1 px-7 py-6 overflow-auto">
         <div className="grid grid-cols-4 gap-3.5">
           <Tile label="Connected accounts" value={`${enabled} / ${list.length}`} sub="enabled" />
-          <Tile label="Total balance" value={`${PLATFORM_CURRENCY} ${totalBalance.toFixed(0)}`} sub="across tenants" />
-          <Tile label="Payouts · 30d" value={`${PLATFORM_CURRENCY} ${totalNet30.toFixed(0)}`} sub="net" />
-          <Tile label="Gross · 30d" value={`${PLATFORM_CURRENCY} ${totalGross30.toFixed(0)}`} sub="pre-fee" />
+          <Tile label="Total balance" value={`${PLATFORM_CURRENCY} ${fmtKpi(totalBalance)}`} sub="across tenants" />
+          <Tile label="Payouts · 30d" value={`${PLATFORM_CURRENCY} ${fmtKpi(totalNet30)}`} sub="net" />
+          <Tile label="Gross · 30d" value={`${PLATFORM_CURRENCY} ${fmtKpi(totalGross30)}`} sub="pre-fee" />
         </div>
         <div className="mt-6">
           <BillingTable rows={merged} />

--- a/apps/web/src/app/platform/billing/page.tsx
+++ b/apps/web/src/app/platform/billing/page.tsx
@@ -23,9 +23,9 @@ export default async function BillingPage() {
       <div className="flex-1 px-7 py-6 overflow-auto">
         <div className="grid grid-cols-4 gap-3.5">
           <Tile label="Connected accounts" value={`${enabled} / ${list.length}`} sub="enabled" />
-          <Tile label="Total balance" value={`$${totalBalance.toFixed(0)}`} sub="across tenants" />
-          <Tile label="Payouts · 30d" value={`$${totalNet30.toFixed(0)}`} sub="net" />
-          <Tile label="Gross · 30d" value={`$${totalGross30.toFixed(0)}`} sub="pre-fee" />
+          <Tile label="Total balance" value={`AUD ${totalBalance.toFixed(0)}`} sub="across tenants" />
+          <Tile label="Payouts · 30d" value={`AUD ${totalNet30.toFixed(0)}`} sub="net" />
+          <Tile label="Gross · 30d" value={`AUD ${totalGross30.toFixed(0)}`} sub="pre-fee" />
         </div>
         <div className="mt-6">
           <BillingTable rows={merged} />

--- a/apps/web/src/lib/platform/stripe-billing.ts
+++ b/apps/web/src/lib/platform/stripe-billing.ts
@@ -11,43 +11,44 @@ export type TenantBilling = {
   lastPayout: { date: Date; amount: number; currency: string } | null;
   gross30d: number;
   net30d: number;
+  currency: string;
   error: string | null;
 };
+
+export const PLATFORM_BILLING_TAG = "platform-billing";
+export const tenantBillingTag = (tenantId: string) => `platform-billing:${tenantId}`;
 
 async function fetchTenantBilling(tenantId: string, accountId: string | null): Promise<TenantBilling> {
   if (!accountId) {
     return {
       tenantId, accountId: null, chargesEnabled: null, payoutsEnabled: null,
-      balance: null, lastPayout: null, gross30d: 0, net30d: 0, error: null,
+      balance: null, lastPayout: null, gross30d: 0, net30d: 0, currency: "aud", error: null,
     };
   }
   try {
     const stripe = getStripe();
     const stripeOpts = { stripeAccount: accountId };
-    const [acct, balance, payouts, txs] = await Promise.all([
+    const since = Math.floor((Date.now() - 30 * 24 * 60 * 60 * 1000) / 1000);
+
+    const [acct, balance, payouts] = await Promise.all([
       stripe.accounts.retrieve(accountId),
       stripe.balance.retrieve(undefined, stripeOpts),
       stripe.payouts.list({ limit: 1 }, stripeOpts),
-      stripe.balanceTransactions.list(
-        {
-          created: { gte: Math.floor((Date.now() - 30 * 24 * 60 * 60 * 1000) / 1000) },
-          limit: 100,
-        },
-        stripeOpts,
-      ),
     ]);
+
+    let gross = 0;
+    let net = 0;
+    // Auto-paginate so totals don't silently cap at one page when tenants exceed ~100 tx/30d.
+    for await (const t of stripe.balanceTransactions
+      .list({ created: { gte: since }, limit: 100 }, stripeOpts)) {
+      if (t.type === "charge") gross += t.amount / 100;
+      net += t.net / 100;
+    }
 
     const available = (balance.available[0]?.amount ?? 0) / 100;
     const pending = (balance.pending[0]?.amount ?? 0) / 100;
     const currency = balance.available[0]?.currency ?? "aud";
     const last = payouts.data[0];
-
-    let gross = 0;
-    let net = 0;
-    for (const t of txs.data) {
-      if (t.type === "charge") gross += t.amount / 100;
-      net += t.net / 100;
-    }
 
     return {
       tenantId,
@@ -58,12 +59,13 @@ async function fetchTenantBilling(tenantId: string, accountId: string | null): P
       lastPayout: last ? { date: new Date(last.arrival_date * 1000), amount: last.amount / 100, currency: last.currency } : null,
       gross30d: gross,
       net30d: net,
+      currency,
       error: null,
     };
   } catch (err) {
     return {
       tenantId, accountId, chargesEnabled: null, payoutsEnabled: null,
-      balance: null, lastPayout: null, gross30d: 0, net30d: 0,
+      balance: null, lastPayout: null, gross30d: 0, net30d: 0, currency: "aud",
       error: err instanceof Error ? err.message : String(err),
     };
   }
@@ -73,6 +75,6 @@ export const getTenantBilling = cache((tenantId: string, accountId: string | nul
   unstable_cache(
     () => fetchTenantBilling(tenantId, accountId),
     [`tenant-billing:${tenantId}`],
-    { revalidate: 300, tags: ["platform-billing"] },
+    { revalidate: 300, tags: [PLATFORM_BILLING_TAG, tenantBillingTag(tenantId)] },
   )()
 );

--- a/apps/web/src/lib/platform/stripe-billing.ts
+++ b/apps/web/src/lib/platform/stripe-billing.ts
@@ -42,11 +42,13 @@ export async function mapTenantBilling<T>(
   return out;
 }
 
+const FALLBACK_CURRENCY = PLATFORM_CURRENCY.toLowerCase();
+
 async function fetchTenantBilling(tenantId: string, accountId: string | null): Promise<TenantBilling> {
   if (!accountId) {
     return {
       tenantId, accountId: null, chargesEnabled: null, payoutsEnabled: null,
-      balance: null, lastPayout: null, gross30d: 0, net30d: 0, currency: "aud", error: null,
+      balance: null, lastPayout: null, gross30d: 0, net30d: 0, currency: FALLBACK_CURRENCY, error: null,
     };
   }
   try {
@@ -60,18 +62,19 @@ async function fetchTenantBilling(tenantId: string, accountId: string | null): P
       stripe.payouts.list({ limit: 1 }, stripeOpts),
     ]);
 
-    let gross = 0;
-    let net = 0;
+    // Sum cents as integers to avoid float drift over many transactions.
+    let grossCents = 0;
+    let netCents = 0;
     // Auto-paginate so totals don't silently cap at one page when tenants exceed ~100 tx/30d.
     for await (const t of stripe.balanceTransactions
       .list({ created: { gte: since }, limit: 100 }, stripeOpts)) {
-      if (t.type === "charge") gross += t.amount / 100;
-      net += t.net / 100;
+      if (t.type === "charge") grossCents += t.amount;
+      netCents += t.net;
     }
 
     const available = (balance.available[0]?.amount ?? 0) / 100;
     const pending = (balance.pending[0]?.amount ?? 0) / 100;
-    const currency = balance.available[0]?.currency ?? "aud";
+    const currency = balance.available[0]?.currency ?? FALLBACK_CURRENCY;
     const last = payouts.data[0];
 
     return {
@@ -81,24 +84,26 @@ async function fetchTenantBilling(tenantId: string, accountId: string | null): P
       payoutsEnabled: acct.payouts_enabled,
       balance: { available, pending, currency },
       lastPayout: last ? { date: new Date(last.arrival_date * 1000), amount: last.amount / 100, currency: last.currency } : null,
-      gross30d: gross,
-      net30d: net,
+      gross30d: grossCents / 100,
+      net30d: netCents / 100,
       currency,
       error: null,
     };
   } catch (err) {
     return {
       tenantId, accountId, chargesEnabled: null, payoutsEnabled: null,
-      balance: null, lastPayout: null, gross30d: 0, net30d: 0, currency: "aud",
+      balance: null, lastPayout: null, gross30d: 0, net30d: 0, currency: FALLBACK_CURRENCY,
       error: err instanceof Error ? err.message : String(err),
     };
   }
 }
 
+// `accountId` is part of the cache key so onboarding (null → real ID) doesn't
+// keep returning the stale "no account" stub until the next webhook flush.
 export const getTenantBilling = cache((tenantId: string, accountId: string | null) =>
   unstable_cache(
     () => fetchTenantBilling(tenantId, accountId),
-    [`tenant-billing:${tenantId}`],
+    [`tenant-billing:${tenantId}`, accountId ?? "none"],
     { revalidate: 300, tags: [PLATFORM_BILLING_TAG, tenantBillingTag(tenantId)] },
   )()
 );

--- a/apps/web/src/lib/platform/stripe-billing.ts
+++ b/apps/web/src/lib/platform/stripe-billing.ts
@@ -63,18 +63,24 @@ async function fetchTenantBilling(tenantId: string, accountId: string | null): P
     ]);
 
     // Sum cents as integers to avoid float drift over many transactions.
+    // Net = volume after Stripe fees, excluding payout/transfer entries which
+    // represent funds leaving the Stripe balance (not revenue).
     let grossCents = 0;
     let netCents = 0;
     // Auto-paginate so totals don't silently cap at one page when tenants exceed ~100 tx/30d.
     for await (const t of stripe.balanceTransactions
       .list({ created: { gte: since }, limit: 100 }, stripeOpts)) {
       if (t.type === "charge") grossCents += t.amount;
-      netCents += t.net;
+      if (t.type === "charge" || t.type === "refund") netCents += t.net;
     }
 
-    const available = (balance.available[0]?.amount ?? 0) / 100;
-    const pending = (balance.pending[0]?.amount ?? 0) / 100;
-    const currency = balance.available[0]?.currency ?? FALLBACK_CURRENCY;
+    // Stripe Connect AU accounts return a single-currency balance today, but
+    // .find() is cheap insurance against a future multi-currency Stripe response.
+    const availableEntry = balance.available.find((b) => b.currency === FALLBACK_CURRENCY) ?? balance.available[0];
+    const pendingEntry = balance.pending.find((b) => b.currency === FALLBACK_CURRENCY) ?? balance.pending[0];
+    const available = (availableEntry?.amount ?? 0) / 100;
+    const pending = (pendingEntry?.amount ?? 0) / 100;
+    const currency = availableEntry?.currency ?? FALLBACK_CURRENCY;
     const last = payouts.data[0];
 
     return {

--- a/apps/web/src/lib/platform/stripe-billing.ts
+++ b/apps/web/src/lib/platform/stripe-billing.ts
@@ -1,0 +1,78 @@
+import { cache } from "react";
+import { unstable_cache } from "next/cache";
+import { getStripe } from "@/lib/stripe";
+
+export type TenantBilling = {
+  tenantId: string;
+  accountId: string | null;
+  chargesEnabled: boolean | null;
+  payoutsEnabled: boolean | null;
+  balance: { available: number; pending: number; currency: string } | null;
+  lastPayout: { date: Date; amount: number; currency: string } | null;
+  gross30d: number;
+  net30d: number;
+  error: string | null;
+};
+
+async function fetchTenantBilling(tenantId: string, accountId: string | null): Promise<TenantBilling> {
+  if (!accountId) {
+    return {
+      tenantId, accountId: null, chargesEnabled: null, payoutsEnabled: null,
+      balance: null, lastPayout: null, gross30d: 0, net30d: 0, error: null,
+    };
+  }
+  try {
+    const stripe = getStripe();
+    const stripeOpts = { stripeAccount: accountId };
+    const [acct, balance, payouts, txs] = await Promise.all([
+      stripe.accounts.retrieve(accountId),
+      stripe.balance.retrieve(undefined, stripeOpts),
+      stripe.payouts.list({ limit: 1 }, stripeOpts),
+      stripe.balanceTransactions.list(
+        {
+          created: { gte: Math.floor((Date.now() - 30 * 24 * 60 * 60 * 1000) / 1000) },
+          limit: 100,
+        },
+        stripeOpts,
+      ),
+    ]);
+
+    const available = (balance.available[0]?.amount ?? 0) / 100;
+    const pending = (balance.pending[0]?.amount ?? 0) / 100;
+    const currency = balance.available[0]?.currency ?? "aud";
+    const last = payouts.data[0];
+
+    let gross = 0;
+    let net = 0;
+    for (const t of txs.data) {
+      if (t.type === "charge") gross += t.amount / 100;
+      net += t.net / 100;
+    }
+
+    return {
+      tenantId,
+      accountId,
+      chargesEnabled: acct.charges_enabled,
+      payoutsEnabled: acct.payouts_enabled,
+      balance: { available, pending, currency },
+      lastPayout: last ? { date: new Date(last.arrival_date * 1000), amount: last.amount / 100, currency: last.currency } : null,
+      gross30d: gross,
+      net30d: net,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      tenantId, accountId, chargesEnabled: null, payoutsEnabled: null,
+      balance: null, lastPayout: null, gross30d: 0, net30d: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export const getTenantBilling = cache((tenantId: string, accountId: string | null) =>
+  unstable_cache(
+    () => fetchTenantBilling(tenantId, accountId),
+    [`tenant-billing:${tenantId}`],
+    { revalidate: 300, tags: ["platform-billing"] },
+  )()
+);

--- a/apps/web/src/lib/platform/stripe-billing.ts
+++ b/apps/web/src/lib/platform/stripe-billing.ts
@@ -18,6 +18,30 @@ export type TenantBilling = {
 export const PLATFORM_BILLING_TAG = "platform-billing";
 export const tenantBillingTag = (tenantId: string) => `platform-billing:${tenantId}`;
 
+// AUD is the platform-wide currency. Stripe Connect accounts are AU-only; KPI
+// aggregation assumes a single currency. Revisit if non-AU tenants are added.
+export const PLATFORM_CURRENCY = "AUD";
+
+// Cap parallel Stripe fan-out so a cold-cache load of N tenants doesn't burst
+// past Stripe's 100 req/s limit (each tenant fires 4 calls + paginated tx list).
+export async function mapTenantBilling<T>(
+  items: T[],
+  fn: (item: T) => Promise<TenantBilling>,
+  concurrency = 5,
+): Promise<TenantBilling[]> {
+  const out = new Array<TenantBilling>(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      out[i] = await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
 async function fetchTenantBilling(tenantId: string, accountId: string | null): Promise<TenantBilling> {
   if (!accountId) {
     return {


### PR DESCRIPTION
## Summary

Phase 6 of the platform-portal initiative — `/platform/billing` shows connected-account state, balances, and 30d gross/net per tenant, fronted by a 5-min cache that invalidates on `account.updated` webhook.

- **Cached Stripe lookup** (`lib/platform/stripe-billing.ts`) — `getTenantBilling(id, accountId)` parallel-fetches `accounts.retrieve`, `balance.retrieve`, `payouts.list`, `balanceTransactions.list`. Wrapped in React `cache()` for in-request dedup + `unstable_cache` (5-min TTL, tag `"platform-billing"`) for cross-request persistence. `getStripe()` is called inside the fetcher (not at module top) per AGENTS.md.
- **Webhook invalidation** — `account.updated` branch in `api/stripe/webhook/route.ts` calls `revalidateTag("platform-billing", "max")` to flush all tenant entries the moment Stripe reports a state change.
- **Billing page** — RSC fetches all tenants, runs `Promise.all(getTenantBilling(...))`, computes 4 KPIs (connected count, total balance, payouts 30d, gross 30d). Client `<BillingTable>` renders one row per tenant with charges/payouts ✓-flags, balance, 30d gross, last payout, and Stripe-dashboard link. Per-row error fields render inline; one tenant's API failure doesn't crash the page.

## What's in this PR
| Area | Files |
|---|---|
| Cache module | `lib/platform/stripe-billing.ts` |
| Webhook | `app/api/stripe/webhook/route.ts` (+2 lines: import + revalidateTag in account.updated branch) |
| Page | `app/platform/billing/page.tsx` |
| Table | `app/platform/billing/billing-table.tsx` |

## Notes on Next.js 16 \`revalidateTag\`

The TS signature now requires a second \`profile\` arg. We use \`\"max\"\` because the source explicitly handles it as the immediate-expiration path; \`\"seconds\"\` would instead apply a 60s TTL profile to the cache entry, which isn't what we want for webhook-driven invalidation.

## Plan + spec
- Plan: \`docs/superpowers/plans/2026-05-09-platform-portal.md\` Phase 6 (lines 3012-3271)
- Spec: \`docs/superpowers/specs/2026-05-09-platform-portal-design.md\` v5
- Depends on: PR C (portal scaffold #15). PR D (#16) NOT required.

## Test plan
- [ ] \`/platform/billing\` — table renders with NSBH/RGSH balances + payouts, 4 KPI tiles
- [ ] Tenants with no \`stripeAccountId\` render \"—\" cells, no crash
- [ ] In Stripe test mode: \`stripe trigger account.updated\` — refresh \`/platform/billing\` within seconds, charges-enabled flag updates without waiting for the 5-min TTL
- [ ] If a Stripe call fails for one tenant (e.g., revoked account), that row shows the error message; other rows render normally
- [ ] Stripe dashboard link opens \`https://dashboard.stripe.com/connect/accounts/{id}\` in a new tab
- [ ] \`pnpm check-types:web\` clean