### PR TITLE
fix(posthog): wrap useSearchParams in Suspense (#26)

### DIFF
--- a/apps/web/src/components/posthog-provider.tsx
+++ b/apps/web/src/components/posthog-provider.tsx
@@ -1,23 +1,28 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { Suspense, useEffect, useRef } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { initPosthog, capturePageview, identifyUser, resetUser } from "@/lib/analytics/client";
 import { useSession } from "@/lib/auth/client";
 
-export default function PostHogProvider({ children }: { children: React.ReactNode }) {
+function PageviewTracker() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  useEffect(() => {
+    capturePageview();
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+export default function PostHogProvider({ children }: { children: React.ReactNode }) {
   const { data: session } = useSession();
   const identifiedUserIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     initPosthog();
   }, []);
-
-  useEffect(() => {
-    capturePageview();
-  }, [pathname, searchParams]);
 
   useEffect(() => {
     const userId = session?.user?.id ?? null;
@@ -34,5 +39,12 @@ export default function PostHogProvider({ children }: { children: React.ReactNod
     }
   }, [session]);
 
-  return <>{children}</>;
+  return (
+    <>
+      <Suspense fallback={null}>
+        <PageviewTracker />
+      </Suspense>
+      {children}
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- Closes #26 — `pnpm build:web` failed during static generation of `/_not-found` and `/admin` because `posthog-provider.tsx` called `useSearchParams()` from the root layout without a Suspense boundary.
- Extracted the pageview tracking effect into a `<PageviewTracker>` child component and wrapped it in `<Suspense fallback={null}>`. Init + identify effects stay on the parent (no `useSearchParams` dependency).

## Test plan
- [x] `pnpm check-types:web` — clean
- [x] `pnpm build:web` — completes; all routes prerender (incl. `/_not-found`, `/admin`)
- [ ] Verify pageview events still fire on client navigation in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)