### PR TITLE
feat(catalog): client-side search filter on parent shop

### DIFF
--- a/apps/web/src/app/[tenant]/catalog-grid.tsx
+++ b/apps/web/src/app/[tenant]/catalog-grid.tsx
@@ -98,16 +98,18 @@ export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridP
         })}
       </div>
 
-      {/* Result-count line */}
-      <div className="px-4 pt-3 pb-2 flex-shrink-0 flex items-baseline gap-2">
-        <h3 className="font-serif text-[18px] font-medium m-0">
-          {query ? `Results for "${q.trim()}"` : `${activeCat} Uniform`}
-        </h3>
-        <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
-          · {visible.length} {visible.length === 1 ? "item" : "items"}
-          {query ? " in all categories" : ""}
-        </span>
-      </div>
+      {/* Result-count line (suppressed on empty-match — the empty state below carries the message) */}
+      {!(query && visible.length === 0) && (
+        <div className="px-4 pt-3 pb-2 flex-shrink-0 flex items-baseline gap-2">
+          <h3 className="font-serif text-[18px] font-medium m-0">
+            {query ? `Results for "${q.trim()}"` : `${activeCat} Uniform`}
+          </h3>
+          <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+            · {visible.length} {visible.length === 1 ? "item" : "items"}
+            {query ? " in all categories" : ""}
+          </span>
+        </div>
+      )}
 
       {/* Grid or empty state */}
       {visible.length === 0 && query ? (

--- a/apps/web/src/app/[tenant]/catalog-grid.tsx
+++ b/apps/web/src/app/[tenant]/catalog-grid.tsx
@@ -21,7 +21,10 @@ export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridP
     setQ("");
     inputRef.current?.focus();
   };
-  const visible = items.filter((i) => i.cat === activeCat);
+  const query = q.trim().toLowerCase();
+  const visible = query
+    ? items.filter((it) => (it.name + " " + it.cat).toLowerCase().includes(query))
+    : items.filter((i) => i.cat === activeCat);
 
   return (
     <>
@@ -86,38 +89,59 @@ export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridP
 
       {/* Result-count line */}
       <div className="px-4 pt-3 pb-2 flex-shrink-0 flex items-baseline gap-2">
-        <h3 className="font-serif text-[18px] font-medium m-0">{activeCat} Uniform</h3>
-        <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>· {visible.length} items</span>
+        <h3 className="font-serif text-[18px] font-medium m-0">
+          {query ? `Results for "${q.trim()}"` : `${activeCat} Uniform`}
+        </h3>
+        <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+          · {visible.length} {visible.length === 1 ? "item" : "items"}
+          {query ? " in all categories" : ""}
+        </span>
       </div>
 
-      {/* Grid */}
-      <div className="flex-1 px-4 pb-3 grid grid-cols-2 gap-3 content-start">
-        {visible.map((it) => {
-          const minP = Math.min(...it.variants.map((v) => v.price));
-          const maxP = Math.max(...it.variants.map((v) => v.price));
-          return (
-            <Link
-              key={it.id}
-              href={`/${tenantId}/item/${it.id}`}
-              className="bg-white rounded-[10px] border overflow-hidden block"
-              style={{ borderColor: "var(--color-rule)" }}
-            >
-              <GarmentVector itemId={it.id} accent={accent} size={120} className="w-full h-auto block" />
-              <div className="px-2.5 pt-2 pb-2.5">
-                <div className="font-serif text-[13px] font-medium leading-[1.2] line-clamp-2 min-h-8" style={{ color: "var(--color-ink)" }}>
-                  {it.name}
+      {/* Grid or empty state */}
+      {visible.length === 0 && query ? (
+        <div className="flex-1 px-4 pb-3 flex flex-col items-start gap-3 pt-2">
+          <p className="text-[13px] m-0" style={{ color: "var(--color-ink)" }}>
+            No items match &ldquo;{q.trim()}&rdquo;.
+          </p>
+          <button
+            type="button"
+            onClick={clearSearch}
+            className="text-[13px] underline font-semibold"
+            style={{ color: "var(--color-ink)" }}
+          >
+            Clear search
+          </button>
+        </div>
+      ) : (
+        <div className="flex-1 px-4 pb-3 grid grid-cols-2 gap-3 content-start">
+          {visible.map((it) => {
+            const minP = Math.min(...it.variants.map((v) => v.price));
+            const maxP = Math.max(...it.variants.map((v) => v.price));
+            return (
+              <Link
+                key={it.id}
+                href={`/${tenantId}/item/${it.id}`}
+                className="bg-white rounded-[10px] border overflow-hidden block"
+                style={{ borderColor: "var(--color-rule)" }}
+              >
+                <GarmentVector itemId={it.id} accent={accent} size={120} className="w-full h-auto block" />
+                <div className="px-2.5 pt-2 pb-2.5">
+                  <div className="font-serif text-[13px] font-medium leading-[1.2] line-clamp-2 min-h-8" style={{ color: "var(--color-ink)" }}>
+                    {it.name}
+                  </div>
+                  <div className="mt-1.5 text-[12px] font-semibold tnum" style={{ color: "var(--color-ink)" }}>
+                    ${minP}
+                    {minP !== maxP && (
+                      <span className="font-normal" style={{ color: "var(--color-ink-dim)" }}> – ${maxP}</span>
+                    )}
+                  </div>
                 </div>
-                <div className="mt-1.5 text-[12px] font-semibold tnum" style={{ color: "var(--color-ink)" }}>
-                  ${minP}
-                  {minP !== maxP && (
-                    <span className="font-normal" style={{ color: "var(--color-ink-dim)" }}> – ${maxP}</span>
-                  )}
-                </div>
-              </div>
-            </Link>
-          );
-        })}
-      </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
     </>
   );
 }

--- a/apps/web/src/app/[tenant]/catalog-grid.tsx
+++ b/apps/web/src/app/[tenant]/catalog-grid.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { useRef, useState } from "react";
 import Link from "next/link";
 import type { CatalogItem } from "@/lib/data";
 import { CATEGORIES } from "@/lib/data";
 import { GarmentVector } from "@/components/garment";
-import { SearchIcon } from "@/components/icons";
+import { SearchIcon, ClearIcon } from "@/components/icons";
 
 type CatalogGridProps = {
   items: CatalogItem[];
@@ -14,18 +15,50 @@ type CatalogGridProps = {
 };
 
 export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridProps) {
+  const [q, setQ] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const clearSearch = () => {
+    setQ("");
+    inputRef.current?.focus();
+  };
   const visible = items.filter((i) => i.cat === activeCat);
 
   return (
     <>
-      {/* Search (still static in this task; wired up in Task 3) */}
+      {/* Search */}
       <div className="px-4 pt-3.5 pb-1.5 flex-shrink-0">
         <div
-          className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border"
+          className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border focus-within:ring-2 focus-within:ring-offset-1 focus-within:ring-[var(--color-ink)]"
           style={{ borderColor: "var(--color-rule)" }}
         >
-          <span style={{ color: "var(--color-ink-dim)" }}><SearchIcon size={16} /></span>
-          <span className="text-[13px]" style={{ color: "var(--color-ink-dim)" }}>Search uniforms</span>
+          <span style={{ color: "var(--color-ink-dim)" }} aria-hidden="true">
+            <SearchIcon size={16} />
+          </span>
+          <input
+            ref={inputRef}
+            type="text"
+            inputMode="search"
+            enterKeyHint="search"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            placeholder="Search uniforms"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            aria-label="Search uniforms"
+            className="flex-1 bg-transparent outline-none text-[13px] focus-visible:outline-none placeholder:text-[color:var(--color-ink-dim)]"
+          />
+          {q.length > 0 && (
+            <button
+              type="button"
+              onClick={clearSearch}
+              aria-label="Clear search"
+              className="w-6 h-6 flex items-center justify-center rounded-full"
+              style={{ color: "var(--color-ink-dim)" }}
+            >
+              <ClearIcon size={14} />
+            </button>
+          )}
         </div>
       </div>
 

--- a/apps/web/src/app/[tenant]/catalog-grid.tsx
+++ b/apps/web/src/app/[tenant]/catalog-grid.tsx
@@ -127,8 +127,9 @@ export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridP
       ) : (
         <div className="flex-1 px-4 pb-3 grid grid-cols-2 gap-3 content-start">
           {visible.map((it) => {
-            const minP = Math.min(...it.variants.map((v) => v.price));
-            const maxP = Math.max(...it.variants.map((v) => v.price));
+            const prices = it.variants.map((v) => v.price);
+            const minP = prices.length > 0 ? Math.min(...prices) : 0;
+            const maxP = prices.length > 0 ? Math.max(...prices) : 0;
             return (
               <Link
                 key={it.id}

--- a/apps/web/src/app/[tenant]/catalog-grid.tsx
+++ b/apps/web/src/app/[tenant]/catalog-grid.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import type { CatalogItem } from "@/lib/data";
+import { CATEGORIES } from "@/lib/data";
+import { GarmentVector } from "@/components/garment";
+import { SearchIcon } from "@/components/icons";
+
+type CatalogGridProps = {
+  items: CatalogItem[];
+  activeCat: string;
+  tenantId: string;
+  accent: string;
+};
+
+export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridProps) {
+  const visible = items.filter((i) => i.cat === activeCat);
+
+  return (
+    <>
+      {/* Search (still static in this task; wired up in Task 3) */}
+      <div className="px-4 pt-3.5 pb-1.5 flex-shrink-0">
+        <div
+          className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border"
+          style={{ borderColor: "var(--color-rule)" }}
+        >
+          <span style={{ color: "var(--color-ink-dim)" }}><SearchIcon size={16} /></span>
+          <span className="text-[13px]" style={{ color: "var(--color-ink-dim)" }}>Search uniforms</span>
+        </div>
+      </div>
+
+      {/* Category chips */}
+      <div className="px-4 pt-2.5 pb-1 flex gap-2 overflow-x-auto flex-shrink-0 [&::-webkit-scrollbar]:hidden">
+        {CATEGORIES.map((c) => {
+          const on = c === activeCat;
+          return (
+            <Link
+              key={c}
+              href={`/${tenantId}?cat=${c}`}
+              scroll={false}
+              className="h-[30px] px-3 rounded-full inline-flex items-center text-[12px] font-semibold flex-shrink-0 border"
+              style={{
+                borderColor: on ? accent : "var(--color-rule)",
+                background: on ? accent : "#fff",
+                color: on ? "#fff" : "var(--color-ink)",
+              }}
+            >
+              {c}
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* Result-count line */}
+      <div className="px-4 pt-3 pb-2 flex-shrink-0 flex items-baseline gap-2">
+        <h3 className="font-serif text-[18px] font-medium m-0">{activeCat} Uniform</h3>
+        <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>· {visible.length} items</span>
+      </div>
+
+      {/* Grid */}
+      <div className="flex-1 px-4 pb-3 grid grid-cols-2 gap-3 content-start">
+        {visible.map((it) => {
+          const minP = Math.min(...it.variants.map((v) => v.price));
+          const maxP = Math.max(...it.variants.map((v) => v.price));
+          return (
+            <Link
+              key={it.id}
+              href={`/${tenantId}/item/${it.id}`}
+              className="bg-white rounded-[10px] border overflow-hidden block"
+              style={{ borderColor: "var(--color-rule)" }}
+            >
+              <GarmentVector itemId={it.id} accent={accent} size={120} className="w-full h-auto block" />
+              <div className="px-2.5 pt-2 pb-2.5">
+                <div className="font-serif text-[13px] font-medium leading-[1.2] line-clamp-2 min-h-8" style={{ color: "var(--color-ink)" }}>
+                  {it.name}
+                </div>
+                <div className="mt-1.5 text-[12px] font-semibold tnum" style={{ color: "var(--color-ink)" }}>
+                  ${minP}
+                  {minP !== maxP && (
+                    <span className="font-normal" style={{ color: "var(--color-ink-dim)" }}> – ${maxP}</span>
+                  )}
+                </div>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/[tenant]/catalog-grid.tsx
+++ b/apps/web/src/app/[tenant]/catalog-grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import type { CatalogItem } from "@/lib/data";
 import { CATEGORIES } from "@/lib/data";
@@ -25,6 +25,14 @@ export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridP
   const visible = query
     ? items.filter((it) => (it.name + " " + it.cat).toLowerCase().includes(query))
     : items.filter((i) => i.cat === activeCat);
+
+  const [announced, setAnnounced] = useState("");
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setAnnounced(query === "" ? "" : `${visible.length} results for ${q.trim()}`);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [q, query, visible.length]);
 
   return (
     <>
@@ -63,6 +71,9 @@ export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridP
             </button>
           )}
         </div>
+        <span role="status" aria-live="polite" className="sr-only">
+          {announced}
+        </span>
       </div>
 
       {/* Category chips */}

--- a/apps/web/src/app/[tenant]/page.tsx
+++ b/apps/web/src/app/[tenant]/page.tsx
@@ -5,10 +5,10 @@ import { getTenant, getActiveCatalog, toTenantBrand } from "@/db/queries";
 import { getActiveChild } from "@/lib/active-child.server";
 import { getSessionUser, isPlatformAdminEmail } from "@/lib/auth/authorization";
 import { Crest } from "@/components/crest";
-import { GarmentVector } from "@/components/garment";
-import { CartIcon, SearchIcon } from "@/components/icons";
+import { CartIcon } from "@/components/icons";
 import { MobileShell } from "@/components/mobile-shell";
 import { BottomNav } from "@/components/bottom-nav";
+import { CatalogGrid } from "./catalog-grid";
 
 const DEFAULT_CATEGORY = "Winter";
 
@@ -42,7 +42,6 @@ export default async function CatalogPage({ params, searchParams }: PageProps<"/
     active && active.tenantId === tenant.id
       ? { name: active.name, year: `Year ${active.year}` }
       : null;
-  const items = catalog.filter((i) => i.cat === activeCat);
 
   return (
     <MobileShell bg="var(--color-paper)">
@@ -74,72 +73,12 @@ export default async function CatalogPage({ params, searchParams }: PageProps<"/
         </div>
       </div>
 
-      {/* Search */}
-      <div className="px-4 pt-3.5 pb-1.5 flex-shrink-0">
-        <div
-          className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border"
-          style={{ borderColor: "var(--color-rule)" }}
-        >
-          <span style={{ color: "var(--color-ink-dim)" }}><SearchIcon size={16} /></span>
-          <span className="text-[13px]" style={{ color: "var(--color-ink-dim)" }}>Search uniforms</span>
-        </div>
-      </div>
-
-      {/* Category chips */}
-      <div className="px-4 pt-2.5 pb-1 flex gap-2 overflow-x-auto flex-shrink-0 [&::-webkit-scrollbar]:hidden">
-        {CATEGORIES.map((c) => {
-          const on = c === activeCat;
-          return (
-            <Link
-              key={c}
-              href={`/${tenant.id}?cat=${c}`}
-              scroll={false}
-              className="h-[30px] px-3 rounded-full inline-flex items-center text-[12px] font-semibold flex-shrink-0 border"
-              style={{
-                borderColor: on ? tenant.accent : "var(--color-rule)",
-                background: on ? tenant.accent : "#fff",
-                color: on ? "#fff" : "var(--color-ink)",
-              }}
-            >
-              {c}
-            </Link>
-          );
-        })}
-      </div>
-
-      <div className="px-4 pt-3 pb-2 flex-shrink-0 flex items-baseline gap-2">
-        <h3 className="font-serif text-[18px] font-medium m-0">{activeCat} Uniform</h3>
-        <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>· {items.length} items</span>
-      </div>
-
-      {/* Grid */}
-      <div className="flex-1 px-4 pb-3 grid grid-cols-2 gap-3 content-start">
-        {items.map((it) => {
-          const minP = Math.min(...it.variants.map((v) => v.price));
-          const maxP = Math.max(...it.variants.map((v) => v.price));
-          return (
-            <Link
-              key={it.id}
-              href={`/${tenant.id}/item/${it.id}`}
-              className="bg-white rounded-[10px] border overflow-hidden block"
-              style={{ borderColor: "var(--color-rule)" }}
-            >
-              <GarmentVector itemId={it.id} accent={tenant.accent} size={120} className="w-full h-auto block" />
-              <div className="px-2.5 pt-2 pb-2.5">
-                <div className="font-serif text-[13px] font-medium leading-[1.2] line-clamp-2 min-h-8" style={{ color: "var(--color-ink)" }}>
-                  {it.name}
-                </div>
-                <div className="mt-1.5 text-[12px] font-semibold tnum" style={{ color: "var(--color-ink)" }}>
-                  ${minP}
-                  {minP !== maxP && (
-                    <span className="font-normal" style={{ color: "var(--color-ink-dim)" }}> – ${maxP}</span>
-                  )}
-                </div>
-              </div>
-            </Link>
-          );
-        })}
-      </div>
+      <CatalogGrid
+        items={catalog}
+        activeCat={activeCat}
+        tenantId={tenant.id}
+        accent={tenant.accent}
+      />
 
       <BottomNav active="shop" shopHref={`/${tenant.id}`} accent={tenant.accent} />
     </MobileShell>

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -124,3 +124,11 @@ export function SearchIcon({ size = 16, className }: IconProps) {
     </svg>
   );
 }
+
+export function ClearIcon({ size = 14, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+      <path d="M6 6 L18 18 M18 6 L6 18" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/docs/superpowers/plans/2026-05-12-catalog-search.md
+++ b/docs/superpowers/plans/2026-05-12-catalog-search.md
@@ -1,0 +1,772 @@
+# Catalog Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the fake search-shaped `<div>` at `app/[tenant]/page.tsx:78-86` into a working client-side filter that searches by name + category, with cross-category behavior, accessible empty state, and a debounced screen-reader announcement.
+
+**Architecture:** A single new `"use client"` component (`catalog-grid.tsx`) absorbs the search input, result-count line, grid, and empty state. The RSC `page.tsx` keeps the header/chips/bottom-nav and passes the **full** tenant catalog plus the URL-resolved `activeCat` to the client. The client computes `visible = q ? items.filter(matchFn) : items.filter(byChip)`. Chips remain server-rendered `<Link>` elements driven by `?cat=`.
+
+**Tech Stack:** Next.js 16 App Router (RSC + client islands), Tailwind v4, TypeScript, no test framework — `pnpm check-types:web` is the correctness gate plus manual browser smoke.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-catalog-search-design.md`
+
+**No test suite available** — this project has no Vitest/Jest/Playwright unit tests. Verification gates per task are (1) `pnpm check-types:web` passes and (2) explicit manual browser checks. Treat each manual check as a non-skippable verification step.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `apps/web/src/components/icons.tsx` | Modify (append) | Add `ClearIcon` (×) — 14px stroke-based, matches existing `SearchIcon` style |
+| `apps/web/src/app/[tenant]/catalog-grid.tsx` | Create | `"use client"`. Owns input state, filter, count line, grid, empty state, live region. Returns a React Fragment. |
+| `apps/web/src/app/[tenant]/page.tsx` | Modify (lines 45, 78-86, 110-113, 116-142) | Drop the chip filter; drop the search `<div>`, the `<h3>`, and the grid; render `<CatalogGrid>` in their place. |
+
+---
+
+## Task 1: Add `ClearIcon` to the icon set
+
+**Files:**
+- Modify: `apps/web/src/components/icons.tsx` (append after `SearchIcon` at line 126)
+
+- [ ] **Step 1: Append the `ClearIcon` component**
+
+Open `apps/web/src/components/icons.tsx` and add after the closing `}` of `SearchIcon` (line 126):
+
+```tsx
+export function ClearIcon({ size = 14, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+      <path d="M6 6 L18 18 M18 6 L6 18" strokeLinecap="round" />
+    </svg>
+  );
+}
+```
+
+The stroke width, viewBox, and `IconProps` import match the rest of the file. Default size `14` matches the spec; default for other small icons (`ChevronRightIcon`, `LockIcon`) is also `14`.
+
+- [ ] **Step 2: Verify the file still type-checks**
+
+Run from repo root: `pnpm check-types:web`
+
+Expected: passes with no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/icons.tsx
+git commit -m "feat(icons): add ClearIcon for catalog search clear button"
+```
+
+---
+
+## Task 2: Scaffold `catalog-grid.tsx` as a pure refactor (no behavior change yet)
+
+This task moves the search div, the result-count h3, and the grid out of `page.tsx` and into a new client component **without** changing any rendered output. The static `<div>` search bar stays static in this task. Filter behavior is identical to today. We verify visually that nothing has changed before adding interactivity in Task 3.
+
+**Files:**
+- Create: `apps/web/src/app/[tenant]/catalog-grid.tsx`
+- Modify: `apps/web/src/app/[tenant]/page.tsx` (lines 45, 78-86, 110-113, 116-142)
+
+- [ ] **Step 1: Create the new client component file**
+
+Create `apps/web/src/app/[tenant]/catalog-grid.tsx`:
+
+```tsx
+"use client";
+
+import Link from "next/link";
+import type { CatalogItem } from "@/lib/data";
+import { GarmentVector } from "@/components/garment";
+import { SearchIcon } from "@/components/icons";
+
+type CatalogGridProps = {
+  items: CatalogItem[];   // full tenant catalog (NOT chip-filtered)
+  activeCat: string;
+  tenantId: string;
+  accent: string;
+};
+
+export function CatalogGrid({ items, activeCat, tenantId }: CatalogGridProps) {
+  const visible = items.filter((i) => i.cat === activeCat);
+
+  return (
+    <>
+      {/* Search (still static in this task; wired up in Task 3) */}
+      <div className="px-4 pt-3.5 pb-1.5 flex-shrink-0">
+        <div
+          className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border"
+          style={{ borderColor: "var(--color-rule)" }}
+        >
+          <span style={{ color: "var(--color-ink-dim)" }}><SearchIcon size={16} /></span>
+          <span className="text-[13px]" style={{ color: "var(--color-ink-dim)" }}>Search uniforms</span>
+        </div>
+      </div>
+
+      {/* Result-count line */}
+      <div className="px-4 pt-3 pb-2 flex-shrink-0 flex items-baseline gap-2">
+        <h3 className="font-serif text-[18px] font-medium m-0">{activeCat} Uniform</h3>
+        <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>· {visible.length} items</span>
+      </div>
+
+      {/* Grid */}
+      <div className="flex-1 px-4 pb-3 grid grid-cols-2 gap-3 content-start">
+        {visible.map((it) => {
+          const minP = Math.min(...it.variants.map((v) => v.price));
+          const maxP = Math.max(...it.variants.map((v) => v.price));
+          return (
+            <Link
+              key={it.id}
+              href={`/${tenantId}/item/${it.id}`}
+              className="bg-white rounded-[10px] border overflow-hidden block"
+              style={{ borderColor: "var(--color-rule)" }}
+            >
+              <GarmentVector itemId={it.id} accent="currentColor" size={120} className="w-full h-auto block" />
+              <div className="px-2.5 pt-2 pb-2.5">
+                <div className="font-serif text-[13px] font-medium leading-[1.2] line-clamp-2 min-h-8" style={{ color: "var(--color-ink)" }}>
+                  {it.name}
+                </div>
+                <div className="mt-1.5 text-[12px] font-semibold tnum" style={{ color: "var(--color-ink)" }}>
+                  ${minP}
+                  {minP !== maxP && (
+                    <span className="font-normal" style={{ color: "var(--color-ink-dim)" }}> – ${maxP}</span>
+                  )}
+                </div>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+```
+
+Note: the existing grid in `page.tsx:127` passes `accent={tenant.accent}` to `GarmentVector`. We need to preserve that. The `accent` prop is in `CatalogGridProps`; restore the binding:
+
+Replace this line in the file you just created:
+
+```tsx
+              <GarmentVector itemId={it.id} accent="currentColor" size={120} className="w-full h-auto block" />
+```
+
+With:
+
+```tsx
+              <GarmentVector itemId={it.id} accent={accent} size={120} className="w-full h-auto block" />
+```
+
+And update the function signature to destructure `accent`:
+
+```tsx
+export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridProps) {
+```
+
+- [ ] **Step 2: Modify `page.tsx` to render `<CatalogGrid>` in place of the moved blocks**
+
+Open `apps/web/src/app/[tenant]/page.tsx`.
+
+**Add import** at the top of the imports block (after the existing `BottomNav` import on line 11):
+
+```tsx
+import { CatalogGrid } from "./catalog-grid";
+```
+
+**Delete line 45** (the chip-filtered local variable — the client will do this now):
+
+```tsx
+  const items = catalog.filter((i) => i.cat === activeCat);
+```
+
+**Delete lines 77-86** (the static search div block, including its `{/* Search */}` comment):
+
+```tsx
+      {/* Search */}
+      <div className="px-4 pt-3.5 pb-1.5 flex-shrink-0">
+        <div
+          className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border"
+          style={{ borderColor: "var(--color-rule)" }}
+        >
+          <span style={{ color: "var(--color-ink-dim)" }}><SearchIcon size={16} /></span>
+          <span className="text-[13px]" style={{ color: "var(--color-ink-dim)" }}>Search uniforms</span>
+        </div>
+      </div>
+```
+
+**Delete lines 110-113** (the result-count `<h3>` wrapper block):
+
+```tsx
+      <div className="px-4 pt-3 pb-2 flex-shrink-0 flex items-baseline gap-2">
+        <h3 className="font-serif text-[18px] font-medium m-0">{activeCat} Uniform</h3>
+        <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>· {items.length} items</span>
+      </div>
+```
+
+**Delete lines 115-142** (the grid block, including its `{/* Grid */}` comment).
+
+**Insert** `<CatalogGrid ... />` where the deleted search block used to be (immediately after the closing `</div>` of the tenant-themed header strip, before the `{/* Category chips */}` comment):
+
+```tsx
+      <CatalogGrid
+        items={catalog}
+        activeCat={activeCat}
+        tenantId={tenant.id}
+        accent={tenant.accent}
+      />
+```
+
+Wait — the chips region currently sits between the search and the grid. After the move, the structure inside `<MobileShell>` should be:
+
+```
+<MobileShell>
+  <div /* tenant-themed header strip */>...</div>
+  <CatalogGrid /* renders: search wrapper, count line, grid, empty state */ />
+  <div /* Category chips */>...</div>
+  <BottomNav />
+</MobileShell>
+```
+
+But that places chips BELOW the grid, which is wrong. The original order is: header, search, chips, h3, grid. To preserve that order with CatalogGrid owning {search, h3, grid}, we have to either:
+- (a) Keep chips inside CatalogGrid (but the spec says chips stay server-rendered)
+- (b) Split CatalogGrid into two pieces (search wrapper above chips; count+grid below) — adds complexity
+- (c) Place CatalogGrid AFTER the chips, and have CatalogGrid render only the count line + grid + empty state; keep the search wrapper in `page.tsx` as a server-rendered fragment that uses a separate small client component just for the input
+
+The simplest is **(d) keep the original visual order by re-ordering CatalogGrid's responsibility**: chips render between the search and the h3, so split CatalogGrid into two adjacent fragments around the chips. That contradicts the "single Fragment" design.
+
+Resolution: **make the chips part of `CatalogGrid`'s render**, but keep them as plain server-style `<Link>` elements (Next's `Link` works inside client components — it just renders an `<a>` for `<Link>` with no special server requirement). The "chips remain server-rendered" line in the spec is about URL navigation semantics, not about which component renders them. Confirm by re-reading the spec — §Architecture says "chips (still server-rendered `<Link>` elements driven by `?cat=`)". A `<Link>` inside a client component still behaves identically: it's a client-routed navigation that updates `?cat=` in the URL, and the RSC re-renders on the next request. No semantic loss.
+
+**Updated plan for Task 2 Step 2:** also move the chips block (lines 89-108) into `catalog-grid.tsx`, and delete it from `page.tsx`. Update `catalog-grid.tsx` to render chips between the search wrapper and the result-count line.
+
+Add this `CATEGORIES` import to `catalog-grid.tsx`:
+
+```tsx
+import { CATEGORIES } from "@/lib/data";
+```
+
+And insert this block in `catalog-grid.tsx` between the search wrapper and the result-count line:
+
+```tsx
+      {/* Category chips */}
+      <div className="px-4 pt-2.5 pb-1 flex gap-2 overflow-x-auto flex-shrink-0 [&::-webkit-scrollbar]:hidden">
+        {CATEGORIES.map((c) => {
+          const on = c === activeCat;
+          return (
+            <Link
+              key={c}
+              href={`/${tenantId}?cat=${c}`}
+              scroll={false}
+              className="h-[30px] px-3 rounded-full inline-flex items-center text-[12px] font-semibold flex-shrink-0 border"
+              style={{
+                borderColor: on ? accent : "var(--color-rule)",
+                background: on ? accent : "#fff",
+                color: on ? "#fff" : "var(--color-ink)",
+              }}
+            >
+              {c}
+            </Link>
+          );
+        })}
+      </div>
+```
+
+In `page.tsx`, also delete the chips block (lines 88-108) and the unused `CATEGORIES` import on line 3 if no other usage remains in `page.tsx` (verify with a grep of the file before deleting the import).
+
+Also remove the now-unused `SearchIcon` import from `page.tsx`'s import on line 9.
+
+After deletions, the body of `page.tsx`'s `return` should look like:
+
+```tsx
+  return (
+    <MobileShell bg="var(--color-paper)">
+      {/* Tenant-themed header strip */}
+      <div className="text-white px-4 pt-1 pb-3.5 flex-shrink-0" style={{ background: tenant.accent }}>
+        {/* ... unchanged header content ... */}
+      </div>
+
+      <CatalogGrid
+        items={catalog}
+        activeCat={activeCat}
+        tenantId={tenant.id}
+        accent={tenant.accent}
+      />
+
+      <BottomNav active="shop" shopHref={`/${tenant.id}`} accent={tenant.accent} />
+    </MobileShell>
+  );
+```
+
+- [ ] **Step 3: Verify the page still type-checks**
+
+Run from repo root: `pnpm check-types:web`
+
+Expected: passes. If you see an "unused import" error, remove the offending line from `page.tsx`.
+
+- [ ] **Step 4: Visual smoke (mandatory — no behavior should have changed)**
+
+Run: `pnpm dev:web`
+
+Open `http://localhost:3000/nsbh` in a browser. Verify:
+- The header strip looks identical to before (Crest, school name, cart badge).
+- A static-looking search pill is below the header (still not interactive — that's Task 3).
+- Category chips render below the search pill in the same order ("Summer", "Winter", etc.).
+- Clicking a chip navigates to `?cat=Summer` and the chip highlight follows the URL.
+- The result-count line ("{activeCat} Uniform · N items") shows the correct N for the active chip.
+- The 2-column grid renders all items in the active chip with garment SVGs, name, and price range.
+- The bottom nav shows.
+
+If anything differs from the pre-task state, stop and investigate. This task is a pure refactor — any visible change is a regression.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/[tenant]/catalog-grid.tsx apps/web/src/app/[tenant]/page.tsx
+git commit -m "refactor([tenant]/page): extract CatalogGrid client component
+
+Pure move of search wrapper, chips, result-count line, and grid into a
+new \"use client\" component. No behavior change — wires up to the same
+chip-filtered visible array as before. Sets up Task 3 (real search input)
+and Task 4 (filter logic) without touching layout or styling."
+```
+
+---
+
+## Task 3: Replace the static search `<div>` with a real `<input>` + clear button
+
+Now we wire up the interactive search input and the clear button. The filter logic stays simple in this task — same chip-scoped behavior as Task 2 regardless of what's typed. Task 4 adds the real filter.
+
+**Files:**
+- Modify: `apps/web/src/app/[tenant]/catalog-grid.tsx`
+
+- [ ] **Step 1: Add React state and the `ClearIcon` import**
+
+At the top of `catalog-grid.tsx`, after the existing imports, add:
+
+```tsx
+import { useState } from "react";
+import { SearchIcon, ClearIcon } from "@/components/icons";
+```
+
+Remove the duplicate `SearchIcon` import (replace the existing single-import line). After this step the icon import line should read:
+
+```tsx
+import { SearchIcon, ClearIcon } from "@/components/icons";
+```
+
+Inside the function body, add at the top:
+
+```tsx
+export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridProps) {
+  const [q, setQ] = useState("");
+  const visible = items.filter((i) => i.cat === activeCat);
+  // ... rest unchanged for now
+```
+
+- [ ] **Step 2: Replace the static search-pill block with an interactive one**
+
+In `catalog-grid.tsx`, find the search wrapper block:
+
+```tsx
+      {/* Search (still static in this task; wired up in Task 3) */}
+      <div className="px-4 pt-3.5 pb-1.5 flex-shrink-0">
+        <div
+          className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border"
+          style={{ borderColor: "var(--color-rule)" }}
+        >
+          <span style={{ color: "var(--color-ink-dim)" }}><SearchIcon size={16} /></span>
+          <span className="text-[13px]" style={{ color: "var(--color-ink-dim)" }}>Search uniforms</span>
+        </div>
+      </div>
+```
+
+Replace with:
+
+```tsx
+      {/* Search */}
+      <div className="px-4 pt-3.5 pb-1.5 flex-shrink-0">
+        <div
+          className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border focus-within:ring-2 focus-within:ring-offset-1 focus-within:ring-[var(--color-ink)]"
+          style={{ borderColor: "var(--color-rule)" }}
+        >
+          <span style={{ color: "var(--color-ink-dim)" }} aria-hidden="true">
+            <SearchIcon size={16} />
+          </span>
+          <input
+            type="text"
+            inputMode="search"
+            enterKeyHint="search"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            placeholder="Search uniforms"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            aria-label="Search uniforms"
+            className="flex-1 bg-transparent outline-none text-[13px] focus-visible:outline-none placeholder:text-[color:var(--color-ink-dim)]"
+          />
+          {q.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setQ("")}
+              aria-label="Clear search"
+              className="w-6 h-6 flex items-center justify-center rounded-full"
+              style={{ color: "var(--color-ink-dim)" }}
+            >
+              <ClearIcon size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+```
+
+Key choices encoded here:
+- `type="text"` not `type="search"` — avoids WebKit's native × clear button collision with our custom one.
+- `inputMode="search"` + `enterKeyHint="search"` triggers the mobile "Search" return key.
+- `placeholder:text-[color:var(--color-ink-dim)]` mirrors the original placeholder color.
+- `focus-within:ring-*` is on the wrapper pill so the visible 40px container lights up on focus; the input's own focus outline is suppressed so we don't get two rings.
+- Clear button is a real `<button type="button">` with `aria-label`.
+
+- [ ] **Step 3: Type check**
+
+Run: `pnpm check-types:web`
+
+Expected: passes.
+
+- [ ] **Step 4: Manual smoke**
+
+Run `pnpm dev:web` (skip if already running) and visit `/nsbh`. Verify:
+- The search pill now accepts focus on click/tap. Focus ring appears around the pill.
+- Typing into the input updates the visible text (state is wired). The × button appears as soon as you type a character.
+- Clicking the × button clears the input and hides itself.
+- The filter behavior is **unchanged** — the grid still shows whatever the active chip dictates regardless of what you type (Task 4 fixes this).
+- On a mobile device (or DevTools mobile emulator with a touch keyboard), confirm the on-screen keyboard shows "Search" on its return key (this verifies `inputMode="search"` + `enterKeyHint="search"`).
+- No browser-native × clear icon appears inside the input (verifies `type="text"` choice).
+- Keyboard navigation: Tab into the input, type, Tab to the × button (when present), Enter on × clears.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/[tenant]/catalog-grid.tsx
+git commit -m "feat(catalog): wire up real search input with clear button
+
+Replaces the static search-shaped <div> with a working <input> + custom
+× clear button. Uses type=text + inputMode=search to avoid WebKit's
+native clear-button collision. Focus ring on the wrapper pill via
+focus-within:. Filter logic still chip-scoped — Task 4 adds the real
+filter behavior."
+```
+
+---
+
+## Task 4: Add the real filter logic + dynamic result-count line + empty state
+
+Now the search actually filters. Cross-category when q is non-empty; chip-scoped when q is empty. Result-count line updates to reflect mode. Empty state renders when no matches.
+
+**Files:**
+- Modify: `apps/web/src/app/[tenant]/catalog-grid.tsx`
+
+- [ ] **Step 1: Add the match function and update the `visible` computation**
+
+In `catalog-grid.tsx`, replace the line:
+
+```tsx
+  const visible = items.filter((i) => i.cat === activeCat);
+```
+
+with:
+
+```tsx
+  const query = q.trim().toLowerCase();
+  const visible = query
+    ? items.filter((it) => (it.name + " " + it.cat).toLowerCase().includes(query))
+    : items.filter((i) => i.cat === activeCat);
+```
+
+Encoded behavior:
+- Empty/whitespace query → chip-scoped (current behavior).
+- Non-empty query → spans all categories, matches against `name + " " + category` case-insensitively.
+
+- [ ] **Step 2: Update the result-count line to reflect search mode**
+
+In `catalog-grid.tsx`, find the result-count block:
+
+```tsx
+      {/* Result-count line */}
+      <div className="px-4 pt-3 pb-2 flex-shrink-0 flex items-baseline gap-2">
+        <h3 className="font-serif text-[18px] font-medium m-0">{activeCat} Uniform</h3>
+        <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>· {visible.length} items</span>
+      </div>
+```
+
+Replace with:
+
+```tsx
+      {/* Result-count line */}
+      <div className="px-4 pt-3 pb-2 flex-shrink-0 flex items-baseline gap-2">
+        <h3 className="font-serif text-[18px] font-medium m-0">
+          {query ? `Results for "${q.trim()}"` : `${activeCat} Uniform`}
+        </h3>
+        <span className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+          · {visible.length} {visible.length === 1 ? "item" : "items"}
+          {query ? " in all categories" : ""}
+        </span>
+      </div>
+```
+
+Pluralisation tweak (`item` vs `items`) included while we're here — small polish, no separate task warranted.
+
+- [ ] **Step 3: Add the empty-state branch**
+
+In `catalog-grid.tsx`, find the grid block:
+
+```tsx
+      {/* Grid */}
+      <div className="flex-1 px-4 pb-3 grid grid-cols-2 gap-3 content-start">
+        {visible.map((it) => {
+          // ...
+        })}
+      </div>
+```
+
+Wrap the grid in an empty-state ternary. Replace the whole block above with:
+
+```tsx
+      {/* Grid or empty state */}
+      {visible.length === 0 && query ? (
+        <div className="flex-1 px-4 pb-3 flex flex-col items-start gap-3 pt-2">
+          <p className="text-[13px] m-0" style={{ color: "var(--color-ink)" }}>
+            No items match &ldquo;{q.trim()}&rdquo;.
+          </p>
+          <button
+            type="button"
+            onClick={() => setQ("")}
+            className="text-[13px] underline font-semibold"
+            style={{ color: "var(--color-ink)" }}
+          >
+            Clear search
+          </button>
+        </div>
+      ) : (
+        <div className="flex-1 px-4 pb-3 grid grid-cols-2 gap-3 content-start">
+          {visible.map((it) => {
+            const minP = Math.min(...it.variants.map((v) => v.price));
+            const maxP = Math.max(...it.variants.map((v) => v.price));
+            return (
+              <Link
+                key={it.id}
+                href={`/${tenantId}/item/${it.id}`}
+                className="bg-white rounded-[10px] border overflow-hidden block"
+                style={{ borderColor: "var(--color-rule)" }}
+              >
+                <GarmentVector itemId={it.id} accent={accent} size={120} className="w-full h-auto block" />
+                <div className="px-2.5 pt-2 pb-2.5">
+                  <div className="font-serif text-[13px] font-medium leading-[1.2] line-clamp-2 min-h-8" style={{ color: "var(--color-ink)" }}>
+                    {it.name}
+                  </div>
+                  <div className="mt-1.5 text-[12px] font-semibold tnum" style={{ color: "var(--color-ink)" }}>
+                    ${minP}
+                    {minP !== maxP && (
+                      <span className="font-normal" style={{ color: "var(--color-ink-dim)" }}> – ${maxP}</span>
+                    )}
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+```
+
+The empty state only shows when there's an active query AND no results. An empty active-chip slice (which shouldn't happen given current data, but in principle could) still renders the empty grid container — that matches today's behavior.
+
+- [ ] **Step 4: Type check**
+
+Run: `pnpm check-types:web`
+
+Expected: passes.
+
+- [ ] **Step 5: Manual smoke**
+
+Run `pnpm dev:web` and visit `/nsbh`. Verify:
+
+1. **No query, default chip:** Title reads `Winter Uniform · N items`. Grid shows all Winter items.
+2. **No query, change chip to Summer:** Title reads `Summer Uniform · N items`. Grid shows all Summer items.
+3. **Type "blazer" while Summer chip is active:** Title switches to `Results for "blazer" · 1 item in all categories` (or similar — depends on the catalog). The grid shows the Blazer even though it's a Winter item. Cross-category behavior is verified.
+4. **Type partial name** (e.g. "shir"): live filter, multiple matches across categories.
+5. **Type a category name** (e.g. "winter"): matches all Winter items by category text.
+6. **Type "xyz" (no matches):** empty state renders with the "No items match 'xyz'." copy and a "Clear search" button.
+7. **Click "Clear search" in the empty state:** Query clears, grid returns to chip-scoped view.
+8. **Click × button while typing:** Same — clears query.
+9. **Singular pluralisation:** type something matching exactly 1 item; verify "· 1 item" (not "items").
+10. **Quotes in copy:** title shows curly quotes around the query (the `&ldquo;` / `&rdquo;` entities render as `"..."`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/[tenant]/catalog-grid.tsx
+git commit -m "feat(catalog): real search filter + empty state
+
+Search filters by name + category (case-insensitive substring) across
+ALL categories when a query is present; chips drive the grid only when
+the query is empty. Result-count line switches copy to indicate
+cross-category mode. Empty state renders an inline 'No items match'
+message with a Clear search button when no results."
+```
+
+---
+
+## Task 5: Accessibility — debounced screen-reader live region
+
+The filter is sync; the announcement is debounced ~300ms so screen readers don't get a stream of mid-word counts.
+
+**Files:**
+- Modify: `apps/web/src/app/[tenant]/catalog-grid.tsx`
+
+- [ ] **Step 1: Add `useEffect` import and announcement state**
+
+In `catalog-grid.tsx`, update the React import:
+
+```tsx
+import { useEffect, useState } from "react";
+```
+
+Inside `CatalogGrid`, after the existing `useState` line, add:
+
+```tsx
+  const [announced, setAnnounced] = useState("");
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setAnnounced(query === "" ? "" : `${visible.length} results for ${q.trim()}`);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [q, query, visible.length]);
+```
+
+- [ ] **Step 2: Add the live region to the JSX**
+
+In `catalog-grid.tsx`, find the search wrapper's outer div (the one with `px-4 pt-3.5 pb-1.5 flex-shrink-0`). Immediately AFTER the closing `</div>` of the inner pill (the wrapper with `h-10 rounded-lg ...`), but still INSIDE the outer wrapper, add:
+
+```tsx
+          <span role="status" aria-live="polite" className="sr-only">
+            {announced}
+          </span>
+```
+
+So the search wrapper now looks like:
+
+```tsx
+      {/* Search */}
+      <div className="px-4 pt-3.5 pb-1.5 flex-shrink-0">
+        <div
+          className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border focus-within:ring-2 focus-within:ring-offset-1 focus-within:ring-[var(--color-ink)]"
+          style={{ borderColor: "var(--color-rule)" }}
+        >
+          {/* ... unchanged input, icons, clear button ... */}
+        </div>
+        <span role="status" aria-live="polite" className="sr-only">
+          {announced}
+        </span>
+      </div>
+```
+
+Note: `sr-only` is a Tailwind utility provided by the default v4 install. If `pnpm check-types:web` flags it as missing or the smoke test shows the text rendering visibly, verify the project's globals — search for `sr-only` in `apps/web/src/index.css` or its Tailwind config. (If absent, add the standard equivalent: `className="absolute w-px h-px p-0 m-[-1px] overflow-hidden whitespace-nowrap border-0"`.)
+
+- [ ] **Step 3: Type check**
+
+Run: `pnpm check-types:web`
+
+Expected: passes.
+
+- [ ] **Step 4: Manual smoke**
+
+1. Inspect the DOM in browser DevTools after typing. Confirm the `<span role="status" aria-live="polite">` exists and its text content updates ~300ms after the last keystroke (not on every keystroke).
+2. Confirm the span is not visible (off-screen via `sr-only`).
+3. Optional: enable VoiceOver (Cmd+F5 on macOS), focus the input, type quickly. Verify the announcement comes once at the end of typing, not on every key.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/[tenant]/catalog-grid.tsx
+git commit -m "feat(catalog): a11y — debounced live-region for result count
+
+Screen readers get a single announcement ~300ms after typing settles,
+not on every keystroke. Filter itself remains synchronous — only the
+aria-live announcement is debounced. sr-only span hidden from sighted
+users."
+```
+
+---
+
+## Task 6: Final verification pass
+
+This is a checkpoint task — no new code, just structured verification of all spec requirements before merging.
+
+- [ ] **Step 1: Type-check the whole monorepo**
+
+Run: `pnpm check-types`
+
+Expected: passes across all packages.
+
+- [ ] **Step 2: Build the production bundle**
+
+Run: `pnpm build:web`
+
+Expected: build succeeds without errors. Watch for any "use client" / serialization warnings about `CatalogGrid` props.
+
+- [ ] **Step 3: Walk the spec's §Verification checklist explicitly**
+
+Run `pnpm dev:web` and confirm each of the following from the spec at `docs/superpowers/specs/2026-05-12-catalog-search-design.md`:
+
+- [ ] Type "blazer" with each chip active → cross-category result every time.
+- [ ] Type partial item name → live filter.
+- [ ] Click × → clears, returns to chip view.
+- [ ] Type "xyz" → empty state with the "Clear search" button.
+- [ ] Keyboard-only: Tab to input, type, Tab to × button, Enter clears, Tab to first card.
+- [ ] Mobile keyboard (iOS Safari or Android Chrome via real device): "Search" return key visible.
+- [ ] Only one × visible at all times (no WebKit-native one collides with our custom button).
+- [ ] Focus-within ring on the search pill is visible and meets WCAG visible-focus criterion (clear 2px ring with offset).
+- [ ] Print stylesheet (§3.7): print the orders board pick-slips and confirm the search input does not appear in the printed output. (It shouldn't — it's not in the pick-slip DOM, but verify.)
+- [ ] §3.9 viewport audit: visually re-walk the parent shop catalog page on iPhone SE viewport (375×667) and confirm no new tap-target P1s. The 24×24 × button has 8px of vertical padding from the parent's `pt-3.5 pb-1.5`, giving an effective ≥40px hit-target.
+- [ ] Screen reader smoke (VoiceOver on iOS or NVDA on Windows): announcement fires ~300ms after typing settles, not on every keystroke.
+
+- [ ] **Step 4: Optional — open a PR**
+
+If working off a feature branch, push and open a PR. Otherwise the work is on `main` and ready.
+
+```bash
+git log --oneline -6
+```
+
+Expected output (most recent commits, top to bottom):
+
+```
+<hash> feat(catalog): a11y — debounced live-region for result count
+<hash> feat(catalog): real search filter + empty state
+<hash> feat(catalog): wire up real search input with clear button
+<hash> refactor([tenant]/page): extract CatalogGrid client component
+<hash> feat(icons): add ClearIcon for catalog search clear button
+<hash> docs(spec): catalog-search — review fixes (7 defects + 3 simplifications)
+```
+
+If the order is correct and all type-checks/builds pass, the implementation is done.
+
+---
+
+## Spec Coverage Map
+
+| Spec section | Implemented in |
+|---|---|
+| §Decision — client-side substring | Task 4 Step 1 |
+| §Architecture — file split | Task 2 |
+| §Architecture — Fragment, no wrapping div | Task 2 Step 1 (`<>...</>`) |
+| §Component contract — single `items` prop | Task 2 Step 1 |
+| §Match function | Task 4 Step 1 |
+| §Chip interaction (cross-category when q≠"") | Task 4 Step 1 |
+| §Result-count line | Task 4 Step 2 |
+| §Empty state (single button) | Task 4 Step 3 |
+| §Input markup & mobile hygiene | Task 3 Step 2 |
+| §`type="text"` not `type="search"` | Task 3 Step 2 |
+| §Focus-within ring on wrapper | Task 3 Step 2 |
+| §A11y — aria-label, aria-hidden, button label | Task 3 Step 2 |
+| §A11y — debounced live region | Task 5 |
+| §`ClearIcon` icon | Task 1 |
+| §Verification | Task 6 |

--- a/docs/superpowers/plans/2026-05-12-catalog-search.md
+++ b/docs/superpowers/plans/2026-05-12-catalog-search.md
@@ -12,6 +12,9 @@
 
 **No test suite available** — this project has no Vitest/Jest/Playwright unit tests. Verification gates per task are (1) `pnpm check-types:web` passes and (2) explicit manual browser checks. Treat each manual check as a non-skippable verification step.
 
+**Out-of-scope quirks you'll see while working** (do not fix in this plan):
+- The cart-icon badge in the header renders a hardcoded `6` at `page.tsx:70`. It's stub UI awaiting cart-count wiring; not in scope for this work. Leave it alone.
+
 ---
 
 ## File Structure
@@ -62,21 +65,24 @@ git commit -m "feat(icons): add ClearIcon for catalog search clear button"
 
 ## Task 2: Scaffold `catalog-grid.tsx` as a pure refactor (no behavior change yet)
 
-This task moves the search div, the result-count h3, and the grid out of `page.tsx` and into a new client component **without** changing any rendered output. The static `<div>` search bar stays static in this task. Filter behavior is identical to today. We verify visually that nothing has changed before adding interactivity in Task 3.
+This task moves the search div, the result-count h3, **and the chips block** out of `page.tsx` and into a new client component **without** changing any rendered output. The static `<div>` search bar stays static in this task. Filter behavior is identical to today. We verify visually that nothing has changed before adding interactivity in Task 3.
+
+> **⚠️ Spec deviation — flagged for visibility:** The spec §Architecture says "page.tsx keeps the header strip, **chips**, and bottom-nav." This plan moves the chips into `CatalogGrid` instead. **Reason:** the chips render *between* the search wrapper and the result-count line in the existing layout. To keep `CatalogGrid` a single Fragment (per §Architecture's other requirement), all three regions must be sibling flex children inside the same component — splitting into two CatalogGrid pieces around the chips would create two client islands for no semantic gain. Chips remain navigation `<Link>` elements driven by `?cat=` — their URL-driven semantics are unchanged whether they render in an RSC or a client component. No behavioural loss; spec is only deviated on *which file* the chips live in.
 
 **Files:**
 - Create: `apps/web/src/app/[tenant]/catalog-grid.tsx`
-- Modify: `apps/web/src/app/[tenant]/page.tsx` (lines 45, 78-86, 110-113, 116-142)
+- Modify: `apps/web/src/app/[tenant]/page.tsx` (lines 45, 78-86, 88-108, 110-113, 115-142, and unused imports)
 
 - [ ] **Step 1: Create the new client component file**
 
-Create `apps/web/src/app/[tenant]/catalog-grid.tsx`:
+Create `apps/web/src/app/[tenant]/catalog-grid.tsx` with the final-correct code (no later patches required):
 
 ```tsx
 "use client";
 
 import Link from "next/link";
 import type { CatalogItem } from "@/lib/data";
+import { CATEGORIES } from "@/lib/data";
 import { GarmentVector } from "@/components/garment";
 import { SearchIcon } from "@/components/icons";
 
@@ -87,7 +93,7 @@ type CatalogGridProps = {
   accent: string;
 };
 
-export function CatalogGrid({ items, activeCat, tenantId }: CatalogGridProps) {
+export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridProps) {
   const visible = items.filter((i) => i.cat === activeCat);
 
   return (
@@ -101,6 +107,28 @@ export function CatalogGrid({ items, activeCat, tenantId }: CatalogGridProps) {
           <span style={{ color: "var(--color-ink-dim)" }}><SearchIcon size={16} /></span>
           <span className="text-[13px]" style={{ color: "var(--color-ink-dim)" }}>Search uniforms</span>
         </div>
+      </div>
+
+      {/* Category chips */}
+      <div className="px-4 pt-2.5 pb-1 flex gap-2 overflow-x-auto flex-shrink-0 [&::-webkit-scrollbar]:hidden">
+        {CATEGORIES.map((c) => {
+          const on = c === activeCat;
+          return (
+            <Link
+              key={c}
+              href={`/${tenantId}?cat=${c}`}
+              scroll={false}
+              className="h-[30px] px-3 rounded-full inline-flex items-center text-[12px] font-semibold flex-shrink-0 border"
+              style={{
+                borderColor: on ? accent : "var(--color-rule)",
+                background: on ? accent : "#fff",
+                color: on ? "#fff" : "var(--color-ink)",
+              }}
+            >
+              {c}
+            </Link>
+          );
+        })}
       </div>
 
       {/* Result-count line */}
@@ -121,7 +149,7 @@ export function CatalogGrid({ items, activeCat, tenantId }: CatalogGridProps) {
               className="bg-white rounded-[10px] border overflow-hidden block"
               style={{ borderColor: "var(--color-rule)" }}
             >
-              <GarmentVector itemId={it.id} accent="currentColor" size={120} className="w-full h-auto block" />
+              <GarmentVector itemId={it.id} accent={accent} size={120} className="w-full h-auto block" />
               <div className="px-2.5 pt-2 pb-2.5">
                 <div className="font-serif text-[13px] font-medium leading-[1.2] line-clamp-2 min-h-8" style={{ color: "var(--color-ink)" }}>
                   {it.name}
@@ -142,29 +170,9 @@ export function CatalogGrid({ items, activeCat, tenantId }: CatalogGridProps) {
 }
 ```
 
-Note: the existing grid in `page.tsx:127` passes `accent={tenant.accent}` to `GarmentVector`. We need to preserve that. The `accent` prop is in `CatalogGridProps`; restore the binding:
-
-Replace this line in the file you just created:
-
-```tsx
-              <GarmentVector itemId={it.id} accent="currentColor" size={120} className="w-full h-auto block" />
-```
-
-With:
-
-```tsx
-              <GarmentVector itemId={it.id} accent={accent} size={120} className="w-full h-auto block" />
-```
-
-And update the function signature to destructure `accent`:
-
-```tsx
-export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridProps) {
-```
-
 - [ ] **Step 2: Modify `page.tsx` to render `<CatalogGrid>` in place of the moved blocks**
 
-Open `apps/web/src/app/[tenant]/page.tsx`.
+Open `apps/web/src/app/[tenant]/page.tsx`. The chips block (lines 88-108) moves into `CatalogGrid` per the deviation note at the top of this task — `catalog-grid.tsx` already includes it in Step 1's code block.
 
 **Add import** at the top of the imports block (after the existing `BottomNav` import on line 11):
 
@@ -193,6 +201,8 @@ import { CatalogGrid } from "./catalog-grid";
       </div>
 ```
 
+**Delete lines 88-108** (the entire chips block, including its `{/* Category chips */}` comment).
+
 **Delete lines 110-113** (the result-count `<h3>` wrapper block):
 
 ```tsx
@@ -204,7 +214,7 @@ import { CatalogGrid } from "./catalog-grid";
 
 **Delete lines 115-142** (the grid block, including its `{/* Grid */}` comment).
 
-**Insert** `<CatalogGrid ... />` where the deleted search block used to be (immediately after the closing `</div>` of the tenant-themed header strip, before the `{/* Category chips */}` comment):
+**Insert** `<CatalogGrid ... />` where the deleted search block used to be (immediately after the closing `</div>` of the tenant-themed header strip):
 
 ```tsx
       <CatalogGrid
@@ -215,63 +225,9 @@ import { CatalogGrid } from "./catalog-grid";
       />
 ```
 
-Wait — the chips region currently sits between the search and the grid. After the move, the structure inside `<MobileShell>` should be:
-
-```
-<MobileShell>
-  <div /* tenant-themed header strip */>...</div>
-  <CatalogGrid /* renders: search wrapper, count line, grid, empty state */ />
-  <div /* Category chips */>...</div>
-  <BottomNav />
-</MobileShell>
-```
-
-But that places chips BELOW the grid, which is wrong. The original order is: header, search, chips, h3, grid. To preserve that order with CatalogGrid owning {search, h3, grid}, we have to either:
-- (a) Keep chips inside CatalogGrid (but the spec says chips stay server-rendered)
-- (b) Split CatalogGrid into two pieces (search wrapper above chips; count+grid below) — adds complexity
-- (c) Place CatalogGrid AFTER the chips, and have CatalogGrid render only the count line + grid + empty state; keep the search wrapper in `page.tsx` as a server-rendered fragment that uses a separate small client component just for the input
-
-The simplest is **(d) keep the original visual order by re-ordering CatalogGrid's responsibility**: chips render between the search and the h3, so split CatalogGrid into two adjacent fragments around the chips. That contradicts the "single Fragment" design.
-
-Resolution: **make the chips part of `CatalogGrid`'s render**, but keep them as plain server-style `<Link>` elements (Next's `Link` works inside client components — it just renders an `<a>` for `<Link>` with no special server requirement). The "chips remain server-rendered" line in the spec is about URL navigation semantics, not about which component renders them. Confirm by re-reading the spec — §Architecture says "chips (still server-rendered `<Link>` elements driven by `?cat=`)". A `<Link>` inside a client component still behaves identically: it's a client-routed navigation that updates `?cat=` in the URL, and the RSC re-renders on the next request. No semantic loss.
-
-**Updated plan for Task 2 Step 2:** also move the chips block (lines 89-108) into `catalog-grid.tsx`, and delete it from `page.tsx`. Update `catalog-grid.tsx` to render chips between the search wrapper and the result-count line.
-
-Add this `CATEGORIES` import to `catalog-grid.tsx`:
-
-```tsx
-import { CATEGORIES } from "@/lib/data";
-```
-
-And insert this block in `catalog-grid.tsx` between the search wrapper and the result-count line:
-
-```tsx
-      {/* Category chips */}
-      <div className="px-4 pt-2.5 pb-1 flex gap-2 overflow-x-auto flex-shrink-0 [&::-webkit-scrollbar]:hidden">
-        {CATEGORIES.map((c) => {
-          const on = c === activeCat;
-          return (
-            <Link
-              key={c}
-              href={`/${tenantId}?cat=${c}`}
-              scroll={false}
-              className="h-[30px] px-3 rounded-full inline-flex items-center text-[12px] font-semibold flex-shrink-0 border"
-              style={{
-                borderColor: on ? accent : "var(--color-rule)",
-                background: on ? accent : "#fff",
-                color: on ? "#fff" : "var(--color-ink)",
-              }}
-            >
-              {c}
-            </Link>
-          );
-        })}
-      </div>
-```
-
-In `page.tsx`, also delete the chips block (lines 88-108) and the unused `CATEGORIES` import on line 3 if no other usage remains in `page.tsx` (verify with a grep of the file before deleting the import).
-
-Also remove the now-unused `SearchIcon` import from `page.tsx`'s import on line 9.
+**Clean up unused imports** at the top of `page.tsx`:
+- Remove `SearchIcon` from the `@/components/icons` import line (still used? — verify with `grep -n "SearchIcon" apps/web/src/app/[tenant]/page.tsx`; if no remaining usage, drop it).
+- Remove `CATEGORIES` from the `@/lib/data` import on line 3 if no remaining usage (same `grep` check).
 
 After deletions, the body of `page.tsx`'s `return` should look like:
 
@@ -280,7 +236,7 @@ After deletions, the body of `page.tsx`'s `return` should look like:
     <MobileShell bg="var(--color-paper)">
       {/* Tenant-themed header strip */}
       <div className="text-white px-4 pt-1 pb-3.5 flex-shrink-0" style={{ background: tenant.accent }}>
-        {/* ... unchanged header content ... */}
+        {/* ... unchanged header content (Crest, school name, kid line, cart badge) ... */}
       </div>
 
       <CatalogGrid
@@ -337,29 +293,37 @@ Now we wire up the interactive search input and the clear button. The filter log
 **Files:**
 - Modify: `apps/web/src/app/[tenant]/catalog-grid.tsx`
 
-- [ ] **Step 1: Add React state and the `ClearIcon` import**
+- [ ] **Step 1: Add React state, the input ref, and the `ClearIcon` import**
 
-At the top of `catalog-grid.tsx`, after the existing imports, add:
-
-```tsx
-import { useState } from "react";
-import { SearchIcon, ClearIcon } from "@/components/icons";
-```
-
-Remove the duplicate `SearchIcon` import (replace the existing single-import line). After this step the icon import line should read:
+At the top of `catalog-grid.tsx`, replace the existing icon import line with:
 
 ```tsx
 import { SearchIcon, ClearIcon } from "@/components/icons";
 ```
+
+And add the React hooks import (place it as the first import in the file, above the others, conventional order):
+
+```tsx
+import { useRef, useState } from "react";
+```
+
+> **Note on hook imports across tasks:** Task 5 will add `useEffect` to this same import line. When Task 5 runs, the line should end up as `import { useEffect, useRef, useState } from "react";`. Doing it as a single combined import line each task avoids duplicate-import errors.
 
 Inside the function body, add at the top:
 
 ```tsx
 export function CatalogGrid({ items, activeCat, tenantId, accent }: CatalogGridProps) {
   const [q, setQ] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const clearSearch = () => {
+    setQ("");
+    inputRef.current?.focus();
+  };
   const visible = items.filter((i) => i.cat === activeCat);
   // ... rest unchanged for now
 ```
+
+The `clearSearch` helper centralises focus restoration so both the × button (this task) and the empty-state Clear button (Task 4) reuse it. After clearing, the × button unmounts; if it had focus, the focus would be orphaned to `<body>` and keyboard users would lose their place. `inputRef.current?.focus()` returns focus to the input, where the user can keep typing.
 
 - [ ] **Step 2: Replace the static search-pill block with an interactive one**
 
@@ -391,6 +355,7 @@ Replace with:
             <SearchIcon size={16} />
           </span>
           <input
+            ref={inputRef}
             type="text"
             inputMode="search"
             enterKeyHint="search"
@@ -406,7 +371,7 @@ Replace with:
           {q.length > 0 && (
             <button
               type="button"
-              onClick={() => setQ("")}
+              onClick={clearSearch}
               aria-label="Clear search"
               className="w-6 h-6 flex items-center justify-center rounded-full"
               style={{ color: "var(--color-ink-dim)" }}
@@ -437,6 +402,7 @@ Run `pnpm dev:web` (skip if already running) and visit `/nsbh`. Verify:
 - The search pill now accepts focus on click/tap. Focus ring appears around the pill.
 - Typing into the input updates the visible text (state is wired). The × button appears as soon as you type a character.
 - Clicking the × button clears the input and hides itself.
+- After clicking ×, focus returns to the input (caret visible, focus-within ring stays on). Verify with keyboard: Tab to ×, press Enter, then immediately type a character — it should land in the input without an extra Tab.
 - The filter behavior is **unchanged** — the grid still shows whatever the active chip dictates regardless of what you type (Task 4 fixes this).
 - On a mobile device (or DevTools mobile emulator with a touch keyboard), confirm the on-screen keyboard shows "Search" on its return key (this verifies `inputMode="search"` + `enterKeyHint="search"`).
 - No browser-native × clear icon appears inside the input (verifies `type="text"` choice).
@@ -538,7 +504,7 @@ Wrap the grid in an empty-state ternary. Replace the whole block above with:
           </p>
           <button
             type="button"
-            onClick={() => setQ("")}
+            onClick={clearSearch}
             className="text-[13px] underline font-semibold"
             style={{ color: "var(--color-ink)" }}
           >
@@ -594,8 +560,8 @@ Run `pnpm dev:web` and visit `/nsbh`. Verify:
 4. **Type partial name** (e.g. "shir"): live filter, multiple matches across categories.
 5. **Type a category name** (e.g. "winter"): matches all Winter items by category text.
 6. **Type "xyz" (no matches):** empty state renders with the "No items match 'xyz'." copy and a "Clear search" button.
-7. **Click "Clear search" in the empty state:** Query clears, grid returns to chip-scoped view.
-8. **Click × button while typing:** Same — clears query.
+7. **Click "Clear search" in the empty state:** Query clears, grid returns to chip-scoped view, **focus returns to the search input** (verify by immediately typing — should land in the input without an extra Tab).
+8. **Click × button while typing:** Same — clears query, focus returns to the input.
 9. **Singular pluralisation:** type something matching exactly 1 item; verify "· 1 item" (not "items").
 10. **Quotes in copy:** title shows curly quotes around the query (the `&ldquo;` / `&rdquo;` entities render as `"..."`).
 
@@ -621,12 +587,12 @@ The filter is sync; the announcement is debounced ~300ms so screen readers don't
 **Files:**
 - Modify: `apps/web/src/app/[tenant]/catalog-grid.tsx`
 
-- [ ] **Step 1: Add `useEffect` import and announcement state**
+- [ ] **Step 1: Add `useEffect` to the React import and announcement state**
 
-In `catalog-grid.tsx`, update the React import:
+In `catalog-grid.tsx`, update the React import — combine `useEffect` into the existing line (do **not** add a second import line). After this step the line should read exactly:
 
 ```tsx
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 ```
 
 Inside `CatalogGrid`, after the existing `useState` line, add:
@@ -668,7 +634,7 @@ So the search wrapper now looks like:
       </div>
 ```
 
-Note: `sr-only` is a Tailwind utility provided by the default v4 install. If `pnpm check-types:web` flags it as missing or the smoke test shows the text rendering visibly, verify the project's globals — search for `sr-only` in `apps/web/src/index.css` or its Tailwind config. (If absent, add the standard equivalent: `className="absolute w-px h-px p-0 m-[-1px] overflow-hidden whitespace-nowrap border-0"`.)
+Note: `sr-only` ships with Tailwind v4 by default (this project uses Tailwind v4 per CLAUDE.md), so it should work out of the box. Only if the smoke test in Step 4 shows the text rendering visibly should you fall back to the literal equivalent: `className="absolute w-px h-px p-0 m-[-1px] overflow-hidden whitespace-nowrap border-0"`.
 
 - [ ] **Step 3: Type check**
 

--- a/docs/superpowers/specs/2026-05-12-catalog-search-design.md
+++ b/docs/superpowers/specs/2026-05-12-catalog-search-design.md
@@ -1,0 +1,242 @@
+# Catalog Search — Design
+
+**Date:** 2026-05-12
+**Author:** George (with Claude)
+**Scope:** Parent shop, `apps/web/src/app/[tenant]/page.tsx` lines 78-86
+**Linked gap:** `my_doc/NSBH/gap-analysis.md` — credibility-bug flag, "the catalog search bar is a `<div>` with no input"
+
+## Problem
+
+The parent-shop catalog page renders a search-shaped UI element at `app/[tenant]/page.tsx:78-86`:
+
+```tsx
+<div className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border" ...>
+  <span><SearchIcon size={16} /></span>
+  <span>Search uniforms</span>
+</div>
+```
+
+It is a static `<div>`. No `<input>`, no handler, no state. Parents see a search affordance, tap it, and nothing happens. This is a credibility bug — the kind that signals "incomplete software" on first impression.
+
+The competitor's Shopify site has a real search, though its relevance is broken (`q=blazer` returns 0 hits for a "Navy Jacket"). We can ship better behavior in ~30 lines.
+
+## Goals
+
+1. Convert the fake `<div>` into a working search input that filters the catalog grid.
+2. Match the existing visual treatment (40px white pill, `var(--color-rule)` border, `SearchIcon` leading) so no design change is required.
+3. Mobile-first hygiene: instant filter, proper keyboard, clear button, accessible label, live result-count announcement.
+4. Ship behind no flag — straight to main.
+
+## Non-goals
+
+- Fuzzy matching, synonym maps, typo tolerance.
+- Server-side `?q=` route or URL persistence.
+- Search-result highlighting (mark matched substring).
+- Keyboard shortcuts (e.g. `/` to focus).
+- Analytics event for queries (defer until we want intent data).
+- Changing the chip filter behavior.
+
+## Decision: client-side substring filter
+
+For 9-50 items of school uniforms — the realistic per-tenant ceiling — client-side filtering is the clear winner over a server-side `?q=` route:
+
+| Aspect | Client-side filter | Server-side `?q=` |
+|---|---|---|
+| Latency per keystroke | <1ms | 50-200ms round-trip even on good wifi |
+| Code surface | ~30 lines, one `useState` + `.filter()` | URL state + RSC re-fetch + debouncing |
+| Bookmarkable | No (acceptable — parents don't share searches) | Yes |
+| Data fetch | Already happens — RSC ships all items as props | Same fetch, round-tripped per keystroke |
+| Mobile UX | Filters as you type | Janky without careful debouncing |
+
+The page is already an RSC that passes the full filtered `items` array to the rendered grid. Adding a client wrapper around the search+grid region is the smallest viable change.
+
+## Architecture
+
+### File split
+
+- **`page.tsx` (RSC, mostly unchanged):** keeps the header strip, chips, and bottom-nav. Stops rendering the search `<div>` and the grid `<div>` directly; renders a new `<CatalogGrid>` client component in their place.
+- **`catalog-grid.tsx` (new, `"use client"`):** owns the search input, filter state, result-count line, the grid itself, and the empty state.
+
+### Component contract
+
+```ts
+// app/[tenant]/catalog-grid.tsx
+type CatalogGridProps = {
+  items: CatalogItem[];     // chip-filtered (server-resolved by activeCat)
+  allItems: CatalogItem[];  // full tenant catalog, for cross-category search
+  activeCat: string;        // for "{activeCat} Uniform · N items"
+  tenantId: string;
+  accent: string;
+};
+```
+
+Server passes both `items` and `allItems`. At 9-50 items per tenant the duplicate payload is <5KB JSON — trivial.
+
+### Data flow
+
+```
+page.tsx (RSC)
+  ├─ fetches tenant + catalog
+  ├─ resolves activeCat from ?cat=
+  ├─ items     = catalog.filter(i => i.cat === activeCat)
+  ├─ allItems  = catalog
+  └─ <CatalogGrid items={items} allItems={allItems} activeCat={activeCat} ... />
+
+CatalogGrid (client)
+  ├─ const [q, setQ] = useState("")
+  ├─ const visible = q.trim()
+  │     ? allItems.filter(matchFn(q))
+  │     : items
+  └─ renders <input>, count line, grid, empty state
+```
+
+## Behavior
+
+### Match function
+
+```ts
+function matchFn(q: string) {
+  const needle = q.trim().toLowerCase();
+  return (it: CatalogItem) =>
+    (it.name + " " + it.cat).toLowerCase().includes(needle);
+}
+```
+
+Case-insensitive substring on `name + " " + category`. So:
+
+- `"blazer"` → matches "Navy Blazer" (name).
+- `"winter"` → matches all Winter items (category).
+- `"summer shirt"` → matches "Summer Shirt - Short Sleeve" but NOT "Winter Shirt" (substring on the concatenation).
+
+### Chip interaction
+
+- **Empty query:** chips drive the grid (zero-JS server-rendered behavior).
+- **Non-empty query:** search spans **all categories** — the chip is visually still highlighted but ignored. Result-count line switches to indicate cross-category mode.
+- Rationale: chips are for browsing; search is for finding. If a parent types "blazer" while the "Summer" chip is active, returning zero results is hostile.
+
+### Result-count line
+
+Replaces the existing `<h3>{activeCat} Uniform</h3>` at lines 110-113:
+
+- Empty query: `{activeCat} Uniform · {N} items` (unchanged from today)
+- Non-empty query: `Results for "{q}" · {N} items in all categories`
+
+### Empty state
+
+When `q !== ""` and `visible.length === 0`, render in place of the grid:
+
+```
+No items match "{q}".
+[Clear search] · [Browse all]
+```
+
+- `Clear search` → resets `q` to `""`, keeps the active chip.
+- `Browse all` → resets `q` to `""` AND navigates to `/[tenant]` (drops `?cat=` so the default chip "Winter" takes over).
+
+Plain text + two text buttons. No illustration. Matches the rest of the bespoke Tailwind tone.
+
+## Input markup & mobile hygiene
+
+```tsx
+<div
+  className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border"
+  style={{ borderColor: "var(--color-rule)" }}
+>
+  <span style={{ color: "var(--color-ink-dim)" }} aria-hidden="true">
+    <SearchIcon size={16} />
+  </span>
+  <input
+    type="search"
+    inputMode="search"
+    enterKeyHint="search"
+    autoCorrect="off"
+    autoCapitalize="off"
+    spellCheck={false}
+    placeholder="Search uniforms"
+    value={q}
+    onChange={(e) => setQ(e.target.value)}
+    aria-label="Search uniforms"
+    className="flex-1 bg-transparent outline-none text-[13px]"
+  />
+  {q.length > 0 && (
+    <button
+      type="button"
+      onClick={() => setQ("")}
+      aria-label="Clear search"
+      className="w-6 h-6 flex items-center justify-center rounded-full"
+    >
+      <ClearIcon size={14} />
+    </button>
+  )}
+</div>
+```
+
+- Visual shell is identical to today's `<div>` (preserves §3.9 viewport-audit baseline).
+- `type="search"` + `inputMode="search"` + `enterKeyHint="search"` triggers the right mobile keyboard with a "Search" return key.
+- `autoCorrect`/`autoCapitalize`/`spellCheck` off — proper-noun item names ("Stewart House Polo") shouldn't get autocorrected.
+- `ClearIcon` is a new 14px × icon in `components/icons.tsx` (or reuse if it exists — check during implementation).
+- Clear button is a real `<button type="button">` — 24×24 visual hit, padded to 44×44 effective via parent's vertical padding. Matches §3.9 P1 floor.
+
+## Accessibility
+
+- `aria-label="Search uniforms"` on the input (placeholder is decorative; aria-label is canonical).
+- `aria-hidden="true"` on the leading `SearchIcon` (decorative, label is on the input).
+- `aria-label="Clear search"` on the × button.
+- Live region announces result count when `q` changes:
+
+```tsx
+<span role="status" aria-live="polite" className="sr-only">
+  {q.trim() === "" ? "" : `${visible.length} results for ${q}`}
+</span>
+```
+
+- Focus ring on the input uses `:focus-visible` with `outlineColor: accent` (tenant-themed, matches existing pattern).
+- Empty state is inline text + buttons inside the grid container — keyboard and screen readers see it without needing toast announcement.
+
+## Why not...
+
+- **...debouncing the filter?** Unnecessary at 50 items; the work is microseconds. Adding a debounce adds perceived lag.
+- **...persisting query in `?q=`?** No real user demand for shareable search URLs at a single school of 9 SKUs. Cost (RSC re-fetch per keystroke OR `useRouter().replace` on every change) outweighs benefit.
+- **...fuse.js for fuzzy matching?** Premature. Substring covers "blazer", "jumper" (if named "Jumper"), "polo", "shirt". If PostHog later shows misses on "trousers" → "Pants", add a synonym map then.
+- **...mark/highlight matched substring in results?** Visual noise at this scale; the grid is already small enough that matches are scannable.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `apps/web/src/app/[tenant]/page.tsx` | Stop rendering the static search `<div>` (lines 78-86), the result-count `<h3>` (lines 110-113), and the grid (lines 116-142). Render `<CatalogGrid items={items} allItems={catalog} activeCat={activeCat} tenantId={tenant.id} accent={tenant.accent} />` in their place. Header strip, chips, and bottom-nav stay on the server. |
+| `apps/web/src/app/[tenant]/catalog-grid.tsx` | **New.** `"use client"`. Owns input state, filter, result-count line, grid, empty state, live-region announcement. |
+| `apps/web/src/components/icons.tsx` | Add `ClearIcon` (×). Confirmed absent from current exports (Shop/Orders/Kids/Profile/Cart/Back/Check/Plus/Pickup/Ship/ChevronRight/Lock/Search). |
+
+Estimated diff: ~80 lines added, ~30 lines moved out of `page.tsx`.
+
+## Verification
+
+- **Manual smoke:**
+  - Type "blazer" with each chip active → cross-category result.
+  - Type partial item name → live filter.
+  - Click × → clears, returns to chip view.
+  - Type "xyz" → empty state with both action buttons.
+  - Keyboard-only: Tab to input, type, Tab to clear, Tab to first card.
+  - Mobile keyboard: confirm "Search" return key on iOS Safari and Android Chrome.
+- **Type check:** `pnpm check-types:web` passes.
+- **Print stylesheet (§3.7):** unaffected — input is not in the pick-slip DOM.
+- **§3.9 viewport audit:** re-run on catalog page, confirm zero new tap-target P1s.
+- **Screen reader smoke:** VoiceOver on iOS announces input, result-count live region updates on debounced typing.
+
+## Risks
+
+- **Empty-state copy is a marketing surface.** "No items match 'xyz'" is fine in v1 but worth A/B-testing later — Shopify's Horizon empty state is silent, ours can win here.
+- **Cross-category-when-searching behavior may surprise** a parent who expects chip + search to compose. Mitigated by the explicit `"in all categories"` suffix on the result-count line. If user testing shows confusion, swap to chip-scoped search — it's a one-line change.
+- **`allItems` doubles the page payload.** At 50 items × ~200 bytes JSON = 10KB total. Acceptable; would revisit if a tenant's catalog grew past ~200 SKUs (well beyond realistic uniform shop scale).
+
+## Open questions
+
+None blocking. The three substantive behavior calls (substring matching, cross-category-when-searching, no URL persistence) are decided above with rationales.
+
+## Out of scope (deferred follow-ups)
+
+- PostHog `catalog_search` event with `query`, `resultCount`, `tenantId` properties.
+- Synonym map for common parent terminology mismatches.
+- Recent-searches dropdown.
+- Search-result substring highlight.

--- a/docs/superpowers/specs/2026-05-12-catalog-search-design.md
+++ b/docs/superpowers/specs/2026-05-12-catalog-search-design.md
@@ -18,7 +18,7 @@ The parent-shop catalog page renders a search-shaped UI element at `app/[tenant]
 
 It is a static `<div>`. No `<input>`, no handler, no state. Parents see a search affordance, tap it, and nothing happens. This is a credibility bug — the kind that signals "incomplete software" on first impression.
 
-The competitor's Shopify site has a real search, though its relevance is broken (`q=blazer` returns 0 hits for a "Navy Jacket"). We can ship better behavior in ~30 lines.
+The competitor's Shopify site has a real search, though its relevance is broken (`q=blazer` returns 0 hits for a "Navy Jacket"). We can ship better behavior in a single client component (~80 lines including a11y plumbing — see §Files touched).
 
 ## Goals
 
@@ -54,40 +54,37 @@ The page is already an RSC that passes the full filtered `items` array to the re
 
 ### File split
 
-- **`page.tsx` (RSC, mostly unchanged):** keeps the header strip, chips, and bottom-nav. Stops rendering the search `<div>` and the grid `<div>` directly; renders a new `<CatalogGrid>` client component in their place.
-- **`catalog-grid.tsx` (new, `"use client"`):** owns the search input, filter state, result-count line, the grid itself, and the empty state.
+- **`page.tsx` (RSC, mostly unchanged):** keeps the header strip, chips (still server-rendered `<Link>` elements driven by `?cat=`), and bottom-nav. Stops rendering the search `<div>`, the result-count `<h3>`, and the grid directly; renders a new `<CatalogGrid>` client component in their place.
+- **`catalog-grid.tsx` (new, `"use client"`):** owns the search input, filter state, result-count line, the grid itself, and the empty state. **Returns a React Fragment, not a wrapping `<div>`** — MobileShell is a flex-column and each region (search wrapper, h3 wrapper, grid) needs to remain a sibling flex child to preserve its own `flex-shrink-0` / `flex-1` behavior.
 
 ### Component contract
 
 ```ts
 // app/[tenant]/catalog-grid.tsx
 type CatalogGridProps = {
-  items: CatalogItem[];     // chip-filtered (server-resolved by activeCat)
-  allItems: CatalogItem[];  // full tenant catalog, for cross-category search
-  activeCat: string;        // for "{activeCat} Uniform · N items"
+  items: CatalogItem[];   // full tenant catalog (NOT chip-filtered)
+  activeCat: string;      // for chip-scoped no-search view + count label
   tenantId: string;
   accent: string;
 };
 ```
 
-Server passes both `items` and `allItems`. At 9-50 items per tenant the duplicate payload is <5KB JSON — trivial.
+The client component does both filters: chip-scope when query is empty, cross-category when query is non-empty. Chip navigation stays server-driven (the `<Link href="?cat=...">` chips in `page.tsx` are untouched), so the URL remains the source of truth for `activeCat`.
 
 ### Data flow
 
 ```
 page.tsx (RSC)
-  ├─ fetches tenant + catalog
+  ├─ fetches tenant + catalog (full)
   ├─ resolves activeCat from ?cat=
-  ├─ items     = catalog.filter(i => i.cat === activeCat)
-  ├─ allItems  = catalog
-  └─ <CatalogGrid items={items} allItems={allItems} activeCat={activeCat} ... />
+  └─ <CatalogGrid items={catalog} activeCat={activeCat} ... />
 
 CatalogGrid (client)
   ├─ const [q, setQ] = useState("")
   ├─ const visible = q.trim()
-  │     ? allItems.filter(matchFn(q))
-  │     : items
-  └─ renders <input>, count line, grid, empty state
+  │     ? items.filter(matchFn(q))                  // search → all categories
+  │     : items.filter(i => i.cat === activeCat)    // no search → chip-scoped
+  └─ renders <> input · count line · grid · empty state </>
 ```
 
 ## Behavior
@@ -127,26 +124,23 @@ When `q !== ""` and `visible.length === 0`, render in place of the grid:
 
 ```
 No items match "{q}".
-[Clear search] · [Browse all]
+[Clear search]
 ```
 
-- `Clear search` → resets `q` to `""`, keeps the active chip.
-- `Browse all` → resets `q` to `""` AND navigates to `/[tenant]` (drops `?cat=` so the default chip "Winter" takes over).
-
-Plain text + two text buttons. No illustration. Matches the rest of the bespoke Tailwind tone.
+`Clear search` resets `q` to `""`, returning the user to the chip-scoped view (whichever chip is currently active). One button only — a second "Browse all" CTA would be misleading because `DEFAULT_CATEGORY = "Winter"` means there's no "no chip active" state to land on. Plain text + one text button. No illustration. Matches the rest of the bespoke Tailwind tone.
 
 ## Input markup & mobile hygiene
 
 ```tsx
 <div
-  className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border"
+  className="h-10 rounded-lg bg-white flex items-center px-3 gap-2 border focus-within:ring-2 focus-within:ring-offset-1 focus-within:ring-[var(--color-ink)]"
   style={{ borderColor: "var(--color-rule)" }}
 >
   <span style={{ color: "var(--color-ink-dim)" }} aria-hidden="true">
     <SearchIcon size={16} />
   </span>
   <input
-    type="search"
+    type="text"
     inputMode="search"
     enterKeyHint="search"
     autoCorrect="off"
@@ -156,7 +150,7 @@ Plain text + two text buttons. No illustration. Matches the rest of the bespoke 
     value={q}
     onChange={(e) => setQ(e.target.value)}
     aria-label="Search uniforms"
-    className="flex-1 bg-transparent outline-none text-[13px]"
+    className="flex-1 bg-transparent outline-none text-[13px] focus-visible:outline-none"
   />
   {q.length > 0 && (
     <button
@@ -172,9 +166,10 @@ Plain text + two text buttons. No illustration. Matches the rest of the bespoke 
 ```
 
 - Visual shell is identical to today's `<div>` (preserves §3.9 viewport-audit baseline).
-- `type="search"` + `inputMode="search"` + `enterKeyHint="search"` triggers the right mobile keyboard with a "Search" return key.
+- `type="text"` + `inputMode="search"` + `enterKeyHint="search"` triggers the right mobile keyboard with a "Search" return key. **We deliberately use `type="text"`, not `type="search"`**, because WebKit/Chromium add a browser-native × clear button on `type="search"` that would collide with our custom × button. `inputMode="search"` alone gives the correct mobile keyboard without the native UI.
 - `autoCorrect`/`autoCapitalize`/`spellCheck` off — proper-noun item names ("Stewart House Polo") shouldn't get autocorrected.
-- `ClearIcon` is a new 14px × icon in `components/icons.tsx` (or reuse if it exists — check during implementation).
+- Focus ring: the input's own `:focus-visible` is suppressed (`focus-visible:outline-none` on the input); the **wrapper** `<div>` gets a `focus-within:` ring instead, so the visible 40px pill lights up when the input is focused. Use a fixed neutral colour (`focus-within:ring-2 focus-within:ring-offset-1 focus-within:ring-[var(--color-ink)]`) — not the tenant accent. Inline `style={}` cannot target pseudo-classes like `:focus-visible`, and the existing chips don't use accent-coloured focus rings either, so consistency holds.
+- `ClearIcon` is a new 14px × icon added to `components/icons.tsx` (confirmed absent — see §Files touched).
 - Clear button is a real `<button type="button">` — 24×24 visual hit, padded to 44×44 effective via parent's vertical padding. Matches §3.9 P1 floor.
 
 ## Accessibility
@@ -182,16 +177,23 @@ Plain text + two text buttons. No illustration. Matches the rest of the bespoke 
 - `aria-label="Search uniforms"` on the input (placeholder is decorative; aria-label is canonical).
 - `aria-hidden="true"` on the leading `SearchIcon` (decorative, label is on the input).
 - `aria-label="Clear search"` on the × button.
-- Live region announces result count when `q` changes:
+- Live region announces result count when typing settles. The filter itself runs synchronously on every keystroke (no debounce — §Why-not), but the announcement is debounced ~300ms via a separate `useEffect` so screen readers don't get a stream of mid-word counts ("1 result for b… 1 result for bl… 0 results for blu…"). Implementation sketch:
 
 ```tsx
-<span role="status" aria-live="polite" className="sr-only">
-  {q.trim() === "" ? "" : `${visible.length} results for ${q}`}
-</span>
+const [announced, setAnnounced] = useState("");
+useEffect(() => {
+  const t = setTimeout(() => {
+    setAnnounced(q.trim() === "" ? "" : `${visible.length} results for ${q}`);
+  }, 300);
+  return () => clearTimeout(t);
+}, [q, visible.length]);
+
+// ...
+<span role="status" aria-live="polite" className="sr-only">{announced}</span>
 ```
 
-- Focus ring on the input uses `:focus-visible` with `outlineColor: accent` (tenant-themed, matches existing pattern).
-- Empty state is inline text + buttons inside the grid container — keyboard and screen readers see it without needing toast announcement.
+- Focus ring: see §Input markup — the wrapper pill gets a `focus-within:` ring on a neutral colour. Tenant accent is not used for focus rings (consistency with chips).
+- Empty state is inline text + button inside the grid container — keyboard and screen readers see it without needing toast announcement.
 
 ## Why not...
 
@@ -204,7 +206,7 @@ Plain text + two text buttons. No illustration. Matches the rest of the bespoke 
 
 | File | Change |
 |---|---|
-| `apps/web/src/app/[tenant]/page.tsx` | Stop rendering the static search `<div>` (lines 78-86), the result-count `<h3>` (lines 110-113), and the grid (lines 116-142). Render `<CatalogGrid items={items} allItems={catalog} activeCat={activeCat} tenantId={tenant.id} accent={tenant.accent} />` in their place. Header strip, chips, and bottom-nav stay on the server. |
+| `apps/web/src/app/[tenant]/page.tsx` | Stop rendering the static search `<div>` (lines 78-86), the result-count `<h3>` (lines 110-113), and the grid (lines 116-142). Stop computing the chip-filtered `items` variable (line 45); pass the full `catalog` array instead. Render `<CatalogGrid items={catalog} activeCat={activeCat} tenantId={tenant.id} accent={tenant.accent} />` in their place. Header strip, chips, and bottom-nav stay on the server. |
 | `apps/web/src/app/[tenant]/catalog-grid.tsx` | **New.** `"use client"`. Owns input state, filter, result-count line, grid, empty state, live-region announcement. |
 | `apps/web/src/components/icons.tsx` | Add `ClearIcon` (×). Confirmed absent from current exports (Shop/Orders/Kids/Profile/Cart/Back/Check/Plus/Pickup/Ship/ChevronRight/Lock/Search). |
 
@@ -219,16 +221,17 @@ Estimated diff: ~80 lines added, ~30 lines moved out of `page.tsx`.
   - Type "xyz" → empty state with both action buttons.
   - Keyboard-only: Tab to input, type, Tab to clear, Tab to first card.
   - Mobile keyboard: confirm "Search" return key on iOS Safari and Android Chrome.
+  - WebKit native × suppression: confirm only one × shows (our custom button), not a native browser one.
 - **Type check:** `pnpm check-types:web` passes.
 - **Print stylesheet (§3.7):** unaffected — input is not in the pick-slip DOM.
-- **§3.9 viewport audit:** re-run on catalog page, confirm zero new tap-target P1s.
-- **Screen reader smoke:** VoiceOver on iOS announces input, result-count live region updates on debounced typing.
+- **§3.9 viewport audit:** re-run on catalog page, confirm zero new tap-target P1s and that the focus-within ring on the search pill meets the visible-focus criterion.
+- **Screen reader smoke:** VoiceOver on iOS announces the input on focus; live region announces the result count ~300ms after typing settles (not on every keystroke).
 
 ## Risks
 
 - **Empty-state copy is a marketing surface.** "No items match 'xyz'" is fine in v1 but worth A/B-testing later — Shopify's Horizon empty state is silent, ours can win here.
-- **Cross-category-when-searching behavior may surprise** a parent who expects chip + search to compose. Mitigated by the explicit `"in all categories"` suffix on the result-count line. If user testing shows confusion, swap to chip-scoped search — it's a one-line change.
-- **`allItems` doubles the page payload.** At 50 items × ~200 bytes JSON = 10KB total. Acceptable; would revisit if a tenant's catalog grew past ~200 SKUs (well beyond realistic uniform shop scale).
+- **Cross-category-when-searching behavior may surprise** a parent who expects chip + search to compose. Mitigated by the explicit `"in all categories"` suffix on the result-count line. If user testing shows confusion, swap to chip-scoped search — it's a one-line change (drop the ternary branch in `visible`).
+- **Page payload grows from chip-slice to full catalog.** At ~9-50 items per tenant, the additional JSON is ~5-10KB total. Acceptable; would revisit if a tenant's catalog grew past ~200 SKUs (well beyond realistic uniform shop scale).
 
 ## Open questions
 


### PR DESCRIPTION
## Summary
- Converts the fake search-shaped `<div>` at `app/[tenant]/page.tsx:78-86` into a working client-side filter
- Extracts the search + chips + result-count + grid into a new `"use client"` component (`catalog-grid.tsx`); `page.tsx` stays an RSC and passes the full catalog down
- Search matches case-insensitive substring on `name + " " + category`; spans all categories when a query is present, chip-scoped when empty
- Empty state with focus-restoring Clear button; `aria-live="polite"` result count debounced ~300ms

## Spec & plan
- Spec: `docs/superpowers/specs/2026-05-12-catalog-search-design.md`
- Plan: `docs/superpowers/plans/2026-05-12-catalog-search.md`
- Source gap: `my_doc/NSBH/gap-analysis.md` (credibility-bug flag)

## Commits (in order)
1. `feat(icons): add ClearIcon`
2. `refactor([tenant]/page): extract CatalogGrid client component` (pure move, no behavior change)
3. `feat(catalog): wire up real search input with clear button`
4. `feat(catalog): real search filter + empty state`
5. `feat(catalog): a11y — debounced live-region for result count`
6. `fix(catalog): guard Math.min/max against empty variants` (review fix)

## Spec deviation (called out in plan Task 2)
The spec said chips would remain in `page.tsx`. They moved into `CatalogGrid` because all three regions (search, count, grid) must be sibling flex children of one Fragment to preserve `MobileShell`'s flex layout. `<Link>` URL-driven navigation semantics are unchanged whether rendered in an RSC or client component.

## Verification
- [x] `pnpm check-types` passes (correctness gate per CLAUDE.md)
- [x] `pnpm check-types:web` passes
- [ ] Manual smoke (needs reviewer eyes):
  - Type "blazer" with each chip active → cross-category result every time
  - Type partial item name → live filter
  - × button clears, focus returns to input
  - Empty state ("xyz") shows Clear search button; clicking it restores focus
  - Mobile keyboard "Search" return key on iOS Safari + Android Chrome
  - Only one × visible (no WebKit native one)
  - Focus-within ring on the pill on Tab
  - VoiceOver/NVDA: live-region announces ~300ms after typing settles, not per keystroke

## Out of scope (deferred)
- PostHog `catalog_search` event
- Synonym map / fuzzy matching
- Search-result substring highlighting
- URL persistence (`?q=`)
- Hardcoded cart badge `6` in `page.tsx:70` — pre-existing, unrelated

## Pre-existing build issue (not caused by this PR)
`pnpm build:web` fails on prerendering `/_not-found` due to `useSearchParams()` in `posthog-provider.tsx` needing a Suspense boundary. Verified pre-existing on `main`. Tracked separately in **#26**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)