### PR TITLE
feat(platform): branding editor drawer for tenant detail page

### DIFF
--- a/apps/web/src/app/platform/tenants/[id]/actions.ts
+++ b/apps/web/src/app/platform/tenants/[id]/actions.ts
@@ -3,13 +3,7 @@ import { db } from "@/db";
 import { tenants } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
-import { getSessionUser, isPlatformAdminEmail } from "@/lib/auth/authorization";
-
-async function requirePlatformAdmin() {
-  const user = await getSessionUser();
-  if (!user || !isPlatformAdminEmail(user.email)) throw new Error("Forbidden");
-  return user;
-}
+import { requirePlatformAdmin } from "@/lib/platform/action-helpers";
 
 export async function togglePublicListing(id: string, on: boolean) {
   await requirePlatformAdmin();

--- a/apps/web/src/app/platform/tenants/[id]/actions.ts
+++ b/apps/web/src/app/platform/tenants/[id]/actions.ts
@@ -61,27 +61,43 @@ export async function resyncStripeStatus(id: string) {
   return { ok: true as const };
 }
 
-export async function editTenantBranding(
-  id: string,
-  input: unknown,
-  changedFields: string[],
-) {
+export async function editTenantBranding(id: string, input: unknown) {
   const user = await requirePlatformAdmin();
   const parsed = parseInput(brandingEditSchema, input);
   if (!parsed.ok) return { ok: false as const, error: parsed.error };
 
-  const [updated] = await db
+  const [existing] = await db
+    .select({
+      logoUrl: tenants.logoUrl,
+      accent: tenants.accent,
+      motto: tenants.motto,
+      status: tenants.platformApprovalStatus,
+    })
+    .from(tenants)
+    .where(eq(tenants.id, id))
+    .limit(1);
+
+  if (!existing) return { ok: false as const, error: "Tenant not found" };
+
+  const nextMotto = parsed.data.motto ?? null;
+  const changedFields: string[] = [];
+  if (parsed.data.logoUrl !== existing.logoUrl) changedFields.push("logoUrl");
+  if (parsed.data.accent.toLowerCase() !== existing.accent.toLowerCase()) {
+    changedFields.push("accent");
+  }
+  if ((nextMotto ?? "") !== (existing.motto ?? "")) changedFields.push("motto");
+
+  if (changedFields.length === 0) return { ok: true as const };
+
+  await db
     .update(tenants)
     .set({
       logoUrl: parsed.data.logoUrl,
       accent: parsed.data.accent,
-      motto: parsed.data.motto ?? null,
+      motto: nextMotto,
       updatedAt: new Date(),
     })
-    .where(eq(tenants.id, id))
-    .returning({ id: tenants.id, status: tenants.platformApprovalStatus });
-
-  if (!updated) return { ok: false as const, error: "Tenant not found" };
+    .where(eq(tenants.id, id));
 
   await serverCapture(user.email, "platform_branding_edited", {
     tenantId: id,
@@ -89,7 +105,7 @@ export async function editTenantBranding(
   });
 
   revalidatePath(`/platform/tenants/${id}`);
-  if (updated.status === "approved") revalidatePath(`/${id}`, "layout");
+  if (existing.status === "approved") revalidatePath(`/${id}`, "layout");
 
   return { ok: true as const };
 }

--- a/apps/web/src/app/platform/tenants/[id]/actions.ts
+++ b/apps/web/src/app/platform/tenants/[id]/actions.ts
@@ -3,7 +3,9 @@ import { db } from "@/db";
 import { tenants } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
-import { requirePlatformAdmin } from "@/lib/platform/action-helpers";
+import { requirePlatformAdmin, parseInput } from "@/lib/platform/action-helpers";
+import { brandingEditSchema } from "@/lib/platform/schema";
+import { serverCapture } from "@/lib/analytics/server";
 
 export async function togglePublicListing(id: string, on: boolean) {
   await requirePlatformAdmin();
@@ -56,5 +58,38 @@ export async function resyncStripeStatus(id: string) {
     stripePayoutsEnabled: !!acct.payouts_enabled,
   });
   revalidatePath(`/platform/tenants/${id}`);
+  return { ok: true as const };
+}
+
+export async function editTenantBranding(
+  id: string,
+  input: unknown,
+  changedFields: string[],
+) {
+  const user = await requirePlatformAdmin();
+  const parsed = parseInput(brandingEditSchema, input);
+  if (!parsed.ok) return { ok: false as const, error: parsed.error };
+
+  const [updated] = await db
+    .update(tenants)
+    .set({
+      logoUrl: parsed.data.logoUrl,
+      accent: parsed.data.accent,
+      motto: parsed.data.motto ?? null,
+      updatedAt: new Date(),
+    })
+    .where(eq(tenants.id, id))
+    .returning({ id: tenants.id, status: tenants.platformApprovalStatus });
+
+  if (!updated) return { ok: false as const, error: "Tenant not found" };
+
+  await serverCapture(user.email, "platform_branding_edited", {
+    tenantId: id,
+    changedFields,
+  });
+
+  revalidatePath(`/platform/tenants/${id}`);
+  if (updated.status === "approved") revalidatePath(`/${id}`, "layout");
+
   return { ok: true as const };
 }

--- a/apps/web/src/app/platform/tenants/[id]/cards/branding-card.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/cards/branding-card.tsx
@@ -2,10 +2,8 @@
 import { useEffect, useState, useTransition } from "react";
 import { Crest } from "@/components/crest";
 import { togglePublicListing } from "../actions";
-import type { tenants } from "@/db/schema";
+import type { TenantRow } from "@/db/schema";
 import { BrandingEditDrawer } from "./branding-edit-drawer";
-
-type TenantRow = typeof tenants.$inferSelect;
 
 export function BrandingCard({ tenant }: { tenant: TenantRow }) {
   const [listed, setListed] = useState(tenant.isPubliclyListed);

--- a/apps/web/src/app/platform/tenants/[id]/cards/branding-card.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/cards/branding-card.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useTransition } from "react";
 import { Crest } from "@/components/crest";
 import { togglePublicListing } from "../actions";
 import type { tenants } from "@/db/schema";
+import { BrandingEditDrawer } from "./branding-edit-drawer";
 
 type TenantRow = typeof tenants.$inferSelect;
 
@@ -10,6 +11,7 @@ export function BrandingCard({ tenant }: { tenant: TenantRow }) {
   const [listed, setListed] = useState(tenant.isPubliclyListed);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const [editing, setEditing] = useState(false);
 
   // Resync local state when the RSC re-renders with a fresh tenant prop
   // (e.g. after revalidatePath from any sibling action).
@@ -31,49 +33,62 @@ export function BrandingCard({ tenant }: { tenant: TenantRow }) {
   };
 
   return (
-    <section className="bg-paper rounded-[10px] border border-rule p-5">
-      <header className="flex items-start justify-between mb-4">
-        <h2 className="font-serif text-lg font-semibold">Branding</h2>
-      </header>
+    <>
+      <section className="bg-paper rounded-[10px] border border-rule p-5">
+        <header className="flex items-start justify-between mb-4">
+          <h2 className="font-serif text-lg font-semibold">Branding</h2>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-sm text-ink-dim hover:text-ink underline"
+          >
+            Edit
+          </button>
+        </header>
 
-      <div className="flex items-center gap-4">
-        {tenant.logoUrl ? (
-          <img src={tenant.logoUrl} alt="" className="w-14 h-14 rounded-md object-cover border border-rule" />
-        ) : (
-          <Crest tenant={{ id: tenant.id, accent: tenant.accent, short: tenant.short }} size={56} />
-        )}
-        <div>
-          <div className="font-serif text-base font-semibold">{tenant.name}</div>
-          <div className="text-sm text-ink-dim">{tenant.short} · {tenant.accent}</div>
-          {tenant.motto ? <div className="text-xs text-ink-dim italic mt-0.5">{tenant.motto}</div> : null}
-        </div>
-      </div>
-
-      <div className="mt-5 pt-4 border-t border-rule flex items-center justify-between">
-        <div>
-          <div className="text-sm font-semibold">Publicly listed</div>
-          <div className="text-xs text-ink-dim mt-0.5">
-            When on, this tenant appears on the public school picker at uniformorder.online.
+        <div className="flex items-center gap-4">
+          {tenant.logoUrl ? (
+            <img src={tenant.logoUrl} alt="" className="w-14 h-14 rounded-md object-cover border border-rule" />
+          ) : (
+            <Crest tenant={{ id: tenant.id, accent: tenant.accent, short: tenant.short }} size={56} />
+          )}
+          <div>
+            <div className="font-serif text-base font-semibold">{tenant.name}</div>
+            <div className="text-sm text-ink-dim">{tenant.short} · {tenant.accent}</div>
+            {tenant.motto ? <div className="text-xs text-ink-dim italic mt-0.5">{tenant.motto}</div> : null}
           </div>
-          {error ? <div className="text-xs text-alert mt-1">{error}</div> : null}
         </div>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={listed}
-          disabled={pending}
-          onClick={() => onToggle(!listed)}
-          className={`relative inline-flex h-6 w-11 items-center rounded-full transition ${
-            listed ? "bg-navy-deep" : "bg-rule"
-          } ${pending ? "opacity-60" : ""}`}
-        >
-          <span
-            className={`inline-block h-5 w-5 transform rounded-full bg-white transition ${
-              listed ? "translate-x-5" : "translate-x-0.5"
-            }`}
-          />
-        </button>
-      </div>
-    </section>
+
+        <div className="mt-5 pt-4 border-t border-rule flex items-center justify-between">
+          <div>
+            <div className="text-sm font-semibold">Publicly listed</div>
+            <div className="text-xs text-ink-dim mt-0.5">
+              When on, this tenant appears on the public school picker at uniformorder.online.
+            </div>
+            {error ? <div className="text-xs text-alert mt-1">{error}</div> : null}
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={listed}
+            disabled={pending}
+            onClick={() => onToggle(!listed)}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition ${
+              listed ? "bg-navy-deep" : "bg-rule"
+            } ${pending ? "opacity-60" : ""}`}
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white transition ${
+                listed ? "translate-x-5" : "translate-x-0.5"
+              }`}
+            />
+          </button>
+        </div>
+      </section>
+
+      {editing ? (
+        <BrandingEditDrawer tenant={tenant} onClose={() => setEditing(false)} />
+      ) : null}
+    </>
   );
 }

--- a/apps/web/src/app/platform/tenants/[id]/cards/branding-edit-drawer.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/cards/branding-edit-drawer.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { UploadButton } from "@/components/uploadthing";
+import { Crest } from "@/components/crest";
+import { AccentPicker } from "@/components/platform/accent-picker";
+import { BrandingPreview } from "@/components/platform/branding-preview";
+import { editTenantBranding } from "../actions";
+import type { TenantRow } from "@/db/schema";
+
+export function BrandingEditDrawer({
+  tenant,
+  onClose,
+}: {
+  tenant: TenantRow;
+  onClose: () => void;
+}) {
+  const initial = {
+    logoUrl: tenant.logoUrl,
+    accent: tenant.accent,
+    motto: tenant.motto ?? "",
+  };
+
+  const [logoUrl, setLogoUrl] = useState<string | null>(initial.logoUrl);
+  const [accent, setAccent] = useState(initial.accent);
+  const [motto, setMotto] = useState<string>(initial.motto);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+
+  // Esc-to-close + lock body scroll while drawer is mounted.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [onClose]);
+
+  // Whitespace-only motto edits are intentionally treated as no-op
+  // (`.trim()` both sides) so we don't burn a DB write or PostHog event.
+  function diffChanged(): string[] {
+    const out: string[] = [];
+    if (logoUrl !== initial.logoUrl) out.push("logoUrl");
+    if (accent.toLowerCase() !== initial.accent.toLowerCase()) out.push("accent");
+    if (motto.trim() !== initial.motto.trim()) out.push("motto");
+    return out;
+  }
+
+  async function save() {
+    setError(null);
+    const changed = diffChanged();
+    if (changed.length === 0) {
+      onClose();
+      return;
+    }
+    setPending(true);
+    const r = await editTenantBranding(
+      tenant.id,
+      {
+        logoUrl,
+        accent,
+        motto: motto.trim() === "" ? undefined : motto.trim(),
+      },
+      changed,
+    );
+    setPending(false);
+    if (!r.ok) {
+      setError(r.error);
+      return;
+    }
+    onClose();
+  }
+
+  const saveDisabled = pending || isUploading;
+
+  return (
+    <div className="fixed inset-0 z-40">
+      {/* scrim */}
+      <button
+        type="button"
+        aria-label="Close drawer"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/40"
+      />
+      {/* panel */}
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="Edit branding"
+        className="absolute right-0 top-0 h-full w-full max-w-[720px] bg-paper shadow-xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-5 py-4 border-b border-rule">
+          <h2 className="font-serif text-lg font-semibold">Edit branding</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="text-ink-dim hover:text-ink text-xl leading-none"
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 grid grid-cols-1 md:grid-cols-[1fr_320px] gap-5">
+          {/* form */}
+          <div className="space-y-5">
+            <div>
+              <div className="text-[11px] font-bold uppercase tracking-[0.6px] mb-2">School logo</div>
+              <div className="flex items-center gap-3.5">
+                <div className="w-14 h-14 rounded-md border border-rule bg-parchment flex items-center justify-center overflow-hidden">
+                  {logoUrl ? (
+                    <img src={logoUrl} alt="" className="max-w-full max-h-full object-contain" />
+                  ) : (
+                    <Crest tenant={{ id: tenant.id, accent, short: tenant.short }} size={48} ring={false} />
+                  )}
+                </div>
+                <UploadButton
+                  endpoint="tenantLogo"
+                  input={{ tenantId: tenant.id }}
+                  onUploadBegin={() => {
+                    setError(null);
+                    setIsUploading(true);
+                  }}
+                  onClientUploadComplete={(res) => {
+                    setIsUploading(false);
+                    const url = res?.[0]?.url ?? null;
+                    if (url) setLogoUrl(url);
+                  }}
+                  onUploadError={(e) => {
+                    setIsUploading(false);
+                    setError(e.message);
+                  }}
+                />
+                {logoUrl ? (
+                  <button
+                    type="button"
+                    onClick={() => setLogoUrl(null)}
+                    className="text-xs text-ink-dim hover:text-ink underline"
+                  >
+                    Remove
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            <div>
+              <div className="text-[11px] font-bold uppercase tracking-[0.6px] mb-2">Accent colour</div>
+              <AccentPicker value={accent} onChange={setAccent} />
+            </div>
+
+            <div>
+              <label
+                htmlFor="motto-input"
+                className="text-[11px] font-bold uppercase tracking-[0.6px] mb-2 block"
+              >
+                Motto <span className="font-normal opacity-60">(optional)</span>
+              </label>
+              <input
+                id="motto-input"
+                type="text"
+                maxLength={200}
+                value={motto}
+                onChange={(e) => setMotto(e.target.value)}
+                className="w-full h-9 px-2 border border-rule rounded-md text-sm"
+                placeholder="e.g. Veritas et Virtus"
+              />
+            </div>
+          </div>
+
+          {/* preview */}
+          <BrandingPreview
+            tenantName={tenant.name}
+            short={tenant.short}
+            accent={accent}
+            logoUrl={logoUrl}
+            motto={motto.trim()}
+          />
+        </div>
+
+        <footer className="px-5 py-4 border-t border-rule flex flex-col gap-2">
+          {error ? <div className="text-sm text-alert">{error}</div> : null}
+          <div className="flex gap-2 justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="h-10 px-4 rounded-md border border-rule text-ink"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={saveDisabled}
+              className="h-10 px-5 rounded-md bg-navy-deep text-white font-semibold disabled:opacity-60"
+            >
+              {pending ? "Saving…" : isUploading ? "Uploading…" : "Save changes"}
+            </button>
+          </div>
+        </footer>
+      </aside>
+    </div>
+  );
+}

--- a/apps/web/src/app/platform/tenants/[id]/cards/branding-edit-drawer.tsx
+++ b/apps/web/src/app/platform/tenants/[id]/cards/branding-edit-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { UploadButton } from "@/components/uploadthing";
 import { Crest } from "@/components/crest";
 import { AccentPicker } from "@/components/platform/accent-picker";
@@ -15,58 +15,44 @@ export function BrandingEditDrawer({
   tenant: TenantRow;
   onClose: () => void;
 }) {
-  const initial = {
-    logoUrl: tenant.logoUrl,
-    accent: tenant.accent,
-    motto: tenant.motto ?? "",
-  };
-
-  const [logoUrl, setLogoUrl] = useState<string | null>(initial.logoUrl);
-  const [accent, setAccent] = useState(initial.accent);
-  const [motto, setMotto] = useState<string>(initial.motto);
+  const [logoUrl, setLogoUrl] = useState<string | null>(tenant.logoUrl);
+  const [accent, setAccent] = useState(tenant.accent);
+  const [motto, setMotto] = useState<string>(tenant.motto ?? "");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
 
+  // Stable refs so the keydown listener isn't re-registered on every parent
+  // render (parents typically pass an inline `() => setEditing(false)`), and
+  // so async post-await setters can no-op once the drawer has unmounted.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const mountedRef = useRef(true);
+
   // Esc-to-close + lock body scroll while drawer is mounted.
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCloseRef.current();
+    };
     window.addEventListener("keydown", onKey);
     const prevOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
       window.removeEventListener("keydown", onKey);
       document.body.style.overflow = prevOverflow;
+      mountedRef.current = false;
     };
-  }, [onClose]);
-
-  // Whitespace-only motto edits are intentionally treated as no-op
-  // (`.trim()` both sides) so we don't burn a DB write or PostHog event.
-  function diffChanged(): string[] {
-    const out: string[] = [];
-    if (logoUrl !== initial.logoUrl) out.push("logoUrl");
-    if (accent.toLowerCase() !== initial.accent.toLowerCase()) out.push("accent");
-    if (motto.trim() !== initial.motto.trim()) out.push("motto");
-    return out;
-  }
+  }, []);
 
   async function save() {
     setError(null);
-    const changed = diffChanged();
-    if (changed.length === 0) {
-      onClose();
-      return;
-    }
     setPending(true);
-    const r = await editTenantBranding(
-      tenant.id,
-      {
-        logoUrl,
-        accent,
-        motto: motto.trim() === "" ? undefined : motto.trim(),
-      },
-      changed,
-    );
+    const r = await editTenantBranding(tenant.id, {
+      logoUrl,
+      accent,
+      motto: motto.trim() === "" ? undefined : motto.trim(),
+    });
+    if (!mountedRef.current) return;
     setPending(false);
     if (!r.ok) {
       setError(r.error);
@@ -84,7 +70,8 @@ export function BrandingEditDrawer({
         type="button"
         aria-label="Close drawer"
         onClick={onClose}
-        className="absolute inset-0 bg-black/40"
+        disabled={pending}
+        className="absolute inset-0 bg-black/40 disabled:cursor-not-allowed"
       />
       {/* panel */}
       <aside
@@ -98,8 +85,9 @@ export function BrandingEditDrawer({
           <button
             type="button"
             onClick={onClose}
+            disabled={pending}
             aria-label="Close"
-            className="text-ink-dim hover:text-ink text-xl leading-none"
+            className="text-ink-dim hover:text-ink text-xl leading-none disabled:opacity-40"
           >
             ×
           </button>
@@ -187,7 +175,8 @@ export function BrandingEditDrawer({
             <button
               type="button"
               onClick={onClose}
-              className="h-10 px-4 rounded-md border border-rule text-ink"
+              disabled={pending}
+              className="h-10 px-4 rounded-md border border-rule text-ink disabled:opacity-60"
             >
               Cancel
             </button>

--- a/apps/web/src/app/platform/tenants/new/actions.ts
+++ b/apps/web/src/app/platform/tenants/new/actions.ts
@@ -3,31 +3,12 @@ import { db } from "@/db";
 import { tenants, catalogItems } from "@/db/schema";
 import { eq, count } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
-import { getSessionUser, isPlatformAdminEmail } from "@/lib/auth/authorization";
 import { step1Schema, step2Schema, step4Schema } from "@/lib/platform/schema";
 import { getStripe } from "@/lib/stripe";
 import { updateTenantStripe } from "@/db/queries";
 import { cloneCatalogFromTenantUnsafe, type CloneResult } from "@/lib/platform/clone-catalog";
 import { serverCapture } from "@/lib/analytics/server";
-import type { ZodSchema } from "zod";
-
-async function requirePlatformAdmin() {
-  const user = await getSessionUser();
-  if (!user || !isPlatformAdminEmail(user.email)) {
-    throw new Error("Forbidden");
-  }
-  return user;
-}
-
-function parseInput<T>(schema: ZodSchema<T>, input: unknown):
-  | { ok: true; data: T }
-  | { ok: false; error: string } {
-  const r = schema.safeParse(input);
-  if (r.success) return { ok: true, data: r.data };
-  const first = r.error.issues[0];
-  const path = first?.path.join(".");
-  return { ok: false, error: path ? `${path}: ${first.message}` : (first?.message ?? "Invalid input") };
-}
+import { requirePlatformAdmin, parseInput } from "@/lib/platform/action-helpers";
 
 export async function createTenantDraft(input: unknown) {
   const user = await requirePlatformAdmin();

--- a/apps/web/src/app/platform/tenants/new/steps/step-2-branding.tsx
+++ b/apps/web/src/app/platform/tenants/new/steps/step-2-branding.tsx
@@ -3,8 +3,7 @@ import { useState } from "react";
 import { UploadButton } from "@/components/uploadthing";
 import type { TenantRow } from "@/db/schema";
 import { updateTenantBranding } from "../actions";
-
-const PRESETS = ["#7A1F2B", "#0F4C5C", "#2F5D50", "#1F3A6E", "#4A2238", "#7A5418", "#0E2A47"];
+import { AccentPicker } from "@/components/platform/accent-picker";
 
 export function Step2Branding({
   tenant,
@@ -64,23 +63,7 @@ export function Step2Branding({
 
       <div>
         <div className="text-[11px] font-bold uppercase tracking-[0.6px] mb-2">Accent colour</div>
-        <div className="flex gap-2.5 items-center">
-          {PRESETS.map((c) => (
-            <button
-              key={c}
-              type="button"
-              onClick={() => onAccentChange(c)}
-              className={`w-11 h-11 rounded-full border ${accent === c ? "border-ink ring-2 ring-white" : "border-rule"}`}
-              style={{ background: c }}
-            />
-          ))}
-          <input
-            type="text"
-            value={accent}
-            onChange={(e) => onAccentChange(e.target.value)}
-            className="ml-2 h-9 w-28 px-2 border border-rule rounded-md text-xs font-mono"
-          />
-        </div>
+        <AccentPicker value={accent} onChange={onAccentChange} />
       </div>
 
       {error && <div className="text-sm text-red-700">{error}</div>}

--- a/apps/web/src/components/platform/accent-picker.tsx
+++ b/apps/web/src/components/platform/accent-picker.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+export const ACCENT_PRESETS = [
+  "#7A1F2B",
+  "#0F4C5C",
+  "#2F5D50",
+  "#1F3A6E",
+  "#4A2238",
+  "#7A5418",
+  "#0E2A47",
+] as const;
+
+export function AccentPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex gap-2.5 items-center">
+      {ACCENT_PRESETS.map((c) => (
+        <button
+          key={c}
+          type="button"
+          aria-label={`Select accent ${c}`}
+          onClick={() => onChange(c)}
+          className={`w-11 h-11 rounded-full border ${
+            value.toLowerCase() === c.toLowerCase()
+              ? "border-ink ring-2 ring-white"
+              : "border-rule"
+          }`}
+          style={{ background: c }}
+        />
+      ))}
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="ml-2 h-9 w-28 px-2 border border-rule rounded-md text-xs font-mono"
+        aria-label="Custom hex colour"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/platform/branding-preview.tsx
+++ b/apps/web/src/components/platform/branding-preview.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Crest } from "@/components/crest";
+
+const STUB_ITEMS = [
+  { name: "Year 7 Blazer", price: "$185" },
+  { name: "School Tie", price: "$24" },
+];
+
+export function BrandingPreview({
+  tenantName,
+  short,
+  accent,
+  logoUrl,
+  motto,
+}: {
+  tenantName: string;
+  short: string;
+  accent: string;
+  logoUrl: string | null;
+  motto: string;
+}) {
+  return (
+    <div className="w-full max-w-[300px]">
+      <div className="text-[11px] font-bold uppercase tracking-[0.6px] mb-2 text-ink-dim">
+        Live preview · parent shop
+      </div>
+      <div className="rounded-[24px] border-[8px] border-[#222] bg-parchment overflow-hidden">
+        {/* header */}
+        <div
+          className="px-3 py-2.5 flex items-center gap-2 text-white"
+          style={{ background: accent }}
+        >
+          {logoUrl ? (
+            <img
+              src={logoUrl}
+              alt=""
+              className="w-6 h-6 rounded-sm bg-white object-contain"
+            />
+          ) : (
+            <Crest tenant={{ id: "preview", accent, short }} size={24} ring={false} />
+          )}
+          <div className="font-serif text-sm font-semibold truncate">{tenantName}</div>
+        </div>
+
+        {/* body */}
+        <div className="px-3 py-3 text-[11px] text-ink">
+          {motto ? (
+            <div className="italic mb-2" style={{ color: accent }}>
+              {motto}
+            </div>
+          ) : null}
+          {STUB_ITEMS.map((it) => (
+            <div
+              key={it.name}
+              className="bg-paper border border-rule rounded-md px-2 py-1.5 mb-1.5 flex justify-between"
+            >
+              <span>{it.name}</span>
+              <span className="tnum">{it.price}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <p className="text-[11px] text-ink-dim mt-1.5">Updates as you edit.</p>
+    </div>
+  );
+}

--- a/apps/web/src/lib/platform/action-helpers.ts
+++ b/apps/web/src/lib/platform/action-helpers.ts
@@ -1,0 +1,24 @@
+import type { ZodSchema } from "zod";
+import { getSessionUser, isPlatformAdminEmail } from "@/lib/auth/authorization";
+
+export async function requirePlatformAdmin() {
+  const user = await getSessionUser();
+  if (!user || !isPlatformAdminEmail(user.email)) {
+    throw new Error("Forbidden");
+  }
+  return user;
+}
+
+export function parseInput<T>(
+  schema: ZodSchema<T>,
+  input: unknown,
+): { ok: true; data: T } | { ok: false; error: string } {
+  const r = schema.safeParse(input);
+  if (r.success) return { ok: true, data: r.data };
+  const first = r.error.issues[0];
+  const path = first?.path.join(".");
+  return {
+    ok: false,
+    error: path ? `${path}: ${first.message}` : (first?.message ?? "Invalid input"),
+  };
+}

--- a/apps/web/src/lib/platform/schema.ts
+++ b/apps/web/src/lib/platform/schema.ts
@@ -22,6 +22,12 @@ export const step2Schema = z.object({
   accent: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
 });
 
+export const brandingEditSchema = z.object({
+  logoUrl: z.string().url().nullable(),
+  accent: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
+  motto: z.string().max(200).optional(),
+});
+
 export const step4Schema = z.object({
   shopEmail: z.string().email(),
   shopHours: z.string().max(200).optional(),
@@ -30,4 +36,5 @@ export const step4Schema = z.object({
 
 export type Step1 = z.infer<typeof step1Schema>;
 export type Step2 = z.infer<typeof step2Schema>;
+export type BrandingEdit = z.infer<typeof brandingEditSchema>;
 export type Step4 = z.infer<typeof step4Schema>;


### PR DESCRIPTION
## Summary
- Adds drawer-based branding editor to `/platform/tenants/[id]` with live `MobileShell` preview — closes `docs/remaining_work.md` §2.2.
- New `editTenantBranding` server action covers `logoUrl + accent + motto`, revalidates `/platform/tenants/[id]` and `/[id]` layout (when approved), captures `platform_branding_edited` PostHog event with `changedFields`.
- Extracts `requirePlatformAdmin` + `parseInput` to `lib/platform/action-helpers.ts` so wizard and editor share one admin gate; extracts `AccentPicker` and `BrandingPreview` to `components/platform/` (wizard step-2 now consumes the shared `AccentPicker`).

## Spec & plan
- Spec: `docs/superpowers/specs/2026-05-10-platform-portal-branding-editor-design.md`
- Plan: `docs/superpowers/plans/2026-05-10-platform-portal-branding-editor.md`

## Notes
- `step2Schema` (wizard) intentionally unchanged — `motto` lives in the new `brandingEditSchema` only, so wizard saves don't silently null motto.
- Drawer a11y: `role="dialog"`, `aria-modal="true"`, Esc-to-close, body-scroll-lock. Full focus trap and success toast deferred (no toast primitive in repo yet — see "Out-of-plan follow-ups" in the plan).
- Upload race fix: Save button is disabled while UploadThing is uploading.

## Test plan
- [ ] Sign in as platform admin (`PLATFORM_ADMIN_EMAILS`), open `/platform/tenants/nsbh`, click Edit on Branding card.
- [ ] Change accent (preset + custom hex) → preview updates → Save → `/nsbh` parent shop reflects new colour without manual reload (revalidation gate).
- [ ] Upload logo → preview swaps from Crest to image → Save → `/nsbh` header shows new logo. Remove → reverts to Crest.
- [ ] Edit + clear motto → confirm `tenant.motto` is `null` in DB (not empty string).
- [ ] Invalid hex via DevTools (`#zzz`) → inline error above footer, no DB write.
- [ ] Upload race: pick large image → mash Save → button shows "Uploading…" disabled until upload resolves.
- [ ] No-op save (open, no edits, Save) → drawer closes silently, no DB write, no PostHog event.
- [ ] PostHog: `platform_branding_edited` events land with `tenantId` and a sensible `changedFields` array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)