### PR TITLE
feat(orders): batch print pick slips (§3.7 code half)

### DIFF
--- a/apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx
@@ -2,40 +2,12 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getOrderById, getOrderRefunds, getTotalRefunded, getTenant, toTenantBrand } from "@/db/queries";
 import { AdminTopbar } from "@/components/admin-shell";
-import { Chip } from "@/components/chip";
 import { DoubleRule } from "@/components/double-rule";
-import { Crest } from "@/components/crest";
 import { OrderDetailActions } from "./order-detail-actions";
 import { PrintButton } from "@/components/print-button";
 import { loadOrderActivity } from "@/lib/audit/load-order-activity";
 import { OrderActivityStrip } from "@/components/admin/order-activity-strip";
-
-function Barcode({ orderId }: { orderId: string }) {
-  const widths = [3, 1, 2, 1, 1, 3, 1, 2, 3, 1, 1, 2, 3, 2, 1, 1, 3, 1, 2, 1, 1, 3, 2, 1];
-  let x = 0;
-  return (
-    <svg width={180} height={48}>
-      {widths.map((w, i) => {
-        const fill = i % 2 === 0 ? "var(--color-ink)" : "transparent";
-        const el = (
-          <rect key={i} x={x} y={0} width={w * 2} height={36} fill={fill} />
-        );
-        x += w * 2 + 1;
-        return el;
-      })}
-      <text
-        x={0}
-        y={46}
-        fontFamily="var(--font-mono)"
-        fontSize="10"
-        fill="var(--color-ink-dim)"
-        letterSpacing="2"
-      >
-        {orderId}
-      </text>
-    </svg>
-  );
-}
+import { PickSlip, type PickSlipOrder, type PickSlipLine } from "@/components/admin/pick-slip";
 
 export default async function OrderDetailPage({
   params,
@@ -45,7 +17,6 @@ export default async function OrderDetailPage({
   if (!tenantRecord) notFound();
   const tenant = toTenantBrand(tenantRecord);
 
-  // Fetch from live DB
   const order = await getOrderById(orderId);
   if (!order || order.tenantId !== tid) notFound();
 
@@ -53,25 +24,63 @@ export default async function OrderDetailPage({
   const refundedTotal = await getTotalRefunded(orderId);
   const activityRows = await loadOrderActivity(orderId);
 
-  const statusMap: Record<string, { tone: "info" | "warn" | "success" | "neutral" | "danger"; label: string }> = {
-    pending_payment: { tone: "neutral", label: "Pending payment" },
-    new: { tone: "info", label: "New" },
-    packing: { tone: "warn", label: "Packing" },
-    ready: { tone: "success", label: "Ready for pickup" },
-    collected: { tone: "neutral", label: "Collected" },
-    partially_refunded: { tone: "danger", label: "Partially refunded" },
-    refunded: { tone: "danger", label: "Refunded" },
-  };
-  const statusInfo = statusMap[order.status] ?? { tone: "neutral", label: order.status };
   const total = parseFloat(order.total);
-  const gst = parseFloat(order.gst);
-  const placedAt = order.createdAt
-    ? new Date(order.createdAt).toLocaleDateString("en-AU", {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-      })
-    : "—";
+
+  const slipOrder: PickSlipOrder = {
+    id: order.id,
+    status: order.status,
+    parentName: order.parentName,
+    parentEmail: order.parentEmail,
+    parentMobile: order.parentMobile,
+    parentNote: order.parentNote,
+    studentName: order.studentName,
+    studentYear: order.studentYear,
+    studentRoll: order.studentRoll,
+    delivery: order.delivery,
+    total: order.total,
+    gst: order.gst,
+    stripeRef: order.stripeRef,
+    createdAt: order.createdAt ? order.createdAt.toISOString() : "",
+  };
+
+  const slipLines: PickSlipLine[] = order.lines.map((line) => ({
+    itemName: line.itemName,
+    variantLabel: line.variantLabel,
+    qty: line.qty,
+    lineTotal: line.lineTotal,
+  }));
+
+  const refundsBlock = refunds.length > 0 ? (
+    <>
+      <DoubleRule />
+      <div className="mt-4">
+        <div className="text-[10.5px] uppercase tracking-[0.6px] font-bold mb-2" style={{ color: "var(--color-ink-dim)" }}>
+          Refunds
+        </div>
+        {refunds.map((refund) => (
+          <div key={refund.id} className="flex items-center justify-between py-2 border-b text-[12.5px]" style={{ borderColor: "var(--color-rule)", borderStyle: "dashed" }}>
+            <div style={{ color: "var(--color-ink)" }}>
+              {refund.reason ? refund.reason : "Refund"}
+              {refund.stripeRefundId && (
+                <span className="ml-1 text-[10px] font-mono" style={{ color: "var(--color-ink-dim)" }}>
+                  · {refund.stripeRefundId}
+                </span>
+              )}
+            </div>
+            <div className="font-semibold tnum" style={{ color: "#B23A2A" }}>
+              −${parseFloat(String(refund.amount)).toFixed(2)}
+            </div>
+          </div>
+        ))}
+        <div className="flex items-center justify-between pt-2 text-[12.5px] font-semibold">
+          <div style={{ color: "var(--color-ink)" }}>Net total</div>
+          <div className="tnum" style={{ color: "var(--color-ink)" }}>
+            ${Math.max(0, total - refundedTotal).toFixed(2)}
+          </div>
+        </div>
+      </div>
+    </>
+  ) : null;
 
   return (
     <>
@@ -106,205 +115,7 @@ export default async function OrderDetailPage({
       />
       <div className="flex-1 overflow-y-auto p-7">
         <div className="max-w-3xl mx-auto">
-          {/* Pick slip card */}
-          <div
-            className="bg-white rounded-xl border p-7"
-            style={{ borderColor: "var(--color-rule)" }}
-          >
-            {/* Print-only: parent note at top of pick slip */}
-            {order.parentNote && (
-              <div className="print:block hidden mb-4 p-3 border-2 border-black">
-                <div className="text-[11px] font-bold uppercase tracking-wide mb-1">Note from parent</div>
-                <div className="text-[13px] leading-snug">{order.parentNote}</div>
-              </div>
-            )}
-
-            {/* Header */}
-            <div className="flex items-start justify-between mb-5">
-              <div>
-                <div className="flex items-center gap-3 mb-1">
-                  <Crest tenant={tenant} size={44} />
-                  <div>
-                    <div
-                      className="type-h2 leading-tight"
-                      style={{ color: "var(--color-ink)" }}
-                    >
-                      Pick Slip
-                    </div>
-                    <div
-                      className="font-mono text-[13px] font-semibold"
-                      style={{ color: tenant.accent }}
-                    >
-                      {order.id}
-                    </div>
-                  </div>
-                </div>
-                <div className="text-[11.5px] mt-1" style={{ color: "var(--color-ink-dim)" }}>
-                  Placed {placedAt}
-                </div>
-              </div>
-              <Chip tone={statusInfo.tone}>{statusInfo.label}</Chip>
-            </div>
-
-            <DoubleRule />
-
-            {/* Details grid */}
-            <div className="grid grid-cols-3 gap-6 mt-4 mb-5">
-              <div>
-                <div className="type-label mb-1" style={{ color: "var(--color-ink-dim)" }}>
-                  Student
-                </div>
-                <div className="font-serif text-[16px] font-medium" style={{ color: "var(--color-ink)" }}>
-                  {order.studentName}
-                </div>
-                <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
-                  {order.studentYear} · Roll {order.studentRoll}
-                </div>
-              </div>
-              <div>
-                <div className="type-label mb-1" style={{ color: "var(--color-ink-dim)" }}>
-                  Parent
-                </div>
-                <div className="font-serif text-[16px] font-medium" style={{ color: "var(--color-ink)" }}>
-                  {order.parentName}
-                </div>
-                <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
-                  {order.parentMobile}
-                </div>
-              </div>
-              <div>
-                <div className="type-label mb-1" style={{ color: "var(--color-ink-dim)" }}>
-                  Fulfilment
-                </div>
-                <div className="font-serif text-[16px] font-medium" style={{ color: "var(--color-ink)" }}>
-                  {order.delivery === "pickup" ? "Pickup at office" : "Ship to home"}
-                </div>
-                <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
-                  {order.delivery === "pickup" ? "Notify when ready" : order.parentEmail}
-                </div>
-              </div>
-            </div>
-
-            <DoubleRule />
-
-            {/* Parent note callout */}
-            {order.parentNote && (
-              <div
-                className="rounded-lg border p-3 mb-4 mt-4"
-                style={{ borderColor: "var(--color-rule)", background: "var(--color-parchment)" }}
-              >
-                <div className="text-[11px] font-bold tracking-[1.2px] uppercase mb-1" style={{ color: "var(--color-gold)" }}>
-                  Note from parent
-                </div>
-                <div className="text-[13px] leading-[1.5]" style={{ color: "var(--color-ink)" }}>
-                  {order.parentNote}
-                </div>
-              </div>
-            )}
-
-            {/* Items table */}
-            <table className="w-full border-collapse text-[13px] mt-3.5" style={{ fontFamily: "var(--font-sans)" }}>
-              <thead>
-                <tr
-                  className="text-[10.5px] uppercase tracking-[0.6px]"
-                  style={{ color: "var(--color-ink-dim)" }}
-                >
-                  <th className="text-left py-2 font-bold border-b w-8" style={{ borderColor: "var(--color-rule)" }}>✓</th>
-                  <th className="text-left py-2 font-bold border-b" style={{ borderColor: "var(--color-rule)" }}>Item</th>
-                  <th className="text-left py-2 font-bold border-b w-[150px]" style={{ borderColor: "var(--color-rule)" }}>Variant</th>
-                  <th className="text-center py-2 font-bold border-b w-[50px]" style={{ borderColor: "var(--color-rule)" }}>Qty</th>
-                  <th className="text-right py-2 font-bold border-b w-[90px]" style={{ borderColor: "var(--color-rule)" }}>Amount</th>
-                </tr>
-              </thead>
-              <tbody>
-                {order.lines.map((line, i) => (
-                  <tr
-                    key={i}
-                    className="border-b"
-                    style={{ borderColor: "var(--color-rule)", borderStyle: "dashed" }}
-                  >
-                    <td className="py-3">
-                      <div
-                        className="w-[18px] h-[18px] border rounded"
-                        style={{ borderColor: "var(--color-ink)", borderWidth: 1.5 }}
-                      />
-                    </td>
-                    <td className="py-3 font-medium" style={{ color: "var(--color-ink)" }}>
-                      {line.itemName}
-                    </td>
-                    <td className="py-3 text-[12px]" style={{ color: "var(--color-ink-dim)" }}>
-                      {line.variantLabel}
-                    </td>
-                    <td className="py-3 text-center font-bold font-mono" style={{ color: "var(--color-ink)" }}>
-                      {line.qty}
-                    </td>
-                    <td className="py-3 text-right font-semibold tnum" style={{ color: "var(--color-ink)" }}>
-                      ${parseFloat(line.lineTotal).toFixed(2)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-              <tfoot>
-                <tr>
-                  <td colSpan={4} className="pt-3.5 text-right font-serif text-[16px] font-semibold" style={{ color: "var(--color-ink)" }}>
-                    Total (incl. GST)
-                  </td>
-                  <td className="pt-3.5 text-right font-serif text-[22px] font-semibold tnum" style={{ color: "var(--color-ink)" }}>
-                    ${total.toFixed(2)}
-                  </td>
-                </tr>
-                <tr>
-                  <td colSpan={4} className="text-right text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
-                    GST included
-                  </td>
-                  <td className="text-right text-[11px] tnum" style={{ color: "var(--color-ink-dim)" }}>
-                    ${gst.toFixed(2)}
-                  </td>
-                </tr>
-              </tfoot>
-            </table>
-
-            {/* Refund history */}
-            {refunds.length > 0 && (
-              <>
-                <DoubleRule />
-                <div className="mt-4">
-                  <div className="text-[10.5px] uppercase tracking-[0.6px] font-bold mb-2" style={{ color: "var(--color-ink-dim)" }}>
-                    Refunds
-                  </div>
-                  {refunds.map((refund) => (
-                    <div key={refund.id} className="flex items-center justify-between py-2 border-b text-[12.5px]" style={{ borderColor: "var(--color-rule)", borderStyle: "dashed" }}>
-                      <div style={{ color: "var(--color-ink)" }}>
-                        {refund.reason ? refund.reason : "Refund"}
-                        {refund.stripeRefundId && (
-                          <span className="ml-1 text-[10px] font-mono" style={{ color: "var(--color-ink-dim)" }}>
-                            · {refund.stripeRefundId}
-                          </span>
-                        )}
-                      </div>
-                      <div className="font-semibold tnum" style={{ color: "#B23A2A" }}>
-                        −${parseFloat(String(refund.amount)).toFixed(2)}
-                      </div>
-                    </div>
-                  ))}
-                  <div className="flex items-center justify-between pt-2 text-[12.5px] font-semibold">
-                    <div style={{ color: "var(--color-ink)" }}>Net total</div>
-                    <div className="tnum" style={{ color: "var(--color-ink)" }}>
-                      ${Math.max(0, total - refundedTotal).toFixed(2)}
-                    </div>
-                  </div>
-                </div>
-              </>
-            )}
-
-            {/* Footer */}
-            <div className="mt-6 flex items-center justify-between">
-              <div className="text-[11px] font-mono" style={{ color: "var(--color-ink-dim)" }}>
-                {order.stripeRef ? `Paid via Stripe · ${order.stripeRef}` : "Payment pending"} · {order.parentEmail}
-              </div>
-              <Barcode orderId={order.id} />
-            </div>
-          </div>
+          <PickSlip order={slipOrder} tenant={tenant} lines={slipLines} refundsSlot={refundsBlock} />
           <OrderActivityStrip rows={activityRows} />
         </div>
       </div>

--- a/apps/web/src/app/admin/[tenant]/orders/orders-board.tsx
+++ b/apps/web/src/app/admin/[tenant]/orders/orders-board.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import type { Tenant } from "@/lib/data";
 import { Chip } from "@/components/chip";
+import { PickSlip, type PickSlipOrder, type PickSlipLine } from "@/components/admin/pick-slip";
 
 type OrderStatus = "pending_payment" | "new" | "packing" | "ready" | "collected";
 
@@ -12,6 +13,7 @@ interface DbOrder {
   parentName: string;
   parentEmail: string;
   parentMobile: string;
+  parentNote: string | null;
   studentName: string;
   studentYear: string;
   studentRoll: string;
@@ -23,6 +25,7 @@ interface DbOrder {
   stripeRef: string | null;
   status: OrderStatus;
   createdAt: string;
+  lines: PickSlipLine[];
 }
 
 const COLUMNS: { id: OrderStatus; label: string; tone: string }[] = [
@@ -140,17 +143,19 @@ export function OrdersBoard({
   tenantId,
   tenant,
   searchQuery,
+  onNewCountChange,
 }: {
   tenantId: string;
   tenant: Tenant;
   searchQuery: string;
+  onNewCountChange?: (count: number) => void;
 }) {
   const [allOrders, setAllOrders] = useState<DbOrder[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchOrders = useCallback(async () => {
     try {
-      const res = await fetch(`/api/orders?tenantId=${encodeURIComponent(tenantId)}`);
+      const res = await fetch(`/api/orders?tenantId=${encodeURIComponent(tenantId)}&withLines=1`);
       if (!res.ok) {
         const data = await res.json().catch(() => null);
         throw new Error(data?.error ?? "Failed to fetch orders.");
@@ -207,6 +212,14 @@ export function OrdersBoard({
     {} as Record<OrderStatus, number>
   );
 
+  const newOrders = allOrders
+    .filter((o) => o.status === "new")
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+  useEffect(() => {
+    onNewCountChange?.(newOrders.length);
+  }, [newOrders.length, onNewCountChange]);
+
   if (loading) {
     return (
       <div className="flex-1 flex items-center justify-center">
@@ -218,7 +231,8 @@ export function OrdersBoard({
   }
 
   return (
-    <div className="flex-1 p-6 overflow-hidden">
+    <>
+    <div data-no-print className="flex-1 p-6 overflow-hidden">
       <div className="h-full grid gap-3.5" style={{ gridTemplateColumns: "repeat(4, 1fr)" }}>
         {COLUMNS.map((col) => {
           const colOrders = filtered.filter((o) => o.status === col.id);
@@ -268,5 +282,34 @@ export function OrdersBoard({
         })}
       </div>
     </div>
+    <div className="print:block hidden" aria-hidden>
+      {newOrders.map((o, idx) => {
+        const slipOrder: PickSlipOrder = {
+          id: o.id,
+          status: o.status,
+          parentName: o.parentName,
+          parentEmail: o.parentEmail,
+          parentMobile: o.parentMobile,
+          parentNote: o.parentNote,
+          studentName: o.studentName,
+          studentYear: o.studentYear,
+          studentRoll: o.studentRoll,
+          delivery: o.delivery,
+          total: o.total,
+          gst: o.gst,
+          stripeRef: o.stripeRef,
+          createdAt: o.createdAt,
+        };
+        return (
+          <div
+            key={o.id}
+            className={idx < newOrders.length - 1 ? "break-after-page" : undefined}
+          >
+            <PickSlip order={slipOrder} tenant={tenant} lines={o.lines} />
+          </div>
+        );
+      })}
+    </div>
+    </>
   );
 }

--- a/apps/web/src/app/admin/[tenant]/orders/orders-page-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/orders/orders-page-client.tsx
@@ -12,6 +12,17 @@ export function OrdersPageClient({
   tenant: Tenant;
 }) {
   const [searchQuery, setSearchQuery] = useState("");
+  const [newCount, setNewCount] = useState(0);
+
+  const handlePrint = () => {
+    if (newCount === 0) return;
+    // 25 is roughly a full-day picking run at one school. Above that we want a
+    // moment of pause before committing operator-side paper + ink.
+    if (newCount >= 25 && !window.confirm(`Print ${newCount} pick slips?`)) {
+      return;
+    }
+    window.print();
+  };
 
   return (
     <>
@@ -45,14 +56,16 @@ export function OrdersPageClient({
               )}
             </div>
             <button
-              onClick={() => window.print()}
-              className="h-9 px-3.5 text-[12.5px] font-semibold rounded-md border flex items-center gap-1.5"
+              onClick={handlePrint}
+              disabled={newCount === 0}
+              title={newCount === 0 ? "No new orders to pick" : undefined}
+              className="h-9 px-3.5 text-[12.5px] font-semibold rounded-md border flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
               style={{ borderColor: "var(--color-rule)", color: "var(--color-ink)" }}
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
                 <rect x="6" y="3" width="12" height="6" /><rect x="3" y="9" width="18" height="9" rx="1" /><rect x="6" y="15" width="12" height="6" />
               </svg>
-              Print pick slips
+              {newCount > 0 ? `Print pick slips (${newCount})` : "Print pick slips"}
             </button>
             <button
               onClick={() => {
@@ -70,7 +83,12 @@ export function OrdersPageClient({
           </div>
         }
       />
-      <OrdersBoard tenantId={tenantId} tenant={tenant} searchQuery={searchQuery} />
+      <OrdersBoard
+        tenantId={tenantId}
+        tenant={tenant}
+        searchQuery={searchQuery}
+        onNewCountChange={setNewCount}
+      />
     </>
   );
 }

--- a/apps/web/src/app/api/orders/route.ts
+++ b/apps/web/src/app/api/orders/route.ts
@@ -5,7 +5,7 @@ import {
   getOrdersByTenantAndParentEmail,
   getTenant,
 } from "@/db/queries";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { customAlphabet } from "nanoid";
 import {
   ensureParentEmailAccess,
@@ -69,6 +69,22 @@ export async function GET(req: NextRequest) {
     if (rateLimitResponse) return rateLimitResponse;
 
     const rows = await getOrdersByTenant(tenantId);
+
+    if (searchParams.get("withLines") === "1" && rows.length > 0) {
+      const ids = rows.map((r) => r.id);
+      const lines = await db
+        .select()
+        .from(orderLines)
+        .where(inArray(orderLines.orderId, ids));
+      const linesByOrderId: Record<string, typeof lines> = {};
+      for (const line of lines) {
+        (linesByOrderId[line.orderId] ??= []).push(line);
+      }
+      return NextResponse.json(
+        rows.map((r) => ({ ...r, lines: linesByOrderId[r.id] ?? [] })),
+      );
+    }
+
     return NextResponse.json(rows);
   } catch (err) {
     console.error("GET /api/orders error:", err);

--- a/apps/web/src/app/api/orders/route.ts
+++ b/apps/web/src/app/api/orders/route.ts
@@ -70,12 +70,14 @@ export async function GET(req: NextRequest) {
 
     const rows = await getOrdersByTenant(tenantId);
 
-    if (searchParams.get("withLines") === "1" && rows.length > 0) {
-      const ids = rows.map((r) => r.id);
-      const lines = await db
-        .select()
-        .from(orderLines)
-        .where(inArray(orderLines.orderId, ids));
+    if (searchParams.get("withLines") === "1") {
+      // Only the "new" bucket needs lines (it's the batch-print picking queue).
+      // Skipping historical statuses keeps the payload proportional to the
+      // active queue rather than total order count.
+      const newIds = rows.filter((r) => r.status === "new").map((r) => r.id);
+      const lines = newIds.length > 0
+        ? await db.select().from(orderLines).where(inArray(orderLines.orderId, newIds))
+        : [];
       const linesByOrderId: Record<string, typeof lines> = {};
       for (const line of lines) {
         (linesByOrderId[line.orderId] ??= []).push(line);

--- a/apps/web/src/components/admin/pick-slip.tsx
+++ b/apps/web/src/components/admin/pick-slip.tsx
@@ -1,0 +1,233 @@
+import type { ReactNode } from "react";
+import type { Tenant } from "@/lib/data";
+import { Chip } from "@/components/chip";
+import { DoubleRule } from "@/components/double-rule";
+import { Crest } from "@/components/crest";
+
+export interface PickSlipOrder {
+  id: string;
+  status: string;
+  parentName: string;
+  parentEmail: string;
+  parentMobile: string;
+  parentNote: string | null;
+  studentName: string;
+  studentYear: string;
+  studentRoll: string;
+  delivery: string;
+  total: string;
+  gst: string;
+  stripeRef: string | null;
+  createdAt: string; // ISO string — see Task 2 for the detail-page adapter
+}
+
+export interface PickSlipLine {
+  itemName: string;
+  variantLabel: string | null;
+  qty: number;
+  lineTotal: string;
+}
+
+const STATUS_MAP: Record<string, { tone: "info" | "warn" | "success" | "neutral" | "danger"; label: string }> = {
+  pending_payment: { tone: "neutral", label: "Pending payment" },
+  new: { tone: "info", label: "New" },
+  packing: { tone: "warn", label: "Packing" },
+  ready: { tone: "success", label: "Ready for pickup" },
+  collected: { tone: "neutral", label: "Collected" },
+  partially_refunded: { tone: "danger", label: "Partially refunded" },
+  refunded: { tone: "danger", label: "Refunded" },
+};
+
+function PickSlipBarcode({ orderId }: { orderId: string }) {
+  const widths = [3, 1, 2, 1, 1, 3, 1, 2, 3, 1, 1, 2, 3, 2, 1, 1, 3, 1, 2, 1, 1, 3, 2, 1];
+  let x = 0;
+  return (
+    <svg width={180} height={48}>
+      {widths.map((w, i) => {
+        const fill = i % 2 === 0 ? "var(--color-ink)" : "transparent";
+        const el = <rect key={i} x={x} y={0} width={w * 2} height={36} fill={fill} />;
+        x += w * 2 + 1;
+        return el;
+      })}
+      <text
+        x={0}
+        y={46}
+        fontFamily="var(--font-mono)"
+        fontSize="10"
+        fill="var(--color-ink-dim)"
+        letterSpacing="2"
+      >
+        {orderId}
+      </text>
+    </svg>
+  );
+}
+
+export interface PickSlipProps {
+  order: PickSlipOrder;
+  tenant: Tenant;
+  lines: PickSlipLine[];
+  /** Rendered between the items table and the footer. Detail page uses it for the refunds block; batch print passes nothing. */
+  refundsSlot?: ReactNode;
+}
+
+export function PickSlip({ order, tenant, lines, refundsSlot }: PickSlipProps) {
+  const statusInfo = STATUS_MAP[order.status] ?? { tone: "neutral" as const, label: order.status };
+  const total = parseFloat(order.total);
+  const gst = parseFloat(order.gst);
+  const placedAt = order.createdAt
+    ? new Date(order.createdAt).toLocaleDateString("en-AU", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      })
+    : "—";
+
+  return (
+    <div
+      className="bg-white rounded-xl border p-7"
+      style={{ borderColor: "var(--color-rule)" }}
+    >
+      {/* Print-only: parent note at top of pick slip */}
+      {order.parentNote && (
+        <div className="print:block hidden mb-4 p-3 border-2 border-black">
+          <div className="text-[11px] font-bold uppercase tracking-wide mb-1">Note from parent</div>
+          <div className="text-[13px] leading-snug">{order.parentNote}</div>
+        </div>
+      )}
+
+      {/* Header */}
+      <div className="flex items-start justify-between mb-5">
+        <div>
+          <div className="flex items-center gap-3 mb-1">
+            <Crest tenant={tenant} size={44} />
+            <div>
+              <div className="type-h2 leading-tight" style={{ color: "var(--color-ink)" }}>
+                Pick Slip
+              </div>
+              <div
+                className="font-mono text-[13px] font-semibold"
+                style={{ color: tenant.accent }}
+              >
+                {order.id}
+              </div>
+            </div>
+          </div>
+          <div className="text-[11.5px] mt-1" style={{ color: "var(--color-ink-dim)" }}>
+            Placed {placedAt}
+          </div>
+        </div>
+        <Chip tone={statusInfo.tone}>{statusInfo.label}</Chip>
+      </div>
+
+      <DoubleRule />
+
+      {/* Details grid */}
+      <div className="grid grid-cols-3 gap-6 mt-4 mb-5">
+        <div>
+          <div className="type-label mb-1" style={{ color: "var(--color-ink-dim)" }}>Student</div>
+          <div className="font-serif text-[16px] font-medium" style={{ color: "var(--color-ink)" }}>
+            {order.studentName}
+          </div>
+          <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+            {order.studentYear} · Roll {order.studentRoll}
+          </div>
+        </div>
+        <div>
+          <div className="type-label mb-1" style={{ color: "var(--color-ink-dim)" }}>Parent</div>
+          <div className="font-serif text-[16px] font-medium" style={{ color: "var(--color-ink)" }}>
+            {order.parentName}
+          </div>
+          <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+            {order.parentMobile}
+          </div>
+        </div>
+        <div>
+          <div className="type-label mb-1" style={{ color: "var(--color-ink-dim)" }}>Fulfilment</div>
+          <div className="font-serif text-[16px] font-medium" style={{ color: "var(--color-ink)" }}>
+            {order.delivery === "pickup" ? "Pickup at office" : "Ship to home"}
+          </div>
+          <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+            {order.delivery === "pickup" ? "Notify when ready" : order.parentEmail}
+          </div>
+        </div>
+      </div>
+
+      <DoubleRule />
+
+      {/* Parent note callout (on-screen, screen + print) */}
+      {order.parentNote && (
+        <div
+          className="rounded-lg border p-3 mb-4 mt-4"
+          style={{ borderColor: "var(--color-rule)", background: "var(--color-parchment)" }}
+        >
+          <div className="text-[11px] font-bold tracking-[1.2px] uppercase mb-1" style={{ color: "var(--color-gold)" }}>
+            Note from parent
+          </div>
+          <div className="text-[13px] leading-[1.5]" style={{ color: "var(--color-ink)" }}>
+            {order.parentNote}
+          </div>
+        </div>
+      )}
+
+      {/* Items table */}
+      <table className="w-full border-collapse text-[13px] mt-3.5" style={{ fontFamily: "var(--font-sans)" }}>
+        <thead>
+          <tr className="text-[10.5px] uppercase tracking-[0.6px]" style={{ color: "var(--color-ink-dim)" }}>
+            <th className="text-left py-2 font-bold border-b w-8" style={{ borderColor: "var(--color-rule)" }}>✓</th>
+            <th className="text-left py-2 font-bold border-b" style={{ borderColor: "var(--color-rule)" }}>Item</th>
+            <th className="text-left py-2 font-bold border-b w-[150px]" style={{ borderColor: "var(--color-rule)" }}>Variant</th>
+            <th className="text-center py-2 font-bold border-b w-[50px]" style={{ borderColor: "var(--color-rule)" }}>Qty</th>
+            <th className="text-right py-2 font-bold border-b w-[90px]" style={{ borderColor: "var(--color-rule)" }}>Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lines.map((line, i) => (
+            <tr
+              key={i}
+              className="border-b"
+              style={{ borderColor: "var(--color-rule)", borderStyle: "dashed" }}
+            >
+              <td className="py-3">
+                <div
+                  className="w-[18px] h-[18px] border rounded"
+                  style={{ borderColor: "var(--color-ink)", borderWidth: 1.5 }}
+                />
+              </td>
+              <td className="py-3 font-medium" style={{ color: "var(--color-ink)" }}>{line.itemName}</td>
+              <td className="py-3 text-[12px]" style={{ color: "var(--color-ink-dim)" }}>{line.variantLabel}</td>
+              <td className="py-3 text-center font-bold font-mono" style={{ color: "var(--color-ink)" }}>{line.qty}</td>
+              <td className="py-3 text-right font-semibold tnum" style={{ color: "var(--color-ink)" }}>
+                ${parseFloat(line.lineTotal).toFixed(2)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colSpan={4} className="pt-3.5 text-right font-serif text-[16px] font-semibold" style={{ color: "var(--color-ink)" }}>
+              Total (incl. GST)
+            </td>
+            <td className="pt-3.5 text-right font-serif text-[22px] font-semibold tnum" style={{ color: "var(--color-ink)" }}>
+              ${total.toFixed(2)}
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={4} className="text-right text-[11px]" style={{ color: "var(--color-ink-dim)" }}>GST included</td>
+            <td className="text-right text-[11px] tnum" style={{ color: "var(--color-ink-dim)" }}>${gst.toFixed(2)}</td>
+          </tr>
+        </tfoot>
+      </table>
+
+      {refundsSlot}
+
+      {/* Footer */}
+      <div className="mt-6 flex items-center justify-between">
+        <div className="text-[11px] font-mono" style={{ color: "var(--color-ink-dim)" }}>
+          {order.stripeRef ? `Paid via Stripe · ${order.stripeRef}` : "Payment pending"} · {order.parentEmail}
+        </div>
+        <PickSlipBarcode orderId={order.id} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -76,6 +76,11 @@ html, body {
 
 /* ─── Print styles ──────────────────────────────────────────────────────────── */
 @media print {
+  @page {
+    size: A4;
+    margin: 12mm;
+  }
+
   /* Hide the admin sidebar, topbar, and action buttons */
   nav,
   aside,

--- a/docs/remaining_work.md
+++ b/docs/remaining_work.md
@@ -92,9 +92,11 @@ Done. See `docs/completed.md` §4.12. Production ops verifications carried over 
 
 The reports page produces monthly GST totals client-side. Before go-live, have an Australian accountant confirm the formula (1/11 of GST-inclusive total), the rounding rules, and the Stripe-fee deduction model.
 
-### 3.7 Print stylesheet QA
+### 3.7 Print stylesheet QA — manual A4 verification only
 
-`window.print()` works for pick slips, but needs verification on real A4 in Chrome and Safari (page breaks for multi-page picks, single-slip-per-page mode for batch printing).
+**Code half shipped.** `window.print()` works for the single-slip path (order detail page) and for batch picking from the orders page (one slip per A4 page for every order in status `new`, via the shared `PickSlip` component, `@page A4` rule, and `break-after-page` between slips). See `docs/superpowers/plans/2026-05-11-batch-print-pick-slips.md` and spec `…/specs/2026-05-11-batch-print-pick-slips-design.md`.
+
+**Remaining (manual):** Real A4 paper QA in Chrome and Safari on macOS — single slip prints clean, batch prints one slip per page with no trailing blank, parent-note banner appears on slips that have a note, barcode renders, Kanban never appears in print output.
 
 ### 3.8 Accessibility audit
 

--- a/docs/superpowers/plans/2026-05-11-batch-print-pick-slips.md
+++ b/docs/superpowers/plans/2026-05-11-batch-print-pick-slips.md
@@ -1,0 +1,859 @@
+# Batch print pick slips — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the "Print pick slips" button on `/admin/[tenant]/orders` print one slip per A4 page for every order in status `new`, in the same visual format as the existing single-slip print, with no Kanban/print data drift.
+
+**Architecture:** Extract the pick-slip card body into a shared presentational `<PickSlip />` (no data fetching of its own). Orders state remains owned by `OrdersBoard`; a hidden `print:block` section renders one `<PickSlip />` per `new` order as a sibling of the Kanban. Lines reach the client via a new `?withLines=1` query on `/api/orders`. The topbar button reads a lifted `newCount` to disable/confirm, then calls `window.print()`.
+
+**Tech Stack:** Next.js 16 App Router, React 19 (RSC + client components), Drizzle ORM on Neon, Tailwind CSS v4, native CSS `@page` + `break-after: page`.
+
+**Correctness gate:** This repo has no test suite — `pnpm check-types:web` from the repo root is the type/correctness gate. Visual + interaction verification happens via `pnpm dev:web` in a browser (golden path on `/admin/nsbh/orders`), and §3.7 of `docs/remaining_work.md` carries a manual A4-printer QA pass that is handed off after merge.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-batch-print-pick-slips-design.md`.
+
+---
+
+## File map
+
+- **Create:** `apps/web/src/components/admin/pick-slip.tsx` — pure presentational component (parent-note banner + crest header + student/parent/fulfilment grid + items table + totals + footer + barcode). Accepts a `refundsSlot?: ReactNode` so the detail page can render refunds in the existing visual position without `PickSlip` knowing the refund shape.
+- **Modify:** `apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx` — replace the inline card JSX with `<PickSlip … refundsSlot={…} />`. Convert `Date` and `Decimal` fields to strings before passing in. `OrderActivityStrip` stays outside the card, unchanged.
+- **Modify:** `apps/web/src/app/api/orders/route.ts` — handle `?withLines=1` on the operator-tenant path; one extra batched `inArray` query attaches `lines` to each row.
+- **Modify:** `apps/web/src/app/admin/[tenant]/orders/orders-board.tsx` — request `withLines=1`, derive `newOrders` sorted oldest-first, build `linesByOrderId`, render the hidden batch-print block, add `data-no-print` to the Kanban root, fire `onNewCountChange` via `useEffect`.
+- **Modify:** `apps/web/src/app/admin/[tenant]/orders/orders-page-client.tsx` — hold `newCount` state, pass `onNewCountChange` to the board, replace the inline `window.print()` with `handlePrint`, add count + `disabled` to the button label.
+- **Modify:** `apps/web/src/index.css` — add `@page { size: A4; margin: 12mm; }` inside the existing `@media print` block; if Tailwind v4's `break-after-page` utility does not resolve in this project, add a one-line `@layer utilities` fallback.
+- **Modify:** `docs/remaining_work.md` — note §3.7 code half complete; A4-printer QA pass remains.
+
+---
+
+## Task 1: Extract `PickSlip` presentational component
+
+**Files:**
+- Create: `apps/web/src/components/admin/pick-slip.tsx`
+- Modify: `apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx` (lines 1-313)
+
+This task is a pure refactor: zero behaviour change, same DOM output on the detail page.
+
+- [ ] **Step 1: Create the shared component**
+
+Create `apps/web/src/components/admin/pick-slip.tsx` with the exact content below. The JSX is lifted verbatim from `[orderId]/page.tsx` lines 110-265 + 300-307 (the card wrapper, parent-note print banner, header, details grid, parent-note callout, items table with totals, and the footer with barcode). The `Barcode` helper at lines 13-38 moves into this file as `PickSlipBarcode`. The Refunds block at lines 267-298 is **not** included; the detail page passes it via `refundsSlot`.
+
+```tsx
+import type { ReactNode } from "react";
+import type { Tenant } from "@/lib/data";
+import { Chip } from "@/components/chip";
+import { DoubleRule } from "@/components/double-rule";
+import { Crest } from "@/components/crest";
+
+export interface PickSlipOrder {
+  id: string;
+  status: string;
+  parentName: string;
+  parentEmail: string;
+  parentMobile: string;
+  parentNote: string | null;
+  studentName: string;
+  studentYear: string;
+  studentRoll: string;
+  delivery: string;
+  total: string;
+  gst: string;
+  stripeRef: string | null;
+  createdAt: string; // ISO string — see Task 2 for the detail-page adapter
+}
+
+export interface PickSlipLine {
+  itemName: string;
+  variantLabel: string | null;
+  qty: number;
+  lineTotal: string;
+}
+
+const STATUS_MAP: Record<string, { tone: "info" | "warn" | "success" | "neutral" | "danger"; label: string }> = {
+  pending_payment: { tone: "neutral", label: "Pending payment" },
+  new: { tone: "info", label: "New" },
+  packing: { tone: "warn", label: "Packing" },
+  ready: { tone: "success", label: "Ready for pickup" },
+  collected: { tone: "neutral", label: "Collected" },
+  partially_refunded: { tone: "danger", label: "Partially refunded" },
+  refunded: { tone: "danger", label: "Refunded" },
+};
+
+function PickSlipBarcode({ orderId }: { orderId: string }) {
+  const widths = [3, 1, 2, 1, 1, 3, 1, 2, 3, 1, 1, 2, 3, 2, 1, 1, 3, 1, 2, 1, 1, 3, 2, 1];
+  let x = 0;
+  return (
+    <svg width={180} height={48}>
+      {widths.map((w, i) => {
+        const fill = i % 2 === 0 ? "var(--color-ink)" : "transparent";
+        const el = <rect key={i} x={x} y={0} width={w * 2} height={36} fill={fill} />;
+        x += w * 2 + 1;
+        return el;
+      })}
+      <text
+        x={0}
+        y={46}
+        fontFamily="var(--font-mono)"
+        fontSize="10"
+        fill="var(--color-ink-dim)"
+        letterSpacing="2"
+      >
+        {orderId}
+      </text>
+    </svg>
+  );
+}
+
+export interface PickSlipProps {
+  order: PickSlipOrder;
+  tenant: Tenant;
+  lines: PickSlipLine[];
+  /** Rendered between the items table and the footer. Detail page uses it for the refunds block; batch print passes nothing. */
+  refundsSlot?: ReactNode;
+}
+
+export function PickSlip({ order, tenant, lines, refundsSlot }: PickSlipProps) {
+  const statusInfo = STATUS_MAP[order.status] ?? { tone: "neutral" as const, label: order.status };
+  const total = parseFloat(order.total);
+  const gst = parseFloat(order.gst);
+  const placedAt = order.createdAt
+    ? new Date(order.createdAt).toLocaleDateString("en-AU", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      })
+    : "—";
+
+  return (
+    <div
+      className="bg-white rounded-xl border p-7"
+      style={{ borderColor: "var(--color-rule)" }}
+    >
+      {/* Print-only: parent note at top of pick slip */}
+      {order.parentNote && (
+        <div className="print:block hidden mb-4 p-3 border-2 border-black">
+          <div className="text-[11px] font-bold uppercase tracking-wide mb-1">Note from parent</div>
+          <div className="text-[13px] leading-snug">{order.parentNote}</div>
+        </div>
+      )}
+
+      {/* Header */}
+      <div className="flex items-start justify-between mb-5">
+        <div>
+          <div className="flex items-center gap-3 mb-1">
+            <Crest tenant={tenant} size={44} />
+            <div>
+              <div className="type-h2 leading-tight" style={{ color: "var(--color-ink)" }}>
+                Pick Slip
+              </div>
+              <div
+                className="font-mono text-[13px] font-semibold"
+                style={{ color: tenant.accent }}
+              >
+                {order.id}
+              </div>
+            </div>
+          </div>
+          <div className="text-[11.5px] mt-1" style={{ color: "var(--color-ink-dim)" }}>
+            Placed {placedAt}
+          </div>
+        </div>
+        <Chip tone={statusInfo.tone}>{statusInfo.label}</Chip>
+      </div>
+
+      <DoubleRule />
+
+      {/* Details grid */}
+      <div className="grid grid-cols-3 gap-6 mt-4 mb-5">
+        <div>
+          <div className="type-label mb-1" style={{ color: "var(--color-ink-dim)" }}>Student</div>
+          <div className="font-serif text-[16px] font-medium" style={{ color: "var(--color-ink)" }}>
+            {order.studentName}
+          </div>
+          <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+            {order.studentYear} · Roll {order.studentRoll}
+          </div>
+        </div>
+        <div>
+          <div className="type-label mb-1" style={{ color: "var(--color-ink-dim)" }}>Parent</div>
+          <div className="font-serif text-[16px] font-medium" style={{ color: "var(--color-ink)" }}>
+            {order.parentName}
+          </div>
+          <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+            {order.parentMobile}
+          </div>
+        </div>
+        <div>
+          <div className="type-label mb-1" style={{ color: "var(--color-ink-dim)" }}>Fulfilment</div>
+          <div className="font-serif text-[16px] font-medium" style={{ color: "var(--color-ink)" }}>
+            {order.delivery === "pickup" ? "Pickup at office" : "Ship to home"}
+          </div>
+          <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+            {order.delivery === "pickup" ? "Notify when ready" : order.parentEmail}
+          </div>
+        </div>
+      </div>
+
+      <DoubleRule />
+
+      {/* Parent note callout (on-screen, screen + print) */}
+      {order.parentNote && (
+        <div
+          className="rounded-lg border p-3 mb-4 mt-4"
+          style={{ borderColor: "var(--color-rule)", background: "var(--color-parchment)" }}
+        >
+          <div className="text-[11px] font-bold tracking-[1.2px] uppercase mb-1" style={{ color: "var(--color-gold)" }}>
+            Note from parent
+          </div>
+          <div className="text-[13px] leading-[1.5]" style={{ color: "var(--color-ink)" }}>
+            {order.parentNote}
+          </div>
+        </div>
+      )}
+
+      {/* Items table */}
+      <table className="w-full border-collapse text-[13px] mt-3.5" style={{ fontFamily: "var(--font-sans)" }}>
+        <thead>
+          <tr className="text-[10.5px] uppercase tracking-[0.6px]" style={{ color: "var(--color-ink-dim)" }}>
+            <th className="text-left py-2 font-bold border-b w-8" style={{ borderColor: "var(--color-rule)" }}>✓</th>
+            <th className="text-left py-2 font-bold border-b" style={{ borderColor: "var(--color-rule)" }}>Item</th>
+            <th className="text-left py-2 font-bold border-b w-[150px]" style={{ borderColor: "var(--color-rule)" }}>Variant</th>
+            <th className="text-center py-2 font-bold border-b w-[50px]" style={{ borderColor: "var(--color-rule)" }}>Qty</th>
+            <th className="text-right py-2 font-bold border-b w-[90px]" style={{ borderColor: "var(--color-rule)" }}>Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lines.map((line, i) => (
+            <tr
+              key={i}
+              className="border-b"
+              style={{ borderColor: "var(--color-rule)", borderStyle: "dashed" }}
+            >
+              <td className="py-3">
+                <div
+                  className="w-[18px] h-[18px] border rounded"
+                  style={{ borderColor: "var(--color-ink)", borderWidth: 1.5 }}
+                />
+              </td>
+              <td className="py-3 font-medium" style={{ color: "var(--color-ink)" }}>{line.itemName}</td>
+              <td className="py-3 text-[12px]" style={{ color: "var(--color-ink-dim)" }}>{line.variantLabel}</td>
+              <td className="py-3 text-center font-bold font-mono" style={{ color: "var(--color-ink)" }}>{line.qty}</td>
+              <td className="py-3 text-right font-semibold tnum" style={{ color: "var(--color-ink)" }}>
+                ${parseFloat(line.lineTotal).toFixed(2)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colSpan={4} className="pt-3.5 text-right font-serif text-[16px] font-semibold" style={{ color: "var(--color-ink)" }}>
+              Total (incl. GST)
+            </td>
+            <td className="pt-3.5 text-right font-serif text-[22px] font-semibold tnum" style={{ color: "var(--color-ink)" }}>
+              ${total.toFixed(2)}
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={4} className="text-right text-[11px]" style={{ color: "var(--color-ink-dim)" }}>GST included</td>
+            <td className="text-right text-[11px] tnum" style={{ color: "var(--color-ink-dim)" }}>${gst.toFixed(2)}</td>
+          </tr>
+        </tfoot>
+      </table>
+
+      {refundsSlot}
+
+      {/* Footer */}
+      <div className="mt-6 flex items-center justify-between">
+        <div className="text-[11px] font-mono" style={{ color: "var(--color-ink-dim)" }}>
+          {order.stripeRef ? `Paid via Stripe · ${order.stripeRef}` : "Payment pending"} · {order.parentEmail}
+        </div>
+        <PickSlipBarcode orderId={order.id} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Rewire the detail page to use `<PickSlip />`**
+
+Replace the file body of `apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx` with the version below. Changes vs. current: removes the local `Barcode` helper; removes the inline `statusMap`/`total`/`gst`/`placedAt` derivations (they live in `PickSlip` now); converts `order.createdAt` (Date) to ISO string before passing in; renders the refunds block via the `refundsSlot` prop so its visual position between items table and footer is preserved.
+
+```tsx
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getOrderById, getOrderRefunds, getTotalRefunded, getTenant, toTenantBrand } from "@/db/queries";
+import { AdminTopbar } from "@/components/admin-shell";
+import { DoubleRule } from "@/components/double-rule";
+import { OrderDetailActions } from "./order-detail-actions";
+import { PrintButton } from "@/components/print-button";
+import { loadOrderActivity } from "@/lib/audit/load-order-activity";
+import { OrderActivityStrip } from "@/components/admin/order-activity-strip";
+import { PickSlip, type PickSlipOrder, type PickSlipLine } from "@/components/admin/pick-slip";
+
+export default async function OrderDetailPage({
+  params,
+}: { params: Promise<{ tenant: string; orderId: string }> }) {
+  const { tenant: tid, orderId } = await params;
+  const tenantRecord = await getTenant(tid);
+  if (!tenantRecord) notFound();
+  const tenant = toTenantBrand(tenantRecord);
+
+  const order = await getOrderById(orderId);
+  if (!order || order.tenantId !== tid) notFound();
+
+  const refunds = await getOrderRefunds(orderId);
+  const refundedTotal = await getTotalRefunded(orderId);
+  const activityRows = await loadOrderActivity(orderId);
+
+  const total = parseFloat(order.total);
+
+  const slipOrder: PickSlipOrder = {
+    id: order.id,
+    status: order.status,
+    parentName: order.parentName,
+    parentEmail: order.parentEmail,
+    parentMobile: order.parentMobile,
+    parentNote: order.parentNote,
+    studentName: order.studentName,
+    studentYear: order.studentYear,
+    studentRoll: order.studentRoll,
+    delivery: order.delivery,
+    total: order.total,
+    gst: order.gst,
+    stripeRef: order.stripeRef,
+    createdAt: order.createdAt ? order.createdAt.toISOString() : "",
+  };
+
+  const slipLines: PickSlipLine[] = order.lines.map((line) => ({
+    itemName: line.itemName,
+    variantLabel: line.variantLabel,
+    qty: line.qty,
+    lineTotal: line.lineTotal,
+  }));
+
+  const refundsBlock = refunds.length > 0 ? (
+    <>
+      <DoubleRule />
+      <div className="mt-4">
+        <div className="text-[10.5px] uppercase tracking-[0.6px] font-bold mb-2" style={{ color: "var(--color-ink-dim)" }}>
+          Refunds
+        </div>
+        {refunds.map((refund) => (
+          <div key={refund.id} className="flex items-center justify-between py-2 border-b text-[12.5px]" style={{ borderColor: "var(--color-rule)", borderStyle: "dashed" }}>
+            <div style={{ color: "var(--color-ink)" }}>
+              {refund.reason ? refund.reason : "Refund"}
+              {refund.stripeRefundId && (
+                <span className="ml-1 text-[10px] font-mono" style={{ color: "var(--color-ink-dim)" }}>
+                  · {refund.stripeRefundId}
+                </span>
+              )}
+            </div>
+            <div className="font-semibold tnum" style={{ color: "#B23A2A" }}>
+              −${parseFloat(String(refund.amount)).toFixed(2)}
+            </div>
+          </div>
+        ))}
+        <div className="flex items-center justify-between pt-2 text-[12.5px] font-semibold">
+          <div style={{ color: "var(--color-ink)" }}>Net total</div>
+          <div className="tnum" style={{ color: "var(--color-ink)" }}>
+            ${Math.max(0, total - refundedTotal).toFixed(2)}
+          </div>
+        </div>
+      </div>
+    </>
+  ) : null;
+
+  return (
+    <>
+      <AdminTopbar
+        kicker={`${tenant.short} · Orders`}
+        title={order.id}
+        right={
+          <div className="flex items-center gap-2">
+            <Link
+              href={`/admin/${tid}/orders`}
+              className="h-9 px-3.5 text-[12.5px] font-semibold rounded-md border flex items-center gap-1.5"
+              style={{ borderColor: "var(--color-rule)", color: "var(--color-ink)" }}
+            >
+              ← Back to orders
+            </Link>
+            <PrintButton label="Print pick slip" />
+            <div className="relative">
+              <OrderDetailActions
+                orderId={order.id}
+                tenantId={tid}
+                currentStatus={order.status}
+                accent={tenant.accent}
+                parentEmail={order.parentEmail}
+                parentName={order.parentName}
+                studentName={order.studentName}
+                total={total}
+                refunded={refundedTotal}
+              />
+            </div>
+          </div>
+        }
+      />
+      <div className="flex-1 overflow-y-auto p-7">
+        <div className="max-w-3xl mx-auto">
+          <PickSlip order={slipOrder} tenant={tenant} lines={slipLines} refundsSlot={refundsBlock} />
+          <OrderActivityStrip rows={activityRows} />
+        </div>
+      </div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run from the repo root: `pnpm check-types:web`
+Expected: clean, no errors.
+
+- [ ] **Step 4: Visual sanity check**
+
+Run: `pnpm dev:web`. Open `http://localhost:3000/admin/nsbh/orders/<any-order-id>` (pick any order from the Kanban). Confirm:
+- The page looks identical to before (header, crest, slip card, items, totals, refunds if present, audit activity strip below).
+- Click "Print pick slip" — the print preview shows the slip card alone, no sidebar/topbar.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/admin/pick-slip.tsx \
+        "apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx"
+git commit -m "refactor: extract PickSlip component from order detail page
+
+Pure refactor: no visual or behavioural change on the detail page.
+PickSlip is a presentational component that takes a JSON-shaped
+order, tenant, and lines, plus an optional refundsSlot for the
+detail page's refunds block. Sets up Task 2 (batch print)."
+```
+
+---
+
+## Task 2: Eager line-item fetch on `/api/orders?withLines=1`
+
+**Files:**
+- Modify: `apps/web/src/app/api/orders/route.ts` (the GET handler, lines 27-77)
+
+- [ ] **Step 1: Add `withLines` handling on the operator path**
+
+In `apps/web/src/app/api/orders/route.ts`:
+
+1. Add `inArray` to the existing `drizzle-orm` import.
+2. Add `orderLines` to the existing `@/db` import (it is already exported from `@/db` per Task 2 of audit-log impl).
+3. After `const rows = await getOrdersByTenant(tenantId);` (currently line 71) and **before** the `return NextResponse.json(rows);`, insert the `withLines` branch.
+
+Final handler shape (replace the operator branch block beginning at the `ensureTenantAccess` check):
+
+```ts
+const tenantAccessResponse = ensureTenantAccess(authResult.user, tenant.shopEmail);
+if (tenantAccessResponse) return tenantAccessResponse;
+
+const rateLimitResponse = applyRateLimit(req, `orders:tenant:${tenantId}:${authResult.user.id}`, {
+  limit: 120,
+  windowMs: 60_000,
+});
+if (rateLimitResponse) return rateLimitResponse;
+
+const rows = await getOrdersByTenant(tenantId);
+
+if (searchParams.get("withLines") === "1" && rows.length > 0) {
+  const ids = rows.map((r) => r.id);
+  const lines = await db
+    .select()
+    .from(orderLines)
+    .where(inArray(orderLines.orderId, ids));
+  const linesByOrderId: Record<string, typeof lines> = {};
+  for (const line of lines) {
+    (linesByOrderId[line.orderId] ??= []).push(line);
+  }
+  return NextResponse.json(
+    rows.map((r) => ({ ...r, lines: linesByOrderId[r.id] ?? [] })),
+  );
+}
+
+return NextResponse.json(rows);
+```
+
+The parent-email path (when `email` is present) is unchanged — it never uses `withLines`.
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm check-types:web`
+Expected: clean.
+
+- [ ] **Step 3: Manual smoke**
+
+Run `pnpm dev:web`. In a browser devtools tab, with the operator session active, fetch:
+- `http://localhost:3000/api/orders?tenantId=nsbh` — response is an array of orders **without** `lines`.
+- `http://localhost:3000/api/orders?tenantId=nsbh&withLines=1` — response is the same array, each order now has a `lines: [...]` array (may be empty for some).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/app/api/orders/route.ts
+git commit -m "feat(api): support ?withLines=1 on GET /api/orders
+
+Operator-tenant path only. Adds a single batched inArray query for
+order_lines keyed on the returned order ids and attaches them as
+.lines on each row. Used by the orders Kanban for the upcoming
+batch pick-slip print."
+```
+
+---
+
+## Task 3: Print CSS — `@page` + `break-after-page` utility
+
+**Files:**
+- Modify: `apps/web/src/index.css` (the `@media print` block at lines 77-107)
+
+- [ ] **Step 1: Add `@page` rule and the break utility**
+
+In `apps/web/src/index.css`, inside the existing `@media print { … }` block (currently ending at line 107), add an `@page` rule. The block becomes:
+
+```css
+@media print {
+  @page {
+    size: A4;
+    margin: 12mm;
+  }
+
+  /* Hide the admin sidebar, topbar, and action buttons */
+  nav,
+  aside,
+  [data-admin-sidebar],
+  [data-admin-topbar],
+  [data-no-print] {
+    display: none !important;
+  }
+
+  /* Remove background colours and shadows for clean print output */
+  body {
+    background: white !important;
+    color: black !important;
+  }
+
+  /* Expand the pick slip card to fill the page */
+  .print\:full-page {
+    width: 100% !important;
+    max-width: 100% !important;
+    box-shadow: none !important;
+    border: none !important;
+    padding: 0 !important;
+  }
+
+  /* Ensure page breaks don't split table rows */
+  tr {
+    page-break-inside: avoid;
+  }
+}
+```
+
+- [ ] **Step 2: Verify Tailwind's `break-after-page` utility resolves**
+
+Tailwind v4 ships `break-after-page` as a first-class utility. Run a quick check by searching the generated build for the class, or just test on a throwaway element in Task 4. If it does not resolve in this project's config, add the following at the end of `apps/web/src/index.css` (outside the `@media print` block):
+
+```css
+@layer utilities {
+  .break-after-page { break-after: page; }
+}
+```
+
+If the utility does resolve, **do not** add the fallback. Pick exactly one. Decide in Task 4 step 3 when you can see the print preview directly.
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm check-types:web`
+Expected: clean (CSS doesn't affect typecheck, but run anyway to confirm nothing else broke).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/index.css
+git commit -m "style(print): add @page A4 rule for pick-slip printing
+
+Sets explicit A4 page size with 12mm margins. Used by the upcoming
+batch pick-slip print on the orders page; the existing single-slip
+print path inherits the same margins."
+```
+
+---
+
+## Task 4: Wire `OrdersBoard` — batch print block + Kanban tagging + count callback
+
+**Files:**
+- Modify: `apps/web/src/app/admin/[tenant]/orders/orders-board.tsx`
+
+- [ ] **Step 1: Read the file to locate the integration points**
+
+Open `apps/web/src/app/admin/[tenant]/orders/orders-board.tsx`. The integration points are:
+- Top of file: `OrderStatus`, props interface, the `fetchOrders` call.
+- The `useEffect` block (around line 167-169) calls `fetchOrders()`.
+- Bottom of file: the JSX returns columns + cards. Identify the **root element** of the Kanban (the outermost `<div>` that wraps the columns) — this is where `data-no-print` is added in Step 5.
+
+- [ ] **Step 2: Extend props with `onNewCountChange`**
+
+In the props interface for `OrdersBoard` (or wherever it currently declares `tenantId`, `tenant`, `searchQuery`), add:
+
+```ts
+onNewCountChange?: (count: number) => void;
+```
+
+Accept it in the destructure: `({ tenantId, tenant, searchQuery, onNewCountChange })`.
+
+- [ ] **Step 3: Extend the order type to include lines**
+
+Wherever the local `Order` (or `OrderRow`) interface is declared in this file, add a `lines` field matching `PickSlipLine` (a re-export from `pick-slip.tsx`):
+
+```ts
+import type { PickSlipLine } from "@/components/admin/pick-slip";
+
+interface Order {
+  // ...existing fields stay here
+  lines: PickSlipLine[]; // populated by the withLines=1 fetch
+}
+```
+
+If the file already imports types from elsewhere for `Order`, add `lines` to that source instead. Decimal fields on lines (`unitPrice`, `lineTotal`) come over the wire as strings — that matches `PickSlipLine` already.
+
+- [ ] **Step 4: Change the fetch URL to include `withLines=1`**
+
+In `fetchOrders` (around line 153), change:
+
+```ts
+const res = await fetch(`/api/orders?tenantId=${encodeURIComponent(tenantId)}`);
+```
+
+to:
+
+```ts
+const res = await fetch(`/api/orders?tenantId=${encodeURIComponent(tenantId)}&withLines=1`);
+```
+
+- [ ] **Step 5: Add `data-no-print` to the Kanban root and render the hidden batch-print block**
+
+Find the JSX block that renders the columns (around line 224 — the `filtered.filter((o) => o.status === col.id)` loop). The outermost wrapping element of this Kanban is the root container — add `data-no-print` to that element.
+
+After the Kanban root's closing tag (still inside the component's returned fragment), append the hidden batch-print section. Import `PickSlip` at the top of the file:
+
+```ts
+import { PickSlip, type PickSlipOrder, type PickSlipLine } from "@/components/admin/pick-slip";
+```
+
+Then inside the component body, before the return:
+
+```ts
+const newOrders = orders
+  .filter((o) => o.status === "new")
+  .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+```
+
+And in the returned JSX, *after* the Kanban root element, add the hidden batch-print section:
+
+```tsx
+<div className="print:block hidden" aria-hidden>
+  {newOrders.map((o, idx) => {
+    const slipOrder: PickSlipOrder = {
+      id: o.id,
+      status: o.status,
+      parentName: o.parentName,
+      parentEmail: o.parentEmail,
+      parentMobile: o.parentMobile,
+      parentNote: o.parentNote,
+      studentName: o.studentName,
+      studentYear: o.studentYear,
+      studentRoll: o.studentRoll,
+      delivery: o.delivery,
+      total: o.total,
+      gst: o.gst,
+      stripeRef: o.stripeRef,
+      createdAt: o.createdAt,
+    };
+    return (
+      <div
+        key={o.id}
+        className={idx < newOrders.length - 1 ? "break-after-page" : undefined}
+      >
+        <PickSlip order={slipOrder} tenant={tenant} lines={o.lines} />
+      </div>
+    );
+  })}
+</div>
+```
+
+If a field above (e.g. `parentMobile`) doesn't exist on the local `Order` type but does exist on the JSON the server returns, extend the local `Order` type in Step 3 to include it. Compare against `PickSlipOrder` in `pick-slip.tsx` — those exact field names must be present on the local `Order`.
+
+- [ ] **Step 6: Fire `onNewCountChange` via `useEffect`**
+
+Below the `newOrders` derivation, add:
+
+```tsx
+useEffect(() => {
+  onNewCountChange?.(newOrders.length);
+}, [newOrders.length, onNewCountChange]);
+```
+
+The callback **must** be in a `useEffect` (not inline during render) to avoid the parent-`setState`-during-child-render warning and a render loop.
+
+- [ ] **Step 7: Type-check**
+
+Run: `pnpm check-types:web`
+Expected: clean. If `Order` is missing fields that `PickSlipOrder` requires, add them in Step 3 and re-run.
+
+- [ ] **Step 8: Visual sanity check + print preview**
+
+Run `pnpm dev:web` and open `http://localhost:3000/admin/nsbh/orders`.
+
+- The Kanban should look unchanged.
+- Open browser devtools → Rendering tab → enable "Emulate CSS media type: print" (or use `Cmd+P` to open print preview).
+- Confirm: the Kanban disappears, and a sequence of pick slips appears in its place, one per page (page breaks between them), oldest-`createdAt` first. **No trailing blank page after the last slip.**
+- If `break-after-page` does not produce page breaks, go back to Task 3 step 2 and add the `@layer utilities` fallback now, then re-check.
+- Disable print emulation when done.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add "apps/web/src/app/admin/[tenant]/orders/orders-board.tsx"
+git commit -m "feat(orders): hidden batch pick-slip block for print
+
+OrdersBoard now requests withLines=1, derives newOrders sorted
+oldest-first, and renders a print-only block of PickSlip components
+as a sibling of the Kanban. Adds data-no-print to the Kanban root.
+Lifts newCount to OrdersPageClient via onNewCountChange in a
+useEffect to avoid setState-during-render."
+```
+
+---
+
+## Task 5: Wire `OrdersPageClient` — lifted count, `handlePrint`, button state
+
+**Files:**
+- Modify: `apps/web/src/app/admin/[tenant]/orders/orders-page-client.tsx`
+
+- [ ] **Step 1: Add `newCount` state and pass `onNewCountChange` to the board**
+
+At the top of `OrdersPageClient`, alongside the existing `searchQuery` state:
+
+```ts
+const [newCount, setNewCount] = useState(0);
+```
+
+In the `<OrdersBoard … />` JSX at the bottom of the component, add the new prop:
+
+```tsx
+<OrdersBoard
+  tenantId={tenantId}
+  tenant={tenant}
+  searchQuery={searchQuery}
+  onNewCountChange={setNewCount}
+/>
+```
+
+- [ ] **Step 2: Replace the inline `window.print()` with `handlePrint`**
+
+Above the returned JSX, define:
+
+```ts
+const handlePrint = () => {
+  if (newCount === 0) return;
+  // 25 is roughly a full-day picking run at one school. Above that we want a
+  // moment of pause before committing operator-side paper + ink.
+  if (newCount >= 25 && !window.confirm(`Print ${newCount} pick slips?`)) {
+    return;
+  }
+  window.print();
+};
+```
+
+In the Print pick slips button JSX (currently `<button onClick={() => window.print()} className="…">…</button>`), replace it with:
+
+```tsx
+<button
+  onClick={handlePrint}
+  disabled={newCount === 0}
+  title={newCount === 0 ? "No new orders to pick" : undefined}
+  className="h-9 px-3.5 text-[12.5px] font-semibold rounded-md border flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+  style={{ borderColor: "var(--color-rule)", color: "var(--color-ink)" }}
+>
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
+    <rect x="6" y="3" width="12" height="6" /><rect x="3" y="9" width="18" height="9" rx="1" /><rect x="6" y="15" width="12" height="6" />
+  </svg>
+  {newCount > 0 ? `Print pick slips (${newCount})` : "Print pick slips"}
+</button>
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm check-types:web`
+Expected: clean.
+
+- [ ] **Step 4: Manual smoke (golden path + edge cases)**
+
+Run `pnpm dev:web` and open `http://localhost:3000/admin/nsbh/orders`.
+
+- If there are 0 `new` orders, the button is disabled, label reads "Print pick slips", hovering shows tooltip "No new orders to pick".
+- If there are some `new` orders, the label reads "Print pick slips (N)" with the live count.
+- Click the button — the print dialog opens immediately when N < 25; the hidden batch-print block prints (see Task 4 step 8 for what to look for).
+- If you have ≥ 25 `new` orders available, the confirm dialog should appear with the right count; declining cancels.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/app/admin/[tenant]/orders/orders-page-client.tsx"
+git commit -m "feat(orders): batch print button with count + confirm guard
+
+Lifts the new-order count from OrdersBoard via the new callback,
+disables the button when zero, suffixes the live count to the label,
+and shows a confirm dialog when printing >= 25 slips to prevent
+accidental paper avalanches."
+```
+
+---
+
+## Task 6: Update `docs/remaining_work.md` for the §3.7 code half
+
+**Files:**
+- Modify: `docs/remaining_work.md` (the §3.7 entry, currently lines 95-97)
+
+- [ ] **Step 1: Update §3.7 to note the code half is shipped**
+
+Open `docs/remaining_work.md` and replace the §3.7 block (currently:
+
+```
+### 3.7 Print stylesheet QA
+
+`window.print()` works for pick slips, but needs verification on real A4 in Chrome and Safari (page breaks for multi-page picks, single-slip-per-page mode for batch printing).
+```
+
+) with:
+
+```
+### 3.7 Print stylesheet QA — manual A4 verification only
+
+**Code half shipped.** `window.print()` works for the single-slip path (order detail page) and for batch picking from the orders page (one slip per A4 page for every order in status `new`, via the shared `PickSlip` component, `@page A4` rule, and `break-after-page` between slips). See `docs/superpowers/plans/2026-05-11-batch-print-pick-slips.md` and spec `…/specs/2026-05-11-batch-print-pick-slips-design.md`.
+
+**Remaining (manual):** Real A4 paper QA in Chrome and Safari on macOS — single slip prints clean, batch prints one slip per page with no trailing blank, parent-note banner appears on slips that have a note, barcode renders, Kanban never appears in print output.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/remaining_work.md
+git commit -m "docs: §3.7 code half shipped; manual A4 QA remains
+
+Batch pick-slip print is implemented (PickSlip component + @page
+A4 + hidden print:block batch section on the orders page). The
+remaining work is real-A4 verification on Chrome and Safari."
+```
+
+---
+
+## Self-review checklist (run after Task 6)
+
+- [ ] Open the spec `docs/superpowers/specs/2026-05-11-batch-print-pick-slips-design.md` and confirm each numbered design section has a corresponding implementation step in this plan: §1 (PickSlip) → Task 1. §2 (batch render in OrdersBoard, `data-no-print`, callback in `useEffect`) → Task 4. §3 (`withLines=1`) → Task 2. §4 (button behaviour) → Task 5. §5 (`@page` + `break-after-page`) → Task 3.
+- [ ] Confirm verification steps cover: §6.1 single slip prints (Task 1 step 4), §6.2-§6.5 batch with 0 / 1 / N / ≥25 orders (Task 4 step 8 + Task 5 step 4), §6.6 Kanban hidden in print (Task 4 step 8), §6.7 Safari pass — flag for the user that this part is manual and lives in `remaining_work.md` §3.7 post-merge.
+- [ ] Confirm no step references `"paid"` status, `placedAt`, or a server-side fetch in `orders/page.tsx` — all three were corrected after spec review.
+- [ ] Confirm `PickSlipOrder` field list in Task 1 matches the field list consumed by `PickSlip` JSX and the field list mapped from `getOrderById` in Task 1 step 2 and from `Order` in Task 4 step 5. Names must be identical across all three.
+
+If any item fails, fix the relevant task inline.

--- a/docs/superpowers/plans/2026-05-11-batch-print-pick-slips.md
+++ b/docs/superpowers/plans/2026-05-11-batch-print-pick-slips.md
@@ -510,7 +510,11 @@ batch pick-slip print."
 
 - [ ] **Step 1: Add `@page` rule and the break utility**
 
-In `apps/web/src/index.css`, inside the existing `@media print { … }` block (currently ending at line 107), add an `@page` rule. The block becomes:
+In `apps/web/src/index.css`, inside the existing `@media print { … }` block (currently ending at line 107), add an `@page` rule.
+
+**Scope note for future readers:** `@page` is a global CSS at-rule. Once added, every `window.print()` invocation anywhere in the app inherits A4 + 12 mm margins. There are no other print callers today (the only other reference to `window.print` is `components/print-button.tsx`, which is itself used by the order detail page). If a future print view needs different paper or margins, scope it with named pages (`@page slip { … } .slip { page: slip; }`) rather than redefining the global rule.
+
+The block becomes:
 
 ```css
 @media print {
@@ -602,20 +606,34 @@ onNewCountChange?: (count: number) => void;
 
 Accept it in the destructure: `({ tenantId, tenant, searchQuery, onNewCountChange })`.
 
-- [ ] **Step 3: Extend the order type to include lines**
+- [ ] **Step 3: Extend the order type with `lines` and any `PickSlipOrder` fields it is missing**
 
-Wherever the local `Order` (or `OrderRow`) interface is declared in this file, add a `lines` field matching `PickSlipLine` (a re-export from `pick-slip.tsx`):
+The local `Order` / `DbOrder` type in this file currently only carries the fields the Kanban cards render. To feed the print block, every field on `PickSlipOrder` (Task 1) must be present. Verified against `db/schema.ts` (`orders` table): `parentNote` and `stripeRef` are nullable, everything else is `notNull`.
 
 ```ts
 import type { PickSlipLine } from "@/components/admin/pick-slip";
 
 interface Order {
   // ...existing fields stay here
+
+  // Fields required by PickSlipOrder — add any that aren't already present:
+  parentEmail: string;
+  parentMobile: string;
+  parentNote: string | null;
+  studentName: string;
+  studentYear: string;
+  studentRoll: string;
+  delivery: string;
+  total: string;
+  gst: string;
+  stripeRef: string | null;
+  createdAt: string; // ISO string — comes over the wire as JSON
+
   lines: PickSlipLine[]; // populated by the withLines=1 fetch
 }
 ```
 
-If the file already imports types from elsewhere for `Order`, add `lines` to that source instead. Decimal fields on lines (`unitPrice`, `lineTotal`) come over the wire as strings — that matches `PickSlipLine` already.
+If the file already imports types from elsewhere for `Order`, add the missing fields to that source instead. Decimal fields on lines (`unitPrice`, `lineTotal`) come over the wire as strings — that matches `PickSlipLine` already.
 
 - [ ] **Step 4: Change the fetch URL to include `withLines=1`**
 
@@ -631,11 +649,30 @@ to:
 const res = await fetch(`/api/orders?tenantId=${encodeURIComponent(tenantId)}&withLines=1`);
 ```
 
-- [ ] **Step 5: Add `data-no-print` to the Kanban root and render the hidden batch-print block**
+- [ ] **Step 5: Add `data-no-print` to the Kanban root and render the hidden batch-print block as a sibling fragment**
 
-Find the JSX block that renders the columns (around line 224 — the `filtered.filter((o) => o.status === col.id)` loop). The outermost wrapping element of this Kanban is the root container — add `data-no-print` to that element.
+Find the JSX block that renders the columns (around line 224 — the `filtered.filter((o) => o.status === col.id)` loop). The outermost wrapping element of this Kanban is the root container — currently `<div className="flex-1 p-6 overflow-hidden">`. Add `data-no-print` to that element.
 
-After the Kanban root's closing tag (still inside the component's returned fragment), append the hidden batch-print section. Import `PickSlip` at the top of the file:
+**Critical — return must become a fragment, not nest.** The component currently returns a single `<div>`. Wrap the return in a fragment so the new print block becomes a **sibling** of the Kanban root. Do **not** nest the print block inside that `<div>` — its `overflow-hidden` would clip multi-page print output past the first page.
+
+Target shape:
+
+```tsx
+return (
+  <>
+    <div data-no-print className="flex-1 p-6 overflow-hidden">
+      {/* …existing Kanban columns/cards stay exactly as they are… */}
+    </div>
+    <div className="print:block hidden" aria-hidden>
+      {/* batch-print block — code below */}
+    </div>
+  </>
+);
+```
+
+**Loading-state invariant (do not "fix"):** The early `if (loading) return <div…>Loading orders…</div>` returns before the print block is reachable. This is intentional: the topbar button is disabled until `newCount > 0`, and `newCount` is `0` while loading, so the print pathway is unreachable in that window. Leave the early return as-is.
+
+Import `PickSlip` at the top of the file:
 
 ```ts
 import { PickSlip, type PickSlipOrder, type PickSlipLine } from "@/components/admin/pick-slip";
@@ -709,6 +746,7 @@ Run `pnpm dev:web` and open `http://localhost:3000/admin/nsbh/orders`.
 - Open browser devtools → Rendering tab → enable "Emulate CSS media type: print" (or use `Cmd+P` to open print preview).
 - Confirm: the Kanban disappears, and a sequence of pick slips appears in its place, one per page (page breaks between them), oldest-`createdAt` first. **No trailing blank page after the last slip.**
 - If `break-after-page` does not produce page breaks, go back to Task 3 step 2 and add the `@layer utilities` fallback now, then re-check.
+- **If the print preview is clipped past page 1** (only the first slip prints, or content cuts off mid-slip), an ancestor of `OrdersBoard` has an active `overflow-hidden`/`max-height` in print mode. Inspect the elements walking up from the print block in devtools with print-emulation on; add a targeted `@media print { .[ancestor-class] { overflow: visible !important; height: auto !important; } }` rule in `src/index.css` for the culprit. This is unlikely with the fragment-sibling structure from Step 5, but flagged in case the admin shell layout enforces overflow upstream.
 - Disable print emulation when done.
 
 - [ ] **Step 9: Commit**

--- a/docs/superpowers/specs/2026-05-11-batch-print-pick-slips-design.md
+++ b/docs/superpowers/specs/2026-05-11-batch-print-pick-slips-design.md
@@ -63,7 +63,7 @@ interface PickSlipProps {
 }
 ```
 
-`Order` / `OrderLine` types: define a single shared interface in the new component file matching what `/api/orders` returns over JSON (decimals as strings, `createdAt` as ISO string). The detail page currently uses the Drizzle row type from `getOrderById`; we keep that path working by passing a normalized adapter (same fields, decimals → strings) so `<PickSlip />` accepts one shape from both call sites.
+`Order` / `OrderLine` types: define a single shared interface in the new component file. The canonical shape is the JSON-over-the-wire form (`createdAt` as ISO `string`, `unitPrice` / `lineTotal` / `total` as `string`) — the slip only needs to display these fields, not arithmetic on them, so the simpler string form wins. The detail page (which uses Drizzle's row type from `getOrderById` returning `Date`/`Decimal`) is responsible for converting `createdAt.toISOString()` and `String(decimal)` *before* passing the row into `<PickSlip />`. Conversion happens at exactly one site, in one direction, so the component never has to accept a union shape.
 
 The detail page renders `<PickSlip order={…} tenant={…} lines={…} />` inside its existing white card. There is no visual change to the single-slip print path.
 
@@ -89,7 +89,7 @@ Inside `orders-board.tsx`:
 
 3. Add `data-no-print` to the Kanban root container so the existing `@media print` rule in `src/index.css` hides it. **This is required** — the Kanban is not inside an `aside`, so the existing `aside { display: none }` rule does not catch it.
 
-4. Lift `newOrders.length` to `OrdersPageClient` via a callback prop on `<OrdersBoard onNewCountChange={…} />`. `OrdersPageClient` stores it in local state and passes it to the topbar button for the disable/confirm logic in §4.
+4. Lift `newOrders.length` to `OrdersPageClient` via a callback prop on `<OrdersBoard onNewCountChange={…} />`. `OrdersPageClient` stores it in local state and passes it to the topbar button for the disable/confirm logic in §4. The callback must fire from a `useEffect(() => onNewCountChange(newOrders.length), [newOrders.length, onNewCountChange])` — never inline during render — to avoid a parent-`setState`-during-child-render warning and a render loop.
 
 ### 3. Line items — eager fetch via `/api/orders?withLines=1`
 

--- a/docs/superpowers/specs/2026-05-11-batch-print-pick-slips-design.md
+++ b/docs/superpowers/specs/2026-05-11-batch-print-pick-slips-design.md
@@ -1,0 +1,156 @@
+# Batch print pick slips — design
+
+**Date:** 2026-05-11
+**Source:** `docs/remaining_work.md` §3.7 (print stylesheet QA) — split into code half (this spec) and manual A4/Chrome/Safari verification half (to be done by the operator after merge).
+**Status:** Spec.
+
+## Problem
+
+The "Print pick slips" button on `apps/web/src/app/admin/[tenant]/orders/orders-page-client.tsx:48` calls `window.print()` directly on the orders page. With the current `@media print` rules in `src/index.css:78-107` this prints the visible Kanban board — not a sequence of one-pick-slip-per-page. Operators have no way to print the day's picking queue in a single action; they must navigate into each order's detail page and print slips one at a time.
+
+Single-slip printing from `apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx` already works correctly (the detail-page card was designed to be print-friendly). The gap is batch printing.
+
+## Goal
+
+Clicking **Print pick slips** on the orders page prints one pick slip per "Paid" order, one slip per A4 page, in the same visual format as the single-slip print from the order detail page. No new routes, no popup tabs, no data refetch.
+
+## Non-goals
+
+- Multi-select print (per-order checkboxes on the Kanban).
+- Printing "Ready" or "Collected" orders in bulk (reprints stay on the detail page).
+- Per-day or per-filter scope. Always the full "Paid" bucket.
+- PDF download. The browser's print-to-PDF is sufficient.
+- Audit log integration. Printing is a read action and not part of the 12 audited mutations.
+
+## Design
+
+### 1. Shared `PickSlip` component
+
+Extract the existing pick-slip markup from `app/admin/[tenant]/orders/[orderId]/page.tsx` (the inner card starting at the `print:block hidden` parent-note banner, through the crest header, student/parent/order grid, line items, and totals) into a new `apps/web/src/components/admin/pick-slip.tsx`.
+
+Props:
+
+```ts
+interface PickSlipProps {
+  order: Order;            // from db/schema, includes parentNote, studentName, etc.
+  tenant: Tenant;          // for Crest + accent colour
+  lines: OrderLine[];      // line items
+}
+```
+
+The detail page (`[orderId]/page.tsx`) renders `<PickSlip order={…} tenant={…} lines={…} />` inside its existing card wrapper. There is no visual or behavioural change to the single-slip print path.
+
+### 2. Batch render on the orders page
+
+`app/admin/[tenant]/orders/page.tsx` is a Server Component that fetches the Kanban data. It already loads orders for the tenant. Add a query for line items keyed on the "Paid" subset only (so we do not over-fetch lines for "Ready" or "Collected" buckets, which can grow indefinitely):
+
+```ts
+const paidOrders = orders.filter(o => o.status === "paid");
+const paidOrderIds = paidOrders.map(o => o.id);
+const paidLines = paidOrderIds.length > 0
+  ? await db.select().from(orderLines).where(inArray(orderLines.orderId, paidOrderIds))
+  : [];
+const linesByOrderId: Record<string, OrderLine[]> = {};
+for (const line of paidLines) {
+  (linesByOrderId[line.orderId] ??= []).push(line);
+}
+```
+
+Pass `paidOrders`, `linesByOrderId`, and `tenant` to the client component.
+
+In `orders-page-client.tsx`, append a print-only section after the Kanban:
+
+```tsx
+<div className="print:block hidden" aria-hidden>
+  {paidOrders.map((order, idx) => (
+    <div
+      key={order.id}
+      className={idx < paidOrders.length - 1 ? "break-after-page" : undefined}
+    >
+      <PickSlip order={order} tenant={tenant} lines={linesByOrderId[order.id] ?? []} />
+    </div>
+  ))}
+</div>
+```
+
+`break-after-page` on every slip except the last avoids a trailing blank page. The Tailwind v4 utility maps to `break-after: page;` so no custom CSS rule is required; if it does not resolve in this project's Tailwind v4 config, fall back to a one-line `@layer utilities` declaration in `src/index.css`.
+
+Slip order: by `placedAt ASC` (oldest paid order first), matching the picking queue's FIFO intent.
+
+### 3. Print CSS additions (`src/index.css`)
+
+Add a single `@page` rule inside the existing `@media print` block:
+
+```css
+@page {
+  size: A4;
+  margin: 12mm;
+}
+```
+
+The 12 mm margin gives standard home/office printers a safe area without consuming so much page that the slip's content gets cramped. No other CSS changes; the existing rules already hide `nav`, `aside`, `[data-admin-sidebar]`, `[data-admin-topbar]`, and `[data-no-print]`, and remove backgrounds.
+
+The Kanban itself does not have a `data-no-print` attribute today — it is hidden by virtue of the page's surrounding `aside`/sidebar wrapper. Verify during QA that the Kanban (which lives inside the page body, not inside an `aside`) is also hidden. If it is not, tag the Kanban container with `data-no-print` so the existing rule catches it.
+
+### 4. Button behaviour
+
+In `orders-page-client.tsx`, replace the existing `onClick={() => window.print()}` with:
+
+```tsx
+function handlePrint() {
+  if (paidOrders.length === 0) return;
+  if (paidOrders.length >= 25 && !window.confirm(`Print ${paidOrders.length} pick slips?`)) {
+    return;
+  }
+  window.print();
+}
+```
+
+Also:
+
+- Button is `disabled` when `paidOrders.length === 0`.
+- Button label remains "Print pick slips"; append a count in parentheses when > 0 (e.g. "Print pick slips (7)") to give the operator a heads-up before they click. Hidden when 0.
+
+### 5. Data flow summary
+
+```
+orders/page.tsx (RSC)
+  ├─ fetches orders + (for Paid only) orderLines
+  └─ passes paidOrders + linesByOrderId to client
+        │
+orders-page-client.tsx
+  ├─ Kanban (visible on screen, hidden in print)
+  ├─ Print button (handlePrint with confirm at ≥ 25)
+  └─ Hidden batch-print section (hidden on screen, visible in print)
+        └─ <PickSlip /> × N with break-after-page on all but last
+
+[orderId]/page.tsx
+  └─ single <PickSlip /> inside its card (unchanged data fetching)
+```
+
+## Risks & open questions
+
+- **Tailwind v4 `break-after-page` utility.** Tailwind v4 ships this utility, but the project's `@theme` block in `src/index.css` does not extend it. If the class does not resolve, add `.break-after-page { break-after: page; }` to `@layer utilities`. Verify during implementation.
+- **Kanban visibility in print.** The orders page wraps the Kanban in a flex container inside the admin shell. The shell's sidebar and topbar are hidden via `aside` and `[data-admin-sidebar]`/`[data-admin-topbar]`. The Kanban itself may still render unless the surrounding container is tagged. Plan to add `data-no-print` to the Kanban container in step 2 to make this explicit rather than rely on inheritance.
+- **DOM weight.** With 50 paid orders × ~30 elements per slip, the hidden print block adds ~1500 nodes to the orders page. Negligible for desktop Chrome/Safari at school-shop scale; not a concern until > 500 paid orders, which would itself be a workflow problem worth flagging.
+- **Long line-item lists.** A single order with > 20 line items could overflow a single A4 page even at 12 mm margin. Acceptable: the slip overflows to a second page and the next slip still starts fresh because `break-after-page` is on the wrapper, not on `tr`. Document this as a known edge case rather than special-case it; school uniform orders rarely exceed 10 items.
+
+## Files touched
+
+- **New:** `apps/web/src/components/admin/pick-slip.tsx`.
+- **Modified:** `apps/web/src/app/admin/[tenant]/orders/page.tsx` (fetch paid-only lines, pass through).
+- **Modified:** `apps/web/src/app/admin/[tenant]/orders/orders-page-client.tsx` (handlePrint, count in label, hidden batch-print section, `data-no-print` on Kanban container).
+- **Modified:** `apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx` (replace inline slip markup with `<PickSlip />`).
+- **Modified:** `apps/web/src/index.css` (add `@page` rule; conditionally add `.break-after-page` if Tailwind utility is unavailable).
+
+## Verification (handed off to operator after merge)
+
+Manual QA on real A4, both Chrome and Safari, on macOS:
+
+1. Single slip: navigate to an order detail page, click Print pick slip, confirm one page with the slip filling it, margins look right, parent-note banner present when set.
+2. Batch (0 paid): orders page button is disabled.
+3. Batch (1 paid): button shows "Print pick slips (1)"; clicking opens the print dialog with exactly one page.
+4. Batch (5 paid): five pages, one slip per page, no trailing blank page, slips ordered oldest-paid-first.
+5. Batch (≥ 25 paid, if available): confirm dialog appears with correct count.
+6. Kanban does not appear anywhere in the print output.
+7. Repeat 1, 4 in Safari.

--- a/docs/superpowers/specs/2026-05-11-batch-print-pick-slips-design.md
+++ b/docs/superpowers/specs/2026-05-11-batch-print-pick-slips-design.md
@@ -1,7 +1,7 @@
 # Batch print pick slips — design
 
 **Date:** 2026-05-11
-**Source:** `docs/remaining_work.md` §3.7 (print stylesheet QA) — split into code half (this spec) and manual A4/Chrome/Safari verification half (to be done by the operator after merge).
+**Source:** `docs/remaining_work.md` §3.7 (print stylesheet QA) — split into a code half (this spec) and a manual A4/Chrome/Safari QA pass handed off to the operator after merge.
 **Status:** Spec.
 
 ## Problem
@@ -12,60 +12,74 @@ Single-slip printing from `apps/web/src/app/admin/[tenant]/orders/[orderId]/page
 
 ## Goal
 
-Clicking **Print pick slips** on the orders page prints one pick slip per "Paid" order, one slip per A4 page, in the same visual format as the single-slip print from the order detail page. No new routes, no popup tabs, no data refetch.
+Clicking **Print pick slips** on the orders page prints one pick slip per "new" order (the picking queue), one slip per A4 page, in the same visual format as the single-slip print from the order detail page. No new routes, no popup tabs, no server snapshot/Kanban-snapshot drift.
 
 ## Non-goals
 
 - Multi-select print (per-order checkboxes on the Kanban).
-- Printing "Ready" or "Collected" orders in bulk (reprints stay on the detail page).
-- Per-day or per-filter scope. Always the full "Paid" bucket.
+- Printing `packing`, `ready`, or `collected` orders in bulk. Reprints stay on the per-order detail page.
+- Per-day or per-filter scope. Always the full `new` bucket.
 - PDF download. The browser's print-to-PDF is sufficient.
-- Audit log integration. Printing is a read action and not part of the 12 audited mutations.
+- Audit log integration. Printing is a read action and is not part of the 12 audited mutations.
+
+## Background — current data flow
+
+- `app/admin/[tenant]/orders/page.tsx` (RSC): fetches tenant only, renders `<OrdersPageClient />`.
+- `orders-page-client.tsx` (client): owns search state + topbar (which contains the **Print pick slips** button), renders `<OrdersBoard />`.
+- `orders-board.tsx` (client): owns the orders array. Loads via `fetch('/api/orders?tenantId=…')` in a `useEffect`. Handles status advance, optimistic update, error revert.
+
+The Kanban data is therefore client-fetched. A naïve fix that adds a separate server-side fetch to `page.tsx` would create a split-brain: the printed slips would come from a request-time snapshot while the on-screen Kanban came from the client fetch, possibly drifting by seconds-to-minutes. The design below keeps the orders state in one place (`OrdersBoard`) and renders the hidden batch-print block as a sibling of the Kanban — so the slips printed and the Kanban shown are always the same array.
+
+## Order status semantics
+
+`OrderStatus` (`orders-board.tsx:7`): `"pending_payment" | "new" | "packing" | "ready" | "collected"`.
+
+Batch print includes **`new` only**:
+
+- `pending_payment` — Stripe hasn't confirmed.
+- **`new` — paid, awaiting pick. The picking queue.**
+- `packing` — operator already started; they already have the slip in hand. Reprints go through the detail page.
+- `ready` — picked + emailed.
+- `collected` — done.
 
 ## Design
 
 ### 1. Shared `PickSlip` component
 
-Extract the existing pick-slip markup from `app/admin/[tenant]/orders/[orderId]/page.tsx` (the inner card starting at the `print:block hidden` parent-note banner, through the crest header, student/parent/order grid, line items, and totals) into a new `apps/web/src/components/admin/pick-slip.tsx`.
+Extract the pick-slip card body from `app/admin/[tenant]/orders/[orderId]/page.tsx` into `apps/web/src/components/admin/pick-slip.tsx`. The card body comprises: optional parent-note banner (print-only), crest + "Pick Slip" title + order ID + `createdAt`, student/parent/order details grid, line items table, totals, and the local barcode SVG. **The Refunds block, the audit `OrderActivityStrip`, and the topbar `<Back / Print / OrderDetailActions>` all stay on the detail page outside `<PickSlip />`.** Reasons:
+
+- Active pickers do not need refund history or audit trail on the slip.
+- Refetching `getOrderRefunds` + `getTotalRefunded` for every `new` order would multiply queries with no operator benefit.
+
+The barcode SVG (currently inline in the detail page) moves into the same file as a local component or sibling (`barcode.tsx`).
 
 Props:
 
 ```ts
 interface PickSlipProps {
-  order: Order;            // from db/schema, includes parentNote, studentName, etc.
-  tenant: Tenant;          // for Crest + accent colour
+  order: Order;            // shape returned by /api/orders (deserialized; createdAt is string)
+  tenant: Tenant;          // the static shape from @/lib/data — what <Crest> accepts today
   lines: OrderLine[];      // line items
 }
 ```
 
-The detail page (`[orderId]/page.tsx`) renders `<PickSlip order={…} tenant={…} lines={…} />` inside its existing card wrapper. There is no visual or behavioural change to the single-slip print path.
+`Order` / `OrderLine` types: define a single shared interface in the new component file matching what `/api/orders` returns over JSON (decimals as strings, `createdAt` as ISO string). The detail page currently uses the Drizzle row type from `getOrderById`; we keep that path working by passing a normalized adapter (same fields, decimals → strings) so `<PickSlip />` accepts one shape from both call sites.
 
-### 2. Batch render on the orders page
+The detail page renders `<PickSlip order={…} tenant={…} lines={…} />` inside its existing white card. There is no visual change to the single-slip print path.
 
-`app/admin/[tenant]/orders/page.tsx` is a Server Component that fetches the Kanban data. It already loads orders for the tenant. Add a query for line items keyed on the "Paid" subset only (so we do not over-fetch lines for "Ready" or "Collected" buckets, which can grow indefinitely):
+### 2. Batch render inside `OrdersBoard`
 
-```ts
-const paidOrders = orders.filter(o => o.status === "paid");
-const paidOrderIds = paidOrders.map(o => o.id);
-const paidLines = paidOrderIds.length > 0
-  ? await db.select().from(orderLines).where(inArray(orderLines.orderId, paidOrderIds))
-  : [];
-const linesByOrderId: Record<string, OrderLine[]> = {};
-for (const line of paidLines) {
-  (linesByOrderId[line.orderId] ??= []).push(line);
-}
-```
+Inside `orders-board.tsx`:
 
-Pass `paidOrders`, `linesByOrderId`, and `tenant` to the client component.
-
-In `orders-page-client.tsx`, append a print-only section after the Kanban:
+1. Derive `newOrders = orders.filter(o => o.status === "new").sort(byCreatedAtAsc)` (FIFO — oldest paid order first).
+2. Render a hidden print-only section as a **sibling of the Kanban**, using the same `orders` state:
 
 ```tsx
 <div className="print:block hidden" aria-hidden>
-  {paidOrders.map((order, idx) => (
+  {newOrders.map((order, idx) => (
     <div
       key={order.id}
-      className={idx < paidOrders.length - 1 ? "break-after-page" : undefined}
+      className={idx < newOrders.length - 1 ? "break-after-page" : undefined}
     >
       <PickSlip order={order} tenant={tenant} lines={linesByOrderId[order.id] ?? []} />
     </div>
@@ -73,13 +87,54 @@ In `orders-page-client.tsx`, append a print-only section after the Kanban:
 </div>
 ```
 
-`break-after-page` on every slip except the last avoids a trailing blank page. The Tailwind v4 utility maps to `break-after: page;` so no custom CSS rule is required; if it does not resolve in this project's Tailwind v4 config, fall back to a one-line `@layer utilities` declaration in `src/index.css`.
+3. Add `data-no-print` to the Kanban root container so the existing `@media print` rule in `src/index.css` hides it. **This is required** — the Kanban is not inside an `aside`, so the existing `aside { display: none }` rule does not catch it.
 
-Slip order: by `placedAt ASC` (oldest paid order first), matching the picking queue's FIFO intent.
+4. Lift `newOrders.length` to `OrdersPageClient` via a callback prop on `<OrdersBoard onNewCountChange={…} />`. `OrdersPageClient` stores it in local state and passes it to the topbar button for the disable/confirm logic in §4.
 
-### 3. Print CSS additions (`src/index.css`)
+### 3. Line items — eager fetch via `/api/orders?withLines=1`
 
-Add a single `@page` rule inside the existing `@media print` block:
+`/api/orders` GET today calls `getOrdersByTenant(tenantId)` which selects from `orders` only. Extend the operator path (no `email` param) so that when `withLines=1` is set, the response includes `lines: OrderLine[]` on each row.
+
+Implementation:
+
+```ts
+const rows = await getOrdersByTenant(tenantId);
+if (searchParams.get("withLines") === "1" && rows.length > 0) {
+  const ids = rows.map(r => r.id);
+  const lines = await db.select().from(orderLines).where(inArray(orderLines.orderId, ids));
+  const linesByOrderId: Record<string, OrderLine[]> = {};
+  for (const line of lines) (linesByOrderId[line.orderId] ??= []).push(line);
+  return NextResponse.json(rows.map(r => ({ ...r, lines: linesByOrderId[r.id] ?? [] })));
+}
+return NextResponse.json(rows);
+```
+
+`OrdersBoard` calls `/api/orders?tenantId=…&withLines=1`. Lines stay attached to the order rows in state; the Kanban ignores them, the hidden print block consumes them via the `linesByOrderId` lookup built in the same component.
+
+Trade-off (acceptable at school-shop scale): every Kanban load now fetches all lines for the tenant, not just `new` orders. Even at 200 orders × 10 lines that is ~50 KB extra JSON. The alternative (a second `/api/orders/lines?orderIds=…` fetched at click time) introduces a state-flush race with `window.print()` and a sync gap between Kanban and slips. Eager fetch is simpler and avoids both.
+
+### 4. Button behaviour
+
+Replace the existing `onClick={() => window.print()}` in `orders-page-client.tsx`:
+
+```tsx
+function handlePrint() {
+  if (newCount === 0) return;
+  // Threshold rationale: 25 is roughly a full-day picking run at one school.
+  // Above that we want a moment of pause before we commit operator-side paper + ink.
+  if (newCount >= 25 && !window.confirm(`Print ${newCount} pick slips?`)) {
+    return;
+  }
+  window.print();
+}
+```
+
+- Button is `disabled` when `newCount === 0` (with a `title` tooltip "No new orders to pick").
+- Button label remains "Print pick slips"; append a count in parentheses when > 0 (e.g. "Print pick slips (7)").
+
+### 5. Print CSS additions (`src/index.css`)
+
+Add to the existing `@media print` block:
 
 ```css
 @page {
@@ -88,69 +143,64 @@ Add a single `@page` rule inside the existing `@media print` block:
 }
 ```
 
-The 12 mm margin gives standard home/office printers a safe area without consuming so much page that the slip's content gets cramped. No other CSS changes; the existing rules already hide `nav`, `aside`, `[data-admin-sidebar]`, `[data-admin-topbar]`, and `[data-no-print]`, and remove backgrounds.
+12 mm gives standard home/office printers a safe area without cramping the slip. No other CSS changes; the existing rules already hide `nav`, `aside`, `[data-admin-sidebar]`, `[data-admin-topbar]`, `[data-no-print]` and remove backgrounds.
 
-The Kanban itself does not have a `data-no-print` attribute today — it is hidden by virtue of the page's surrounding `aside`/sidebar wrapper. Verify during QA that the Kanban (which lives inside the page body, not inside an `aside`) is also hidden. If it is not, tag the Kanban container with `data-no-print` so the existing rule catches it.
+`break-after-page`: Tailwind v4 ships this utility. Verify during implementation that the class resolves under this project's Tailwind v4 config; if not, add a one-line `@layer utilities` rule:
 
-### 4. Button behaviour
-
-In `orders-page-client.tsx`, replace the existing `onClick={() => window.print()}` with:
-
-```tsx
-function handlePrint() {
-  if (paidOrders.length === 0) return;
-  if (paidOrders.length >= 25 && !window.confirm(`Print ${paidOrders.length} pick slips?`)) {
-    return;
-  }
-  window.print();
+```css
+@layer utilities {
+  .break-after-page { break-after: page; }
 }
 ```
 
-Also:
-
-- Button is `disabled` when `paidOrders.length === 0`.
-- Button label remains "Print pick slips"; append a count in parentheses when > 0 (e.g. "Print pick slips (7)") to give the operator a heads-up before they click. Hidden when 0.
-
-### 5. Data flow summary
+### 6. Data flow summary
 
 ```
 orders/page.tsx (RSC)
-  ├─ fetches orders + (for Paid only) orderLines
-  └─ passes paidOrders + linesByOrderId to client
-        │
-orders-page-client.tsx
-  ├─ Kanban (visible on screen, hidden in print)
-  ├─ Print button (handlePrint with confirm at ≥ 25)
-  └─ Hidden batch-print section (hidden on screen, visible in print)
-        └─ <PickSlip /> × N with break-after-page on all but last
+  └─ fetches tenant only → passes to OrdersPageClient
 
-[orderId]/page.tsx
-  └─ single <PickSlip /> inside its card (unchanged data fetching)
+orders-page-client.tsx (client)
+  ├─ topbar
+  │    └─ Print button (handlePrint; reads newCount from local state)
+  ├─ <OrdersBoard onNewCountChange={setNewCount} />
+  └─ search state
+
+orders-board.tsx (client)
+  ├─ fetch('/api/orders?tenantId=…&withLines=1') → orders state (with .lines)
+  ├─ newOrders = orders.filter(status === "new").sort(createdAt ASC)
+  ├─ useEffect → onNewCountChange(newOrders.length)
+  ├─ Kanban (data-no-print on root)
+  └─ Hidden batch-print section
+       └─ <PickSlip /> × newOrders.length, break-after-page on all but last
+
+[orderId]/page.tsx (RSC, unchanged data fetching)
+  └─ <PickSlip /> inside its existing card
+  └─ Refunds + OrderActivityStrip (outside <PickSlip />)
 ```
-
-## Risks & open questions
-
-- **Tailwind v4 `break-after-page` utility.** Tailwind v4 ships this utility, but the project's `@theme` block in `src/index.css` does not extend it. If the class does not resolve, add `.break-after-page { break-after: page; }` to `@layer utilities`. Verify during implementation.
-- **Kanban visibility in print.** The orders page wraps the Kanban in a flex container inside the admin shell. The shell's sidebar and topbar are hidden via `aside` and `[data-admin-sidebar]`/`[data-admin-topbar]`. The Kanban itself may still render unless the surrounding container is tagged. Plan to add `data-no-print` to the Kanban container in step 2 to make this explicit rather than rely on inheritance.
-- **DOM weight.** With 50 paid orders × ~30 elements per slip, the hidden print block adds ~1500 nodes to the orders page. Negligible for desktop Chrome/Safari at school-shop scale; not a concern until > 500 paid orders, which would itself be a workflow problem worth flagging.
-- **Long line-item lists.** A single order with > 20 line items could overflow a single A4 page even at 12 mm margin. Acceptable: the slip overflows to a second page and the next slip still starts fresh because `break-after-page` is on the wrapper, not on `tr`. Document this as a known edge case rather than special-case it; school uniform orders rarely exceed 10 items.
 
 ## Files touched
 
 - **New:** `apps/web/src/components/admin/pick-slip.tsx`.
-- **Modified:** `apps/web/src/app/admin/[tenant]/orders/page.tsx` (fetch paid-only lines, pass through).
-- **Modified:** `apps/web/src/app/admin/[tenant]/orders/orders-page-client.tsx` (handlePrint, count in label, hidden batch-print section, `data-no-print` on Kanban container).
-- **Modified:** `apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx` (replace inline slip markup with `<PickSlip />`).
+- **Modified:** `apps/web/src/app/admin/[tenant]/orders/orders-page-client.tsx` (`newCount` state + `handlePrint` with confirm + label suffix + `disabled`).
+- **Modified:** `apps/web/src/app/admin/[tenant]/orders/orders-board.tsx` (request `withLines=1`, derive `newOrders` sorted FIFO, call `onNewCountChange`, render hidden batch-print section, add `data-no-print` to Kanban root).
+- **Modified:** `apps/web/src/app/admin/[tenant]/orders/[orderId]/page.tsx` (replace inline slip markup with `<PickSlip />`; Refunds + `OrderActivityStrip` stay outside).
+- **Modified:** `apps/web/src/app/api/orders/route.ts` (handle `withLines=1` on the operator-tenant path; second batched `inArray` query for lines).
 - **Modified:** `apps/web/src/index.css` (add `@page` rule; conditionally add `.break-after-page` if Tailwind utility is unavailable).
+
+## Risks
+
+- **Tailwind v4 `break-after-page` utility.** Verify at implementation time. Fallback CSS is one line.
+- **`/api/orders?withLines=1` payload size.** Negligible at current scale (<= a few hundred KB even with 500 orders × 10 lines). Not a concern until well beyond school-shop scale.
+- **Long line-item lists.** A single order with > 20 line items could overflow one A4 page at 12 mm margin. Acceptable: the overflow continues onto a second page and the next slip still starts fresh because `break-after-page` is on the wrapper, not on rows. Documented as a known edge case rather than special-cased; school uniform orders rarely exceed 10 items.
 
 ## Verification (handed off to operator after merge)
 
 Manual QA on real A4, both Chrome and Safari, on macOS:
 
-1. Single slip: navigate to an order detail page, click Print pick slip, confirm one page with the slip filling it, margins look right, parent-note banner present when set.
-2. Batch (0 paid): orders page button is disabled.
-3. Batch (1 paid): button shows "Print pick slips (1)"; clicking opens the print dialog with exactly one page.
-4. Batch (5 paid): five pages, one slip per page, no trailing blank page, slips ordered oldest-paid-first.
-5. Batch (≥ 25 paid, if available): confirm dialog appears with correct count.
+1. Single slip: navigate to an order detail page, click Print pick slip, confirm one page with the slip filling it, margins look right, parent-note banner present when set, barcode renders, refunds + activity strip do *not* print.
+2. Batch (0 new): orders page button is disabled.
+3. Batch (1 new): button shows "Print pick slips (1)"; clicking opens the print dialog with exactly one page.
+4. Batch (5 new): five pages, one slip per page, no trailing blank page, slips ordered oldest-`createdAt`-first.
+5. Batch (≥ 25 new, if available): confirm dialog appears with correct count.
 6. Kanban does not appear anywhere in the print output.
 7. Repeat 1, 4 in Safari.


### PR DESCRIPTION
## Summary

Makes the "Print pick slips" button on `/admin/[tenant]/orders` print one slip per A4 page for every order in status `new`, in the same visual format as the existing single-slip print, with no Kanban/print data drift. Closes the code half of `docs/remaining_work.md` §3.7; the remaining work is manual A4 printer QA in Chrome and Safari.

- Extracted `<PickSlip />` from the order detail page into a shared presentational component with a `refundsSlot` for the detail page's refund block.
- `/api/orders` GET now accepts `?withLines=1` on the operator path, attaching `order_lines` via a single batched `inArray` query.
- Added `@page { size: A4; margin: 12mm }` to the existing `@media print` block.
- `OrdersBoard` now requests `withLines=1`, derives `newOrders` sorted oldest-first, and renders a hidden `print:block` batch as a fragment **sibling** of the Kanban (so the Kanban's `overflow-hidden` can't clip multi-page print output). Lifts `newCount` to `OrdersPageClient` via a `useEffect`-fired callback.
- Topbar **Print pick slips** button: disabled at 0, shows a live count suffix, confirms before printing ≥ 25 slips.

Spec: `docs/superpowers/specs/2026-05-11-batch-print-pick-slips-design.md`
Plan: `docs/superpowers/plans/2026-05-11-batch-print-pick-slips.md`

## Test plan

- [ ] `pnpm check-types:web` — passes (already clean locally)
- [ ] `pnpm dev:web`, log in as operator, open `/admin/nsbh/orders` with ≥ 2 orders in status `new`
- [ ] Click **Print pick slips (N)** → Cmd-P preview shows one slip per A4 page, 12 mm margins, no Kanban/sidebar/topbar, parent-note banner on slips that have one, barcode renders, no trailing blank page
- [ ] With ≥ 25 `new` orders (seed if needed), the confirm dialog appears with the right count
- [ ] Single-slip print on `/admin/nsbh/orders/<id>` still includes the refund block (PickSlip + refundsSlot)
- [ ] Parent portal `/api/orders?tenantId=…&email=…` unaffected
- [ ] Real A4 paper pass in Chrome and Safari on macOS (the remaining manual half of §3.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)