### PR TITLE
feat(desktop-frame): shadow, logo watermark, tip line for desktop canvas

### DIFF
--- a/apps/web/src/app/[tenant]/cart/page.tsx
+++ b/apps/web/src/app/[tenant]/cart/page.tsx
@@ -16,7 +16,7 @@ export default async function CartPage({ params }: PageProps<"/[tenant]/cart">) 
       ? { name: active.name, year: `Year ${active.year}` }
       : null;
   return (
-    <MobileShell bg="var(--color-paper)">
+    <MobileShell bg="var(--color-paper)" logoUrl={tenantRecord.logoUrl ?? undefined}>
       <CartScreen tenant={tenant} activeChild={activeChild} />
       <TenantFooter tenant={tenantRecord} />
     </MobileShell>

--- a/apps/web/src/app/[tenant]/checkout/page.tsx
+++ b/apps/web/src/app/[tenant]/checkout/page.tsx
@@ -28,7 +28,7 @@ export default async function CheckoutPage({ params }: PageProps<"/[tenant]/chec
       : null;
 
   return (
-    <MobileShell bg="var(--color-paper)">
+    <MobileShell bg="var(--color-paper)" logoUrl={tenantRecord.logoUrl ?? undefined}>
       <CheckoutScreen tenant={tenant} prefill={prefill} />
       <TenantFooter tenant={tenantRecord} />
     </MobileShell>

--- a/apps/web/src/app/[tenant]/contact/page.tsx
+++ b/apps/web/src/app/[tenant]/contact/page.tsx
@@ -33,7 +33,7 @@ export default async function ContactPage({
   }
 
   return (
-    <MobileShell bg="var(--color-paper)">
+    <MobileShell bg="var(--color-paper)" logoUrl={tenant.logoUrl ?? undefined}>
       <div className="px-5 py-6">
         <h1
           className="font-serif text-2xl font-semibold pb-2 mb-4 border-b-2"

--- a/apps/web/src/app/[tenant]/item/[itemId]/page.tsx
+++ b/apps/web/src/app/[tenant]/item/[itemId]/page.tsx
@@ -59,7 +59,7 @@ export default async function ItemDetailPage({ params }: PageProps<"/[tenant]/it
   const tenant = toTenantBrand(tenantRecord);
 
   return (
-    <MobileShell bg="var(--color-paper)">
+    <MobileShell bg="var(--color-paper)" logoUrl={tenantRecord.logoUrl ?? undefined}>
       <ItemDetailInteractive
         tenant={tenant}
         item={resolvedItem}

--- a/apps/web/src/app/[tenant]/order/placed/page.tsx
+++ b/apps/web/src/app/[tenant]/order/placed/page.tsx
@@ -22,7 +22,7 @@ export default async function OrderPlacedPage({ params, searchParams }: PageProp
   const receiptEmail = order?.parentEmail ?? "your email";
 
   return (
-    <MobileShell bg="var(--color-parchment)">
+    <MobileShell bg="var(--color-parchment)" logoUrl={tenantRecord.logoUrl ?? undefined}>
       <div className="px-7 pt-16 pb-4 text-center flex-shrink-0">
         <div
           className="w-[76px] h-[76px] mx-auto rounded-[38px] bg-white flex items-center justify-center mb-3"

--- a/apps/web/src/app/[tenant]/page.tsx
+++ b/apps/web/src/app/[tenant]/page.tsx
@@ -45,7 +45,7 @@ export default async function CatalogPage({ params, searchParams }: PageProps<"/
       : null;
 
   return (
-    <MobileShell bg="var(--color-paper)">
+    <MobileShell bg="var(--color-paper)" logoUrl={tenantRecord.logoUrl ?? undefined}>
       {/* Tenant-themed header strip */}
       <div className="text-white px-4 pt-1 pb-3.5 flex-shrink-0" style={{ background: tenant.accent }}>
         <div className="flex items-center gap-2.5 py-1.5">

--- a/apps/web/src/app/[tenant]/refund-policy/page.tsx
+++ b/apps/web/src/app/[tenant]/refund-policy/page.tsx
@@ -32,7 +32,7 @@ export default async function RefundPolicyPage({
   }
 
   return (
-    <MobileShell>
+    <MobileShell logoUrl={tenant.logoUrl ?? undefined}>
       <div className="px-5 py-6">
         <h1
           className="font-serif text-2xl font-semibold pb-2 mb-4 border-b-2"

--- a/apps/web/src/components/mobile-shell.tsx
+++ b/apps/web/src/components/mobile-shell.tsx
@@ -1,24 +1,40 @@
 import type { ReactNode } from "react";
 
-// Container that constrains the parent-flow screens to a phone-ish width on
-// desktop while letting them go full-bleed on real phones. Drops the
-// design-canvas iPhone chrome (status bar, notch) since this is a real web
-// app — those were artifacts of the design preview canvas.
 export function MobileShell({
   children,
   bg = "var(--color-paper)",
+  logoUrl,
 }: {
   children: ReactNode;
   bg?: string;
+  logoUrl?: string;
 }) {
   return (
-    <div className="min-h-dvh w-full flex justify-center" style={{ background: "var(--color-parchment)" }}>
+    <div
+      className="min-h-dvh w-full flex flex-col items-center sm:justify-center relative"
+      style={{ background: "var(--color-parchment)" }}
+    >
+      {logoUrl && (
+        <div className="max-w-[430px] mx-auto absolute inset-0 pointer-events-none hidden sm:block">
+          <img
+            alt=""
+            src={logoUrl}
+            className="absolute top-4 right-4 w-24 h-24 object-contain opacity-[0.08]"
+          />
+        </div>
+      )}
       <div
-        className="w-full max-w-[430px] min-h-dvh flex flex-col"
+        className="w-full max-w-[430px] min-h-dvh sm:min-h-0 flex flex-col sm:rounded-[10px] sm:shadow-[0_4px_32px_rgba(8,26,45,0.14),0_1px_6px_rgba(8,26,45,0.07)]"
         style={{ background: bg }}
       >
         {children}
       </div>
+      <p
+        className="hidden sm:block text-center text-xs mt-3 tracking-wide opacity-60"
+        style={{ color: "var(--color-gold)" }}
+      >
+        Open on your phone for the best experience
+      </p>
     </div>
   );
 }

--- a/apps/web/src/components/mobile-shell.tsx
+++ b/apps/web/src/components/mobile-shell.tsx
@@ -11,22 +11,20 @@ export function MobileShell({
 }) {
   return (
     <div
-      className="min-h-dvh w-full flex flex-col items-center sm:justify-center relative"
+      className="min-h-dvh w-full flex flex-col items-center sm:justify-center"
       style={{ background: "var(--color-parchment)" }}
     >
-      {logoUrl && (
-        <div className="max-w-[430px] mx-auto absolute inset-0 pointer-events-none hidden sm:block">
+      <div
+        className="relative w-full max-w-[430px] min-h-dvh sm:min-h-0 sm:my-6 flex flex-col sm:rounded-[10px] sm:shadow-[0_4px_32px_rgba(8,26,45,0.14),0_1px_6px_rgba(8,26,45,0.07)]"
+        style={{ background: bg }}
+      >
+        {logoUrl && (
           <img
             alt=""
             src={logoUrl}
-            className="absolute top-4 right-4 w-24 h-24 object-contain opacity-[0.08]"
+            className="absolute top-4 right-4 w-24 h-24 object-contain opacity-[0.08] pointer-events-none hidden sm:block"
           />
-        </div>
-      )}
-      <div
-        className="w-full max-w-[430px] min-h-dvh sm:min-h-0 flex flex-col sm:rounded-[10px] sm:shadow-[0_4px_32px_rgba(8,26,45,0.14),0_1px_6px_rgba(8,26,45,0.07)]"
-        style={{ background: bg }}
-      >
+        )}
         {children}
       </div>
       <p


### PR DESCRIPTION
## Summary
- \`MobileShell\` gains a \`logoUrl?: string\` prop; on desktop (≥ sm) renders a top-right watermark image at 8% opacity, positioned inside the inner column (so it stays anchored to the phone canvas regardless of page height)
- Inner column gets rounded corners + two-layer drop shadow + \`sm:my-6\` vertical breathing room on desktop; mobile unchanged
- Tip line ("Open on your phone for the best experience") appears below the column on desktop only (\`hidden sm:block\`)
- All 7 tenant pages thread \`tenantRecord.logoUrl ?? undefined\` (or \`tenant.logoUrl\`) through to the new prop

## Test Plan
- [ ] \`pnpm check-types:web\` passes (pre-existing \`PageProps\` errors are unrelated)
- [ ] Desktop (≥ 640 px): shadow + rounded corners + vertical margin visible on any tenant route
- [ ] Desktop: tip line visible below the column; hidden on ≤ 640 px viewport
- [ ] Desktop: logo watermark appears top-right of the column if \`logoUrl\` is set in DB; corner empty when null
- [ ] Short-content pages (refund policy, order-placed): watermark stays anchored to the column, not the top of the viewport
- [ ] Mobile (430 px): catalog, PDP, cart, checkout look identical to pre-change
- [ ] Non-tenant routes (\`/\`, \`/orders/*\`): shadow + tip present, no watermark, no JS errors