### PR TITLE
feat(§5.17): per-tenant first-visit landing page

### DIFF
--- a/apps/web/src/app/[tenant]/landing-screen.tsx
+++ b/apps/web/src/app/[tenant]/landing-screen.tsx
@@ -1,0 +1,185 @@
+// apps/web/src/app/[tenant]/landing-screen.tsx
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Crest } from "@/components/crest";
+import { GarmentVector } from "@/components/garment";
+import { TenantFooter } from "@/components/tenant-footer";
+import { BottomNav } from "@/components/bottom-nav";
+import { setVisitedCookie } from "@/lib/landing-visit.client";
+import { type TenantRow } from "@/db/schema";
+import { type PopularItem } from "@/db/queries";
+
+export function LandingScreen({
+  tenant,
+  popularItems,
+  accent,
+}: {
+  tenant: TenantRow;
+  popularItems: PopularItem[];
+  accent: string;
+}) {
+  const router = useRouter();
+
+  // CTA: already at /<slug>, so refresh the RSC to re-read the cookie
+  function visitCatalogue() {
+    setVisitedCookie(tenant.id);
+    router.refresh();
+  }
+
+  // Item tiles: navigate to a different URL, so push works fine
+  function visitItem(itemId: string) {
+    setVisitedCookie(tenant.id);
+    router.push(`/${tenant.id}/${itemId}`);
+  }
+
+  return (
+    <>
+      {/* Header strip — crest + name only, no child/cart ornaments */}
+      <div
+        className="text-white px-4 pt-1 pb-3.5 flex-shrink-0 flex items-center gap-2.5 py-1.5"
+        style={{ background: accent }}
+      >
+        <Crest tenant={tenant} size={28} ring={false} />
+        <span className="text-sm font-medium leading-tight opacity-90">
+          {tenant.name}
+        </span>
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-4 pt-6 pb-4 flex flex-col gap-5">
+
+        {/* Hero: large crest + name + motto */}
+        <div className="flex flex-col items-center text-center gap-3 py-2">
+          <Crest tenant={tenant} size={80} ring />
+          <div>
+            <p
+              className="font-serif text-lg font-bold leading-snug"
+              style={{ color: "var(--color-navy-deep)" }}
+            >
+              {tenant.name}
+            </p>
+            {tenant.motto && (
+              <p
+                className="font-serif italic text-xs mt-1 tracking-wide"
+                style={{ color: "var(--color-gold)" }}
+              >
+                {tenant.motto}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div className="h-px" style={{ background: "var(--color-rule)" }} />
+
+        {/* Shop hours card */}
+        {tenant.shopHours && (
+          <div
+            className="rounded-[10px] border px-4 py-3 flex flex-col gap-1.5"
+            style={{ background: "var(--color-paper)", borderColor: "var(--color-rule)" }}
+          >
+            <p
+              className="text-[10px] font-bold tracking-widest uppercase"
+              style={{ color: "var(--color-gold)" }}
+            >
+              Uniform Shop
+            </p>
+            <p
+              className="text-[13px] font-semibold"
+              style={{ color: "var(--color-navy-deep)" }}
+            >
+              {tenant.shopHours}
+            </p>
+            {tenant.collectionInstructions && (
+              <p className="text-xs leading-relaxed" style={{ color: "#4a5060" }}>
+                {tenant.collectionInstructions}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Popular this term */}
+        {popularItems.length > 0 && (
+          <div>
+            <p
+              className="text-[10px] font-bold tracking-widest uppercase mb-3"
+              style={{ color: "var(--color-gold)" }}
+            >
+              Popular this term
+            </p>
+            <div className="grid grid-cols-3 gap-2">
+              {popularItems.map((item) => (
+                <button
+                  type="button"
+                  key={item.itemId}
+                  onClick={() => visitItem(item.itemId)}
+                  className="flex flex-col items-center rounded-[8px] border p-2.5 text-center cursor-pointer hover:border-current transition-colors"
+                  style={{ background: "var(--color-paper)", borderColor: "var(--color-rule)" }}
+                >
+                  <div
+                    className="w-10 h-10 rounded-md flex items-center justify-center mb-1.5 overflow-hidden"
+                    style={{ background: "var(--color-parchment)" }}
+                  >
+                    {item.imageUrl ? (
+                      <img
+                        src={item.imageUrl}
+                        alt=""
+                        width={40}
+                        height={40}
+                        loading="lazy"
+                        decoding="async"
+                        className="w-full h-full object-contain"
+                      />
+                    ) : (
+                      <GarmentVector
+                        itemId={item.itemId}
+                        accent={accent}
+                        size={32}
+                        className="block"
+                      />
+                    )}
+                  </div>
+                  <span
+                    className="text-[10.5px] font-semibold leading-tight"
+                    style={{ color: "var(--color-navy-deep)" }}
+                  >
+                    {item.name}
+                  </span>
+                  <span
+                    className="text-[10.5px] font-medium mt-0.5 tnum"
+                    style={{ color: "var(--color-gold)" }}
+                  >
+                    ${item.minPrice % 1 === 0
+                      ? item.minPrice.toFixed(0)
+                      : item.minPrice.toFixed(2)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* CTA — uses router.refresh() not router.push() because we're already at /<slug> */}
+        <button
+          type="button"
+          onClick={visitCatalogue}
+          className="w-full rounded-[9px] py-3.5 text-sm font-semibold text-white tracking-wide"
+          style={{ background: accent }}
+        >
+          Browse Catalogue →
+        </button>
+
+        {/* Footer note */}
+        <p className="text-center text-[10px] opacity-50">
+          This welcome screen won&apos;t show again for 30 days
+        </p>
+
+      </div>
+
+      <TenantFooter tenant={tenant} />
+      <div className="pb-16" />
+      <BottomNav active="shop" shopHref={`/${tenant.id}`} accent={accent} />
+    </>
+  );
+}

--- a/apps/web/src/app/[tenant]/page.tsx
+++ b/apps/web/src/app/[tenant]/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { cookies } from "next/headers";
 import { CATEGORIES } from "@/lib/data";
-import { getTenant, getActiveCatalog, toTenantBrand } from "@/db/queries";
+import { getTenant, getActiveCatalog, toTenantBrand, getPopularItems } from "@/db/queries";
 import { getActiveChild } from "@/lib/active-child.server";
 import { getSessionUser, isPlatformAdminEmail } from "@/lib/auth/authorization";
 import { Crest } from "@/components/crest";
@@ -10,14 +11,24 @@ import { MobileShell } from "@/components/mobile-shell";
 import { BottomNav } from "@/components/bottom-nav";
 import { TenantFooter } from "@/components/tenant-footer";
 import { CatalogGrid } from "./catalog-grid";
+import { LandingScreen } from "./landing-screen";
 
 const DEFAULT_CATEGORY = "Winter";
 
 export default async function CatalogPage({ params, searchParams }: PageProps<"/[tenant]">) {
   const { tenant: slug } = await params;
+  // Read cookie before DB queries — header lookup, no I/O
+  const cookieStore = await cookies();
+  const hasVisited = !!cookieStore.get(`uo:visited:${slug}`)?.value;
+
+  // Parallel fetch — returning visitors get getTenant + getActiveCatalog in parallel.
+  // First-time visitors skip getActiveCatalog (not needed for landing) and get an
+  // empty placeholder instead; getPopularItems runs after the visibility gate below.
   const [tenantRecord, catalog] = await Promise.all([
     getTenant(slug),
-    getActiveCatalog(slug),
+    hasVisited
+      ? getActiveCatalog(slug)
+      : Promise.resolve([] as Awaited<ReturnType<typeof getActiveCatalog>>),
   ]);
   if (!tenantRecord) notFound();
 
@@ -34,6 +45,22 @@ export default async function CatalogPage({ params, searchParams }: PageProps<"/
   }
 
   const tenant = toTenantBrand(tenantRecord);
+
+  // ── Landing branch — AFTER visibility gate so hidden tenants still 404 ───────
+  if (!hasVisited) {
+    const popularItems = await getPopularItems(slug);
+    return (
+      <MobileShell bg="var(--color-paper)" logoUrl={tenantRecord.logoUrl ?? undefined}>
+        <LandingScreen
+          tenant={tenantRecord}
+          popularItems={popularItems}
+          accent={tenant.accent}
+        />
+      </MobileShell>
+    );
+  }
+
+  // ── Catalogue branch — catalog already fetched above ──────────────────────────
   const sp = await searchParams;
   const catParam = typeof sp.cat === "string" ? sp.cat : undefined;
   const activeCat = (catParam && CATEGORIES.includes(catParam as never) ? catParam : DEFAULT_CATEGORY) as string;

--- a/apps/web/src/app/[tenant]/page.tsx
+++ b/apps/web/src/app/[tenant]/page.tsx
@@ -16,7 +16,8 @@ import { LandingScreen } from "./landing-screen";
 const DEFAULT_CATEGORY = "Winter";
 
 export default async function CatalogPage({ params, searchParams }: PageProps<"/[tenant]">) {
-  const { tenant: slug } = await params;
+  const { tenant: rawSlug } = await params;
+  const slug = rawSlug.toLowerCase();
   // Read cookie before DB queries — header lookup, no I/O
   const cookieStore = await cookies();
   const hasVisited = !!cookieStore.get(`uo:visited:${slug}`)?.value;

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -1120,7 +1120,8 @@ export async function getPopularItems(
       minPrice: r.minPrice != null ? parseFloat(r.minPrice) : 0,
       totalQty: r.totalQty,
     }));
-  } catch {
+  } catch (err) {
+    console.error("getPopularItems failed", err);
     return [];
   }
 }

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -68,6 +68,14 @@ export type LiveReportsData = {
   gstRows: LiveGstRow[];
 };
 
+export type PopularItem = {
+  itemId: string;
+  name: string;
+  imageUrl: string | null;
+  minPrice: number;
+  totalQty: number;
+};
+
 export function money(value: string | number | null | undefined) {
   const parsed = typeof value === "number" ? value : Number(value ?? 0);
   if (!Number.isFinite(parsed)) return 0;
@@ -1067,4 +1075,52 @@ export async function getMaxLegalVersionForTenant(tenantId: string): Promise<num
     .from(tenantLegalVersions)
     .where(eq(tenantLegalVersions.tenantId, tenantId));
   return row?.max ?? 0;
+}
+
+export async function getPopularItems(
+  tenantSlug: string,
+  limit = 3,
+  days = 90,
+): Promise<PopularItem[]> {
+  try {
+    type Row = {
+      itemId: string;
+      name: string | null;
+      imageUrl: string | null;
+      minPrice: string | null; // postgres numeric → string over neon-http
+      totalQty: number;
+    };
+    const result = (await db.execute(sql`
+      WITH ranked AS (
+        SELECT ol.item_id, SUM(ol.qty)::int AS total_qty
+        FROM order_lines ol
+        JOIN orders o ON o.id = ol.order_id
+        WHERE o.tenant_id = ${tenantSlug}
+          AND o.created_at >= NOW() - make_interval(days => ${days})
+          AND o.status NOT IN ('pending_payment', 'refunded')
+        GROUP BY ol.item_id
+        ORDER BY total_qty DESC
+        LIMIT ${limit}
+      )
+      SELECT
+        r.item_id          AS "itemId",
+        ci.name,
+        ci.image_url       AS "imageUrl",
+        (SELECT MIN(price)::text FROM catalog_variants cv
+         WHERE cv.item_id = r.item_id AND cv.active = true) AS "minPrice",
+        r.total_qty        AS "totalQty"
+      FROM ranked r
+      LEFT JOIN catalog_items ci ON ci.id = r.item_id
+      ORDER BY r.total_qty DESC
+    `)) as { rows: Row[] };
+    return result.rows.map((r) => ({
+      itemId: r.itemId,
+      name: r.name ?? r.itemId,
+      imageUrl: r.imageUrl,
+      minPrice: r.minPrice != null ? parseFloat(r.minPrice) : 0,
+      totalQty: r.totalQty,
+    }));
+  } catch {
+    return [];
+  }
 }

--- a/apps/web/src/lib/landing-visit.client.ts
+++ b/apps/web/src/lib/landing-visit.client.ts
@@ -1,0 +1,9 @@
+// apps/web/src/lib/landing-visit.client.ts
+const COOKIE_NAME = (slug: string) => `uo:visited:${slug}`;
+const TTL = 60 * 60 * 24 * 30; // 30 days
+
+// slug is always lowercase ASCII — no URL-encoding needed for Path value
+export function setVisitedCookie(slug: string): void {
+  const secure = location.protocol === "https:" ? "; Secure" : "";
+  document.cookie = `${COOKIE_NAME(slug)}=1; Path=/${slug}; Max-Age=${TTL}; SameSite=Lax${secure}`;
+}

--- a/docs/remaining_work.md
+++ b/docs/remaining_work.md
@@ -185,7 +185,7 @@ Sourced from `my_doc/NSBH/gap-analysis.md` §5 — items not bug-class (those li
   - Phase 2 (real bundles with single Add-all-to-cart via `catalog_bundles` table) tracked separately — large, defer until phase-1 ships and a school asks.
   - ~2–3d.
 
-- [ ] **Per-tenant homepage option (gap-analysis §5.17).** Today `/<tenant>` shows the catalog grid directly. Add an optional cookie-gated landing rendered on first visit (subsequent visits skip straight to catalog). Surfaces: crest, `tenant.motto`, pickup banner (`shopHours` + `collectionInstructions`), and a "Most ordered this term" row driven from order history. ~6h.
+- [x] **Per-tenant homepage option (gap-analysis §5.17).** ✅ shipped (4 commits: cookie helper, `getPopularItems` query, `LandingScreen` component, `page.tsx` cookie branch). Cookie-gated landing on `/<tenant>` first visit — crest, motto, shop hours card, popular items grid (last 90 days), Browse Catalogue CTA (`router.refresh()`). 30-day `uo:visited:{slug}` cookie. Returning visitors go straight to catalogue unchanged.
 
 - [ ] **Desktop frame for parent shop (gap-analysis §5.18).** Parent shop is hard-capped at 430px (`components/mobile-shell.tsx:17`); on a desktop browser the column floats mid-page and reads as broken on first sight (credibility issue for school decision-makers). Keep the 430px column but style the surrounding desktop canvas as a parchment-backed frame: subtle shadow, school crest faded into the corner, a "Tip: open on your phone for the full experience" line. **Do not widen the catalog grid** — mobile-first is core to the visual brand. ~4h.
 

--- a/docs/superpowers/plans/2026-05-13-per-tenant-homepage.md
+++ b/docs/superpowers/plans/2026-05-13-per-tenant-homepage.md
@@ -4,9 +4,9 @@
 
 **Goal:** Show a cookie-gated welcome screen on first visit to `/<tenant>` — crest, motto, shop hours, popular items — then go straight to the catalogue on return visits.
 
-**Architecture:** The existing RSC at `app/[tenant]/page.tsx` reads a `uo:visited:{slug}` cookie server-side and branches: landing path fetches popular items and renders `<LandingScreen>`; catalogue path is unchanged. No new routes. `LandingScreen` is a `"use client"` component that sets the cookie + navigates on any CTA tap.
+**Architecture:** The existing RSC at `app/[tenant]/page.tsx` reads a `uo:visited:{slug}` cookie before the DB fetch, then branches: landing path skips `getActiveCatalog` and fetches popular items instead; catalogue path is unchanged. No new routes. `LandingScreen` is a `"use client"` component that sets the cookie + triggers RSC refresh (CTA) or navigates to an item page (tiles).
 
-**Tech Stack:** Next.js 15 App Router (RSC + Server Actions), Drizzle ORM + neon-http (`db.execute(sql\`...\`)`), `next/headers` cookies, `next/navigation` useRouter, Tailwind CSS v4.
+**Tech Stack:** Next.js 15 App Router (RSC + client companion), Drizzle ORM + neon-http, `next/headers` cookies, `next/navigation` useRouter, Tailwind CSS v4.
 
 ---
 
@@ -74,7 +74,10 @@ export type PopularItem = {
 };
 ```
 
-- [ ] **Step 2: Add `getPopularItems` function at the end of queries.ts (before the final closing)**
+- [ ] **Step 2: Add `getPopularItems` function at the end of queries.ts**
+
+`db.execute` with a generic parameter may not exist on the NeonHttpDatabase type used here. Use
+an explicit row-type cast instead of the generic form:
 
 ```ts
 export async function getPopularItems(
@@ -83,13 +86,14 @@ export async function getPopularItems(
   days = 90,
 ): Promise<PopularItem[]> {
   try {
-    const result = await db.execute<{
+    type Row = {
       itemId: string;
       name: string | null;
       imageUrl: string | null;
-      minPrice: string | null;   // postgres numeric → string over neon-http
+      minPrice: string | null; // postgres numeric → string over neon-http
       totalQty: number;
-    }>(sql`
+    };
+    const result = (await db.execute(sql`
       WITH ranked AS (
         SELECT ol.item_id, SUM(ol.qty)::int AS total_qty
         FROM order_lines ol
@@ -102,15 +106,16 @@ export async function getPopularItems(
         LIMIT ${limit}
       )
       SELECT
-        r.item_id            AS "itemId",
+        r.item_id          AS "itemId",
         ci.name,
-        ci.image_url         AS "imageUrl",
+        ci.image_url       AS "imageUrl",
         (SELECT MIN(price)::text FROM catalog_variants cv
          WHERE cv.item_id = r.item_id AND cv.active = true) AS "minPrice",
-        r.total_qty          AS "totalQty"
+        r.total_qty        AS "totalQty"
       FROM ranked r
       LEFT JOIN catalog_items ci ON ci.id = r.item_id
-    `);
+      ORDER BY r.total_qty DESC
+    `)) as { rows: Row[] };
     return result.rows.map((r) => ({
       itemId: r.itemId,
       name: r.name ?? r.itemId,
@@ -124,16 +129,22 @@ export async function getPopularItems(
 }
 ```
 
+**Why CTE + outer `ORDER BY`:** aggregation happens in `ranked` first (no fan-out from the
+variants join), then `min_price` is a per-row lateral subquery. The outer `ORDER BY r.total_qty DESC`
+is required because PostgreSQL does not guarantee CTE row order is preserved through a join.
+
+**Status filter** excludes `pending_payment` (never paid) and `refunded` (fully reversed).
+All other statuses (`new`, `packing`, `ready`, `collected`, `partially_refunded`) represent
+real demand. Deny-list is intentional — a future new status is almost certainly a legitimate
+fulfillment state.
+
 - [ ] **Step 3: Type-check**
 
 ```bash
 pnpm check-types:web
 ```
 
-Expected: no errors. If `db.execute` type signature complains about the generic, change to:
-```ts
-const result = await db.execute(sql`...`) as { rows: { itemId: string; ... }[] };
-```
+Expected: no errors.
 
 - [ ] **Step 4: Commit**
 
@@ -148,6 +159,10 @@ git commit -m "feat(§5.17): getPopularItems query — top-3 by qty last 90 days
 
 **Files:**
 - Create: `apps/web/src/app/[tenant]/landing-screen.tsx`
+
+**Prop note:** `LandingScreen` receives `tenant: TenantRow` (the raw DB row, nullables intact), not
+the `toTenantBrand(...)` projection (which coerces null fields to `""`). The `shopHours`,
+`collectionInstructions`, and `motto` null checks below depend on this.
 
 - [ ] **Step 1: Create the component**
 
@@ -175,9 +190,16 @@ export function LandingScreen({
 }) {
   const router = useRouter();
 
-  function visit(path: string) {
+  // CTA: already at /<slug>, so refresh the RSC to re-read the cookie
+  function visitCatalogue() {
     setVisitedCookie(tenant.id);
-    router.push(path);
+    router.refresh();
+  }
+
+  // Item tiles: navigate to a different URL, so push works fine
+  function visitItem(itemId: string) {
+    setVisitedCookie(tenant.id);
+    router.push(`/${tenant.id}/${itemId}`);
   }
 
   return (
@@ -259,7 +281,7 @@ export function LandingScreen({
               {popularItems.map((item) => (
                 <button
                   key={item.itemId}
-                  onClick={() => visit(`/${tenant.id}/${item.itemId}`)}
+                  onClick={() => visitItem(item.itemId)}
                   className="flex flex-col items-center rounded-[8px] border p-2.5 text-center cursor-pointer hover:border-current transition-colors"
                   style={{ background: "var(--color-paper)", borderColor: "var(--color-rule)" }}
                 >
@@ -271,6 +293,10 @@ export function LandingScreen({
                       <img
                         src={item.imageUrl}
                         alt=""
+                        width={40}
+                        height={40}
+                        loading="lazy"
+                        decoding="async"
                         className="w-full h-full object-contain"
                       />
                     ) : (
@@ -302,9 +328,9 @@ export function LandingScreen({
           </div>
         )}
 
-        {/* CTA */}
+        {/* CTA — uses router.refresh() not router.push() because we're already at /<slug> */}
         <button
-          onClick={() => visit(`/${tenant.id}`)}
+          onClick={visitCatalogue}
           className="w-full rounded-[9px] py-3.5 text-sm font-semibold text-white tracking-wide"
           style={{ background: accent }}
         >
@@ -332,7 +358,8 @@ export function LandingScreen({
 pnpm check-types:web
 ```
 
-Expected: no errors. Common issue to watch for: `GarmentVector` may not accept a `className` prop — check `components/garment.tsx`. If it doesn't, wrap it in a `<div className="...">` instead.
+Expected: no errors. Common issue: `GarmentVector` may not accept a `className` prop — check
+`components/garment.tsx`. If it doesn't, wrap it: `<div className="block"><GarmentVector .../></div>`.
 
 - [ ] **Step 3: Commit**
 
@@ -348,27 +375,33 @@ git commit -m "feat(§5.17): LandingScreen component — crest/motto/hours/popul
 **Files:**
 - Modify: `apps/web/src/app/[tenant]/page.tsx`
 
-Three surgical edits to the existing file. The catalogue JSX (`return (...)`) is untouched.
+Two surgical edits. The catalogue JSX (`return (...)`) and the visibility gate are untouched.
 
 - [ ] **Step 1: Add three new imports**
 
-At the top of `page.tsx`, add:
+At the top of `page.tsx`, add `cookies` from `next/headers`, merge `getPopularItems` into the
+`@/db/queries` line, and add `LandingScreen`. The full import block becomes:
 
 ```ts
-import { cookies } from "next/headers";                    // after "next/navigation"
-import { getPopularItems } from "@/db/queries";            // merge into existing @/db/queries line
-import { LandingScreen } from "./landing-screen";          // after CatalogGrid import
-```
-
-The `@/db/queries` import line should become:
-
-```ts
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cookies } from "next/headers";
+import { CATEGORIES } from "@/lib/data";
 import { getTenant, getActiveCatalog, toTenantBrand, getPopularItems } from "@/db/queries";
+import { getActiveChild } from "@/lib/active-child.server";
+import { getSessionUser, isPlatformAdminEmail } from "@/lib/auth/authorization";
+import { Crest } from "@/components/crest";
+import { CartIcon } from "@/components/icons";
+import { MobileShell } from "@/components/mobile-shell";
+import { BottomNav } from "@/components/bottom-nav";
+import { TenantFooter } from "@/components/tenant-footer";
+import { CatalogGrid } from "./catalog-grid";
+import { LandingScreen } from "./landing-screen";
 ```
 
-- [ ] **Step 2: Replace the initial `Promise.all` + split fetch**
+- [ ] **Step 2: Replace the initial `Promise.all` block with the cookie-aware parallel fetch**
 
-Find this block near the top of `CatalogPage` (lines 1-4 of the function body):
+Find this block at the top of `CatalogPage` (immediately after `const { tenant: slug } = await params;`):
 
 ```ts
 const [tenantRecord, catalog] = await Promise.all([
@@ -381,20 +414,30 @@ if (!tenantRecord) notFound();
 Replace with:
 
 ```ts
-const tenantRecord = await getTenant(slug);
+// Read cookie before DB queries — header lookup, no I/O
+const cookieStore = await cookies();
+const hasVisited = !!cookieStore.get(`uo:visited:${slug}`)?.value;
+
+// Parallel fetch — returning visitors get getTenant + getActiveCatalog in parallel.
+// First-time visitors skip getActiveCatalog (not needed for landing) and get an
+// empty placeholder instead; getPopularItems runs after the visibility gate below.
+const [tenantRecord, catalog] = await Promise.all([
+  getTenant(slug),
+  hasVisited
+    ? getActiveCatalog(slug)
+    : Promise.resolve([] as Awaited<ReturnType<typeof getActiveCatalog>>),
+]);
 if (!tenantRecord) notFound();
 ```
 
-Then find the line `const tenant = toTenantBrand(tenantRecord);` and insert the landing branch
-**immediately after it**:
+Then find `const tenant = toTenantBrand(tenantRecord);` and insert the landing branch
+**immediately after it** — this is after the existing visibility gate, so hidden tenants
+still 404 on first visit:
 
 ```ts
 const tenant = toTenantBrand(tenantRecord);
 
-// ── Landing branch — first-visit only ──────────────────────────────────────
-const cookieStore = await cookies();
-const hasVisited = !!cookieStore.get(`uo:visited:${slug}`)?.value;
-
+// ── Landing branch — AFTER visibility gate so hidden tenants still 404 ───────
 if (!hasVisited) {
   const popularItems = await getPopularItems(slug);
   return (
@@ -408,19 +451,14 @@ if (!hasVisited) {
   );
 }
 
-// ── Catalogue branch — returning visitors (everything below is unchanged) ───
-const catalog = await getActiveCatalog(slug);
+// ── Catalogue branch — catalog already fetched above ──────────────────────────
 ```
 
-- [ ] **Step 3: Remove the now-stale `catalog` variable reference if needed**
+Everything below (the `const sp = await searchParams;` block, `getActiveChild`, and the full
+`return (...)`) remains exactly as it is. The `catalog` variable from the `Promise.all` is
+consumed unchanged by `<CatalogGrid items={catalog} .../>`.
 
-Because `getActiveCatalog` was moved out of the original `Promise.all`, find any remaining
-destructured `catalog` reference from the old `Promise.all` (if the editor left one). The variable
-`catalog` should now only come from the `const catalog = await getActiveCatalog(slug);` line added
-in Step 2. The rest of the function body (`sp`, `activeCat`, `getActiveChild`, the `return (...)`)
-stays exactly as it was.
-
-- [ ] **Step 4: Type-check**
+- [ ] **Step 3: Type-check**
 
 ```bash
 pnpm check-types:web
@@ -428,19 +466,20 @@ pnpm check-types:web
 
 Expected: no errors.
 
-- [ ] **Step 5: Manual smoke test**
+- [ ] **Step 4: Manual smoke test**
 
 ```bash
 pnpm dev:web
 ```
 
-1. Open `http://localhost:3000/nsbh` in a private/incognito window (no cookie) → should see the landing screen: large crest, school name, motto, shop hours card, and popular items row (or no row if the DB has no orders in the last 90 days).
-2. Click "Browse Catalogue →" → navigates back to `/nsbh` and the catalogue grid appears (cookie is now set).
+1. Open `http://localhost:3000/nsbh` in a **private/incognito** window → should see the landing screen: large crest, school name, italic motto, shop hours card, popular items row (or no row if the DB has no orders in the last 90 days).
+2. Click "Browse Catalogue →" → RSC re-runs, cookie is now present, catalogue grid appears.
 3. Reload `http://localhost:3000/nsbh` in the same window → catalogue directly, no landing.
-4. Open `http://localhost:3000/rgsh` in a new private window → landing appears with RGSH accent colour and data.
-5. Confirm the visibility gate still works: a tenant with `isPubliclyListed = false` should return 404 for a non-admin visitor on both the landing and catalogue branches.
+4. Open `http://localhost:3000/rgsh` in a new private window → landing with RGHS green accent and data.
+5. Confirm the **visibility gate** still works: a tenant with `isPubliclyListed = false` should return 404 for a non-admin visitor on both landing and catalogue branches.
+6. Confirm **admin bypass**: sign in as a platform-admin email and open a hidden/pending tenant → should see the landing (gate falls through for admins).
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add apps/web/src/app/[tenant]/page.tsx

--- a/docs/superpowers/plans/2026-05-13-per-tenant-homepage.md
+++ b/docs/superpowers/plans/2026-05-13-per-tenant-homepage.md
@@ -1,0 +1,448 @@
+# Per-Tenant First-Visit Landing Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a cookie-gated welcome screen on first visit to `/<tenant>` — crest, motto, shop hours, popular items — then go straight to the catalogue on return visits.
+
+**Architecture:** The existing RSC at `app/[tenant]/page.tsx` reads a `uo:visited:{slug}` cookie server-side and branches: landing path fetches popular items and renders `<LandingScreen>`; catalogue path is unchanged. No new routes. `LandingScreen` is a `"use client"` component that sets the cookie + navigates on any CTA tap.
+
+**Tech Stack:** Next.js 15 App Router (RSC + Server Actions), Drizzle ORM + neon-http (`db.execute(sql\`...\`)`), `next/headers` cookies, `next/navigation` useRouter, Tailwind CSS v4.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| **Create** | `apps/web/src/lib/landing-visit.client.ts` | `setVisitedCookie(slug)` — 30-day cookie writer |
+| **Modify** | `apps/web/src/db/queries.ts` | Add `PopularItem` export type + `getPopularItems` query |
+| **Create** | `apps/web/src/app/[tenant]/landing-screen.tsx` | `<LandingScreen>` client component — all landing UI |
+| **Modify** | `apps/web/src/app/[tenant]/page.tsx` | Cookie branch: landing vs catalogue path |
+
+---
+
+## Task 1: Cookie helper
+
+**Files:**
+- Create: `apps/web/src/lib/landing-visit.client.ts`
+
+- [ ] **Step 1: Create the cookie helper**
+
+```ts
+// apps/web/src/lib/landing-visit.client.ts
+const COOKIE_NAME = (slug: string) => `uo:visited:${slug}`;
+const TTL = 60 * 60 * 24 * 30; // 30 days
+
+// slug is always lowercase ASCII — no URL-encoding needed for Path value
+export function setVisitedCookie(slug: string): void {
+  const secure = location.protocol === "https:" ? "; Secure" : "";
+  document.cookie = `${COOKIE_NAME(slug)}=1; Path=/${slug}; Max-Age=${TTL}; SameSite=Lax${secure}`;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm check-types:web
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/landing-visit.client.ts
+git commit -m "feat(§5.17): landing-visit cookie helper"
+```
+
+---
+
+## Task 2: `getPopularItems` query
+
+**Files:**
+- Modify: `apps/web/src/db/queries.ts`
+
+- [ ] **Step 1: Add `PopularItem` type after the existing exported types near the top of queries.ts (after `LiveTopItem`)**
+
+```ts
+export type PopularItem = {
+  itemId: string;
+  name: string;
+  imageUrl: string | null;
+  minPrice: number;
+  totalQty: number;
+};
+```
+
+- [ ] **Step 2: Add `getPopularItems` function at the end of queries.ts (before the final closing)**
+
+```ts
+export async function getPopularItems(
+  tenantSlug: string,
+  limit = 3,
+  days = 90,
+): Promise<PopularItem[]> {
+  try {
+    const result = await db.execute<{
+      itemId: string;
+      name: string | null;
+      imageUrl: string | null;
+      minPrice: string | null;   // postgres numeric → string over neon-http
+      totalQty: number;
+    }>(sql`
+      WITH ranked AS (
+        SELECT ol.item_id, SUM(ol.qty)::int AS total_qty
+        FROM order_lines ol
+        JOIN orders o ON o.id = ol.order_id
+        WHERE o.tenant_id = ${tenantSlug}
+          AND o.created_at >= NOW() - make_interval(days => ${days})
+          AND o.status NOT IN ('pending_payment', 'refunded')
+        GROUP BY ol.item_id
+        ORDER BY total_qty DESC
+        LIMIT ${limit}
+      )
+      SELECT
+        r.item_id            AS "itemId",
+        ci.name,
+        ci.image_url         AS "imageUrl",
+        (SELECT MIN(price)::text FROM catalog_variants cv
+         WHERE cv.item_id = r.item_id AND cv.active = true) AS "minPrice",
+        r.total_qty          AS "totalQty"
+      FROM ranked r
+      LEFT JOIN catalog_items ci ON ci.id = r.item_id
+    `);
+    return result.rows.map((r) => ({
+      itemId: r.itemId,
+      name: r.name ?? r.itemId,
+      imageUrl: r.imageUrl,
+      minPrice: r.minPrice != null ? parseFloat(r.minPrice) : 0,
+      totalQty: r.totalQty,
+    }));
+  } catch {
+    return [];
+  }
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+pnpm check-types:web
+```
+
+Expected: no errors. If `db.execute` type signature complains about the generic, change to:
+```ts
+const result = await db.execute(sql`...`) as { rows: { itemId: string; ... }[] };
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/db/queries.ts
+git commit -m "feat(§5.17): getPopularItems query — top-3 by qty last 90 days"
+```
+
+---
+
+## Task 3: `<LandingScreen>` component
+
+**Files:**
+- Create: `apps/web/src/app/[tenant]/landing-screen.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// apps/web/src/app/[tenant]/landing-screen.tsx
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Crest } from "@/components/crest";
+import { GarmentVector } from "@/components/garment";
+import { TenantFooter } from "@/components/tenant-footer";
+import { BottomNav } from "@/components/bottom-nav";
+import { setVisitedCookie } from "@/lib/landing-visit.client";
+import { type TenantRow } from "@/db/schema";
+import { type PopularItem } from "@/db/queries";
+
+export function LandingScreen({
+  tenant,
+  popularItems,
+  accent,
+}: {
+  tenant: TenantRow;
+  popularItems: PopularItem[];
+  accent: string;
+}) {
+  const router = useRouter();
+
+  function visit(path: string) {
+    setVisitedCookie(tenant.id);
+    router.push(path);
+  }
+
+  return (
+    <>
+      {/* Header strip — crest + name only, no child/cart ornaments */}
+      <div
+        className="text-white px-4 pt-1 pb-3.5 flex-shrink-0 flex items-center gap-2.5 py-1.5"
+        style={{ background: accent }}
+      >
+        <Crest tenant={tenant} size={28} ring={false} />
+        <span className="text-sm font-medium leading-tight opacity-90">
+          {tenant.name}
+        </span>
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-4 pt-6 pb-4 flex flex-col gap-5">
+
+        {/* Hero: large crest + name + motto */}
+        <div className="flex flex-col items-center text-center gap-3 py-2">
+          <Crest tenant={tenant} size={80} ring />
+          <div>
+            <p
+              className="font-serif text-lg font-bold leading-snug"
+              style={{ color: "var(--color-navy-deep)" }}
+            >
+              {tenant.name}
+            </p>
+            {tenant.motto && (
+              <p
+                className="font-serif italic text-xs mt-1 tracking-wide"
+                style={{ color: "var(--color-gold)" }}
+              >
+                {tenant.motto}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div className="h-px" style={{ background: "var(--color-rule)" }} />
+
+        {/* Shop hours card */}
+        {tenant.shopHours && (
+          <div
+            className="rounded-[10px] border px-4 py-3 flex flex-col gap-1.5"
+            style={{ background: "var(--color-paper)", borderColor: "var(--color-rule)" }}
+          >
+            <p
+              className="text-[10px] font-bold tracking-widest uppercase"
+              style={{ color: "var(--color-gold)" }}
+            >
+              Uniform Shop
+            </p>
+            <p
+              className="text-[13px] font-semibold"
+              style={{ color: "var(--color-navy-deep)" }}
+            >
+              {tenant.shopHours}
+            </p>
+            {tenant.collectionInstructions && (
+              <p className="text-xs leading-relaxed" style={{ color: "#4a5060" }}>
+                {tenant.collectionInstructions}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Popular this term */}
+        {popularItems.length > 0 && (
+          <div>
+            <p
+              className="text-[10px] font-bold tracking-widest uppercase mb-3"
+              style={{ color: "var(--color-gold)" }}
+            >
+              Popular this term
+            </p>
+            <div className="grid grid-cols-3 gap-2">
+              {popularItems.map((item) => (
+                <button
+                  key={item.itemId}
+                  onClick={() => visit(`/${tenant.id}/${item.itemId}`)}
+                  className="flex flex-col items-center rounded-[8px] border p-2.5 text-center cursor-pointer hover:border-current transition-colors"
+                  style={{ background: "var(--color-paper)", borderColor: "var(--color-rule)" }}
+                >
+                  <div
+                    className="w-10 h-10 rounded-md flex items-center justify-center mb-1.5 overflow-hidden"
+                    style={{ background: "var(--color-parchment)" }}
+                  >
+                    {item.imageUrl ? (
+                      <img
+                        src={item.imageUrl}
+                        alt=""
+                        className="w-full h-full object-contain"
+                      />
+                    ) : (
+                      <GarmentVector
+                        itemId={item.itemId}
+                        accent={accent}
+                        size={32}
+                        className="block"
+                      />
+                    )}
+                  </div>
+                  <span
+                    className="text-[10.5px] font-semibold leading-tight"
+                    style={{ color: "var(--color-navy-deep)" }}
+                  >
+                    {item.name}
+                  </span>
+                  <span
+                    className="text-[10.5px] font-medium mt-0.5 tnum"
+                    style={{ color: "var(--color-gold)" }}
+                  >
+                    ${item.minPrice % 1 === 0
+                      ? item.minPrice.toFixed(0)
+                      : item.minPrice.toFixed(2)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* CTA */}
+        <button
+          onClick={() => visit(`/${tenant.id}`)}
+          className="w-full rounded-[9px] py-3.5 text-sm font-semibold text-white tracking-wide"
+          style={{ background: accent }}
+        >
+          Browse Catalogue →
+        </button>
+
+        {/* Footer note */}
+        <p className="text-center text-[10px] opacity-50">
+          This welcome screen won&apos;t show again for 30 days
+        </p>
+
+      </div>
+
+      <TenantFooter tenant={tenant} />
+      <div className="pb-16" />
+      <BottomNav active="shop" shopHref={`/${tenant.id}`} accent={accent} />
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm check-types:web
+```
+
+Expected: no errors. Common issue to watch for: `GarmentVector` may not accept a `className` prop — check `components/garment.tsx`. If it doesn't, wrap it in a `<div className="...">` instead.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/app/[tenant]/landing-screen.tsx
+git commit -m "feat(§5.17): LandingScreen component — crest/motto/hours/popular-items/CTA"
+```
+
+---
+
+## Task 4: Wire `page.tsx` — cookie branch
+
+**Files:**
+- Modify: `apps/web/src/app/[tenant]/page.tsx`
+
+Three surgical edits to the existing file. The catalogue JSX (`return (...)`) is untouched.
+
+- [ ] **Step 1: Add three new imports**
+
+At the top of `page.tsx`, add:
+
+```ts
+import { cookies } from "next/headers";                    // after "next/navigation"
+import { getPopularItems } from "@/db/queries";            // merge into existing @/db/queries line
+import { LandingScreen } from "./landing-screen";          // after CatalogGrid import
+```
+
+The `@/db/queries` import line should become:
+
+```ts
+import { getTenant, getActiveCatalog, toTenantBrand, getPopularItems } from "@/db/queries";
+```
+
+- [ ] **Step 2: Replace the initial `Promise.all` + split fetch**
+
+Find this block near the top of `CatalogPage` (lines 1-4 of the function body):
+
+```ts
+const [tenantRecord, catalog] = await Promise.all([
+  getTenant(slug),
+  getActiveCatalog(slug),
+]);
+if (!tenantRecord) notFound();
+```
+
+Replace with:
+
+```ts
+const tenantRecord = await getTenant(slug);
+if (!tenantRecord) notFound();
+```
+
+Then find the line `const tenant = toTenantBrand(tenantRecord);` and insert the landing branch
+**immediately after it**:
+
+```ts
+const tenant = toTenantBrand(tenantRecord);
+
+// ── Landing branch — first-visit only ──────────────────────────────────────
+const cookieStore = await cookies();
+const hasVisited = !!cookieStore.get(`uo:visited:${slug}`)?.value;
+
+if (!hasVisited) {
+  const popularItems = await getPopularItems(slug);
+  return (
+    <MobileShell bg="var(--color-paper)" logoUrl={tenantRecord.logoUrl ?? undefined}>
+      <LandingScreen
+        tenant={tenantRecord}
+        popularItems={popularItems}
+        accent={tenant.accent}
+      />
+    </MobileShell>
+  );
+}
+
+// ── Catalogue branch — returning visitors (everything below is unchanged) ───
+const catalog = await getActiveCatalog(slug);
+```
+
+- [ ] **Step 3: Remove the now-stale `catalog` variable reference if needed**
+
+Because `getActiveCatalog` was moved out of the original `Promise.all`, find any remaining
+destructured `catalog` reference from the old `Promise.all` (if the editor left one). The variable
+`catalog` should now only come from the `const catalog = await getActiveCatalog(slug);` line added
+in Step 2. The rest of the function body (`sp`, `activeCat`, `getActiveChild`, the `return (...)`)
+stays exactly as it was.
+
+- [ ] **Step 4: Type-check**
+
+```bash
+pnpm check-types:web
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Manual smoke test**
+
+```bash
+pnpm dev:web
+```
+
+1. Open `http://localhost:3000/nsbh` in a private/incognito window (no cookie) → should see the landing screen: large crest, school name, motto, shop hours card, and popular items row (or no row if the DB has no orders in the last 90 days).
+2. Click "Browse Catalogue →" → navigates back to `/nsbh` and the catalogue grid appears (cookie is now set).
+3. Reload `http://localhost:3000/nsbh` in the same window → catalogue directly, no landing.
+4. Open `http://localhost:3000/rgsh` in a new private window → landing appears with RGSH accent colour and data.
+5. Confirm the visibility gate still works: a tenant with `isPubliclyListed = false` should return 404 for a non-admin visitor on both the landing and catalogue branches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/[tenant]/page.tsx
+git commit -m "feat(§5.17): wire cookie branch in page.tsx — first-visit landing"
+```

--- a/docs/superpowers/specs/2026-05-13-per-tenant-homepage-design.md
+++ b/docs/superpowers/specs/2026-05-13-per-tenant-homepage-design.md
@@ -1,0 +1,174 @@
+# §5.17 — Per-tenant first-visit landing page
+
+**Date:** 2026-05-13
+**Status:** Approved
+
+## Problem
+
+`/<tenant>` currently drops parents straight into the catalogue grid. A first-visit landing gives
+returning parents context — shop hours, pickup instructions, and a sense of which items are
+popular — before they start browsing.
+
+---
+
+## Behaviour
+
+- **First visit** (no cookie): `/<tenant>` renders `<LandingScreen>` instead of the catalogue.
+- **Subsequent visits** (cookie present): `/<tenant>` renders the catalogue directly, identical to the current experience.
+- The cookie is **written client-side** the moment the parent taps "Browse Catalogue" or any
+  popular-item tile. The page then navigates to `/<tenant>`, which now shows the catalogue.
+- Cookie name: `uo:visited:{tenantSlug}` (e.g. `uo:visited:nsbh`)
+- Cookie TTL: **30 days**. `Path=/{slug}; SameSite=Lax`.
+
+---
+
+## Architecture
+
+### Routing — no new routes
+
+The decision is made entirely inside the existing RSC at `app/[tenant]/page.tsx`:
+
+```ts
+const cookieStore = await cookies();
+const hasVisited = !!cookieStore.get(`uo:visited:${slug}`)?.value;
+
+if (!hasVisited) {
+  // fetch popular items, render LandingScreen
+} else {
+  // existing catalogue path
+}
+```
+
+No redirects. No separate `/<tenant>/welcome` route. No client-side layout shift.
+
+### Data fetching in page.tsx
+
+- **Cookie present** (returning visitor): same `Promise.all([getTenant, getActiveCatalog])` as today.
+- **Cookie absent** (first visit): `Promise.all([getTenant, getPopularItems(slug, 3, 90)])`.
+  `getActiveCatalog` is skipped — the landing screen does not render the catalogue grid.
+
+---
+
+## New component — `<LandingScreen>`
+
+**File:** `apps/web/src/app/[tenant]/landing-screen.tsx`
+**Type:** `"use client"`
+
+### Props
+
+```ts
+type PopularItem = { itemId: string; name: string; imageUrl: string | null; minPrice: number; totalQty: number };
+
+type LandingScreenProps = {
+  tenant: TenantRow;
+  popularItems: PopularItem[];  // may be empty []
+  accent: string;
+};
+```
+
+### Layout (top → bottom inside `MobileShell`)
+
+| # | Section | Notes |
+|---|---------|-------|
+| 1 | **Header strip** | Accent background, `Crest` (28px) + `tenant.name`. Identical to the catalogue header strip. |
+| 2 | **Hero** | Large `Crest` (80px) centred, `tenant.name` in `font-serif` below it, `tenant.motto` in italic gold below that. Motto line omitted when `tenant.motto` is null. |
+| 3 | **Divider** | 1px `--color-rule` line. |
+| 4 | **Shop hours card** | Paper background, rule border, `--color-gold` uppercase label "Uniform Shop". `tenant.shopHours` in bold. `tenant.collectionInstructions` as a second line — omitted when null. |
+| 5 | **"Popular this term" row** | Gold uppercase label. Three item tiles (garment placeholder or `imageUrl`, item name, lowest variant price). Each tile is a link → sets cookie + navigates to `/<slug>/<itemId>`. **Entire row omitted when `popularItems` is empty.** |
+| 6 | **"Browse Catalogue →" button** | Full-width, accent background, `font-sans font-semibold`. On press: `setVisitedCookie(slug)` then `router.push('/<slug>')`. |
+| 7 | **Footer note** | `"This welcome screen won't show again for 30 days"` — tiny, muted, centred. |
+
+### Cookie interaction
+
+`LandingScreen` imports `setVisitedCookie` from `lib/landing-visit.client.ts` and calls it before
+navigating. Both the CTA button and individual popular-item tiles call this.
+
+---
+
+## New query — `getPopularItems`
+
+**File:** `apps/web/src/db/queries.ts`
+
+```ts
+export async function getPopularItems(
+  tenantSlug: string,
+  limit: number = 3,
+  days: number = 90,
+): Promise<PopularItem[]>
+```
+
+Implementation:
+
+```sql
+SELECT
+  ol.item_id,
+  ci.name,
+  ci.image_url,
+  MIN(cv.price)::numeric   AS min_price,
+  SUM(ol.qty)::int         AS total_qty
+FROM order_lines ol
+JOIN orders o        ON o.id   = ol.order_id
+LEFT JOIN catalog_items ci ON ci.id  = ol.item_id
+LEFT JOIN catalog_variants cv ON cv.item_id = ol.item_id AND cv.active = true
+WHERE o.tenant_id = :tenantSlug
+  AND o.created_at >= NOW() - INTERVAL ':days days'
+  AND o.status NOT IN ('pending_payment', 'refunded')
+GROUP BY ol.item_id, ci.name, ci.image_url
+ORDER BY total_qty DESC
+LIMIT :limit
+```
+
+Returns `[]` on error or when no data — not a page-breaking query; the landing renders without the
+popular-items row in that case.
+
+Orders with `pending_payment` and `refunded` status are excluded so only fulfilled demand counts.
+
+---
+
+## New helper — `lib/landing-visit.client.ts`
+
+Same shape as `lib/active-child.client.ts`.
+
+```ts
+const COOKIE_NAME = (slug: string) => `uo:visited:${slug}`;
+const TTL = 60 * 60 * 24 * 30; // 30 days
+
+export function setVisitedCookie(slug: string): void {
+  const secure = location.protocol === 'https:' ? '; Secure' : '';
+  document.cookie = `${COOKIE_NAME(slug)}=1; Path=/${slug}; Max-Age=${TTL}; SameSite=Lax${secure}`;
+}
+```
+
+---
+
+## Graceful degradation
+
+| Scenario | Behaviour |
+|----------|-----------|
+| `tenant.motto` is null | Motto italic line omitted |
+| `tenant.collectionInstructions` is null | Instructions line in hours card omitted |
+| `tenant.shopHours` is null | Entire shop hours card omitted |
+| No order history (new tenant) | "Popular this term" row omitted |
+| `getPopularItems` throws | Caught, returns `[]`; landing renders without the row |
+
+---
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `apps/web/src/app/[tenant]/page.tsx` | Read cookie; branch to `LandingScreen` or catalogue |
+| `apps/web/src/app/[tenant]/landing-screen.tsx` | **New** — client component |
+| `apps/web/src/lib/landing-visit.client.ts` | **New** — cookie helpers |
+| `apps/web/src/db/queries.ts` | Add `getPopularItems` |
+
+No schema migrations required — all data fields (`shopHours`, `collectionInstructions`, `motto`)
+already exist on the `tenants` table.
+
+---
+
+## Out of scope
+
+- Admin UI to configure the landing (tenant operators cannot toggle it off — it shows for all tenants).
+- Term date configuration (rolling 90-day window is sufficient).
+- Analytics events for landing impressions (can be added later with `serverCapture`).

--- a/docs/superpowers/specs/2026-05-13-per-tenant-homepage-design.md
+++ b/docs/superpowers/specs/2026-05-13-per-tenant-homepage-design.md
@@ -1,13 +1,13 @@
 # §5.17 — Per-tenant first-visit landing page
 
 **Date:** 2026-05-13
-**Status:** Approved
+**Status:** Approved (rev 2 — post-review fixes applied)
 
 ## Problem
 
 `/<tenant>` currently drops parents straight into the catalogue grid. A first-visit landing gives
-returning parents context — shop hours, pickup instructions, and a sense of which items are
-popular — before they start browsing.
+parents context — shop hours, pickup instructions, and a sense of which items are popular — before
+they start browsing.
 
 ---
 
@@ -19,6 +19,8 @@ popular — before they start browsing.
   popular-item tile. The page then navigates to `/<tenant>`, which now shows the catalogue.
 - Cookie name: `uo:visited:{tenantSlug}` (e.g. `uo:visited:nsbh`)
 - Cookie TTL: **30 days**. `Path=/{slug}; SameSite=Lax`.
+  - Slugs are always lowercase ASCII (e.g. `nsbh`, `rgsh`) — no URL-encoding is applied to the Path
+    value. A future slug containing uppercase or non-ASCII characters would require encoding here.
 
 ---
 
@@ -26,9 +28,19 @@ popular — before they start browsing.
 
 ### Routing — no new routes
 
-The decision is made entirely inside the existing RSC at `app/[tenant]/page.tsx`:
+The decision is made entirely inside the existing RSC at `app/[tenant]/page.tsx`. The
+public-visibility gate (blocking hidden/pending tenants for non-admins) runs **before** the cookie
+branch — both paths inherit it:
 
 ```ts
+// 1. Validate slug (already in layout.tsx)
+// 2. Public-visibility gate — same logic as today, applied before both branches
+const sessionUser = await getSessionUser();
+if (!tenantRecord.isPubliclyListed && !isPlatformAdminEmail(sessionUser?.email)) {
+  notFound();
+}
+
+// 3. Cookie branch
 const cookieStore = await cookies();
 const hasVisited = !!cookieStore.get(`uo:visited:${slug}`)?.value;
 
@@ -45,7 +57,7 @@ No redirects. No separate `/<tenant>/welcome` route. No client-side layout shift
 
 - **Cookie present** (returning visitor): same `Promise.all([getTenant, getActiveCatalog])` as today.
 - **Cookie absent** (first visit): `Promise.all([getTenant, getPopularItems(slug, 3, 90)])`.
-  `getActiveCatalog` is skipped — the landing screen does not render the catalogue grid.
+  `getActiveCatalog` is skipped — the landing does not render the catalogue grid.
 
 ---
 
@@ -57,7 +69,13 @@ No redirects. No separate `/<tenant>/welcome` route. No client-side layout shift
 ### Props
 
 ```ts
-type PopularItem = { itemId: string; name: string; imageUrl: string | null; minPrice: number; totalQty: number };
+type PopularItem = {
+  itemId: string;
+  name: string;
+  imageUrl: string | null;
+  minPrice: number;
+  totalQty: number;
+};
 
 type LandingScreenProps = {
   tenant: TenantRow;
@@ -70,18 +88,22 @@ type LandingScreenProps = {
 
 | # | Section | Notes |
 |---|---------|-------|
-| 1 | **Header strip** | Accent background, `Crest` (28px) + `tenant.name`. Identical to the catalogue header strip. |
+| 1 | **Header strip** | Accent background. `Crest` (28px) + `tenant.name` only. **No** active-child line. **No** cart badge. These ornaments are irrelevant before the parent has browsed. |
 | 2 | **Hero** | Large `Crest` (80px) centred, `tenant.name` in `font-serif` below it, `tenant.motto` in italic gold below that. Motto line omitted when `tenant.motto` is null. |
 | 3 | **Divider** | 1px `--color-rule` line. |
-| 4 | **Shop hours card** | Paper background, rule border, `--color-gold` uppercase label "Uniform Shop". `tenant.shopHours` in bold. `tenant.collectionInstructions` as a second line — omitted when null. |
-| 5 | **"Popular this term" row** | Gold uppercase label. Three item tiles (garment placeholder or `imageUrl`, item name, lowest variant price). Each tile is a link → sets cookie + navigates to `/<slug>/<itemId>`. **Entire row omitted when `popularItems` is empty.** |
-| 6 | **"Browse Catalogue →" button** | Full-width, accent background, `font-sans font-semibold`. On press: `setVisitedCookie(slug)` then `router.push('/<slug>')`. |
+| 4 | **Shop hours card** | Paper background, rule border, `--color-gold` uppercase label "Uniform Shop". `tenant.shopHours` in bold. `tenant.collectionInstructions` as a second line — omitted when null. Entire card omitted when `tenant.shopHours` is also null. |
+| 5 | **"Popular this term" row** | Gold uppercase label. Three item tiles: `imageUrl` if non-null, otherwise `<GarmentVector itemId>` as fallback (same pattern as catalogue grid). Item name + `minPrice` formatted as currency. Each tile: `onClick` calls `setVisitedCookie(slug)` then `router.push('/<slug>/<itemId>')`. **Entire row omitted when `popularItems` is empty.** |
+| 6 | **"Browse Catalogue →" button** | Full-width, accent background, `font-sans font-semibold`. `onClick`: `setVisitedCookie(slug)` then `router.push('/<slug>')`. Using `onClick` + `router.push` (not a plain `<Link>`) ensures the cookie is written synchronously before the navigation request fires. |
 | 7 | **Footer note** | `"This welcome screen won't show again for 30 days"` — tiny, muted, centred. |
+| 8 | **`<TenantFooter>`** | Kept — carries address, shop email, and legal links distinct from the hero content. |
+| 9 | **`<BottomNav active="shop">`** | Kept — consistent shell; parents may want to navigate from the landing. |
 
 ### Cookie interaction
 
-`LandingScreen` imports `setVisitedCookie` from `lib/landing-visit.client.ts` and calls it before
-navigating. Both the CTA button and individual popular-item tiles call this.
+`LandingScreen` imports `setVisitedCookie` from `lib/landing-visit.client.ts`. Both the CTA button
+and individual popular-item tile `onClick` handlers call it before navigating. `document.cookie`
+writes are synchronous — the cookie is present in the browser's outgoing Cookie header on the
+immediately following navigation request.
 
 ---
 
@@ -97,31 +119,48 @@ export async function getPopularItems(
 ): Promise<PopularItem[]>
 ```
 
-Implementation:
+### SQL shape (Drizzle `sql` template)
+
+Aggregation is done in a CTE first to avoid row inflation from joining `catalog_variants`:
 
 ```sql
+WITH ranked AS (
+  SELECT ol.item_id, SUM(ol.qty)::int AS total_qty
+  FROM order_lines ol
+  JOIN orders o ON o.id = ol.order_id
+  WHERE o.tenant_id = $1
+    AND o.created_at >= NOW() - make_interval(days => $2)
+    AND o.status NOT IN ('pending_payment', 'refunded')
+  GROUP BY ol.item_id
+  ORDER BY total_qty DESC
+  LIMIT $3
+)
 SELECT
-  ol.item_id,
+  r.item_id,
   ci.name,
   ci.image_url,
-  MIN(cv.price)::numeric   AS min_price,
-  SUM(ol.qty)::int         AS total_qty
-FROM order_lines ol
-JOIN orders o        ON o.id   = ol.order_id
-LEFT JOIN catalog_items ci ON ci.id  = ol.item_id
-LEFT JOIN catalog_variants cv ON cv.item_id = ol.item_id AND cv.active = true
-WHERE o.tenant_id = :tenantSlug
-  AND o.created_at >= NOW() - INTERVAL ':days days'
-  AND o.status NOT IN ('pending_payment', 'refunded')
-GROUP BY ol.item_id, ci.name, ci.image_url
-ORDER BY total_qty DESC
-LIMIT :limit
+  (SELECT MIN(price) FROM catalog_variants cv
+   WHERE cv.item_id = r.item_id AND cv.active = true) AS min_price,
+  r.total_qty
+FROM ranked r
+LEFT JOIN catalog_items ci ON ci.id = r.item_id
 ```
 
-Returns `[]` on error or when no data — not a page-breaking query; the landing renders without the
-popular-items row in that case.
+**Why CTE:** The lateral subquery for `min_price` is applied per-row after the ranked set is
+computed, avoiding the fan-out that a direct JOIN would introduce before aggregation.
 
-Orders with `pending_payment` and `refunded` status are excluded so only fulfilled demand counts.
+**Status filter:** Deny-list `NOT IN ('pending_payment', 'refunded')`. Full enum is
+`pending_payment | new | packing | ready | collected | partially_refunded | refunded`.
+The deny-list excludes: orders that never completed payment (`pending_payment`) and orders fully
+reversed (`refunded`). All other statuses represent real demand. `partially_refunded` counts
+(items were delivered). A deny-list is preferred over an allow-list here — any future status added
+to the enum is almost certainly a legitimate fulfillment state.
+
+**`make_interval`** is used instead of `INTERVAL '... days'` string interpolation because Drizzle's
+parameterizer cannot bind values inside an interval literal.
+
+Returns `[]` on error — not a page-breaking query; the landing renders without the popular-items
+row in that case.
 
 ---
 
@@ -135,6 +174,7 @@ const TTL = 60 * 60 * 24 * 30; // 30 days
 
 export function setVisitedCookie(slug: string): void {
   const secure = location.protocol === 'https:' ? '; Secure' : '';
+  // slug is lowercase ASCII — no URL-encoding needed for Path
   document.cookie = `${COOKIE_NAME(slug)}=1; Path=/${slug}; Max-Age=${TTL}; SameSite=Lax${secure}`;
 }
 ```
@@ -150,6 +190,7 @@ export function setVisitedCookie(slug: string): void {
 | `tenant.shopHours` is null | Entire shop hours card omitted |
 | No order history (new tenant) | "Popular this term" row omitted |
 | `getPopularItems` throws | Caught, returns `[]`; landing renders without the row |
+| `imageUrl` is null on a popular item | `<GarmentVector itemId>` renders instead |
 
 ---
 
@@ -157,9 +198,9 @@ export function setVisitedCookie(slug: string): void {
 
 | File | Change |
 |------|--------|
-| `apps/web/src/app/[tenant]/page.tsx` | Read cookie; branch to `LandingScreen` or catalogue |
+| `apps/web/src/app/[tenant]/page.tsx` | Read cookie; preserve visibility gate on both branches; branch to `LandingScreen` or catalogue |
 | `apps/web/src/app/[tenant]/landing-screen.tsx` | **New** — client component |
-| `apps/web/src/lib/landing-visit.client.ts` | **New** — cookie helpers |
+| `apps/web/src/lib/landing-visit.client.ts` | **New** — `setVisitedCookie` helper |
 | `apps/web/src/db/queries.ts` | Add `getPopularItems` |
 
 No schema migrations required — all data fields (`shopHours`, `collectionInstructions`, `motto`)
@@ -169,6 +210,6 @@ already exist on the `tenants` table.
 
 ## Out of scope
 
-- Admin UI to configure the landing (tenant operators cannot toggle it off — it shows for all tenants).
+- Admin UI to configure the landing (shows for all tenants; cannot be toggled off per-tenant).
 - Term date configuration (rolling 90-day window is sufficient).
 - Analytics events for landing impressions (can be added later with `serverCapture`).


### PR DESCRIPTION
## Summary

- Cookie-gated first-visit landing screen on `/<tenant>` — large crest, school motto, shop hours card, popular items grid (top-3 by order qty over last 90 days), and "Browse Catalogue →" CTA
- 30-day `uo:visited:{slug}` cookie written client-side; returning visitors hit the catalogue directly (existing path unchanged)
- CTA uses `router.refresh()` (not `router.push`) to re-trigger the RSC cookie read at the same URL
- Visibility gate runs before the cookie branch — hidden/pending tenants still 404 on first visit
- `getPopularItems` uses a CTE to avoid row fan-out from the variants join; gracefully returns `[]` on error

## Files changed

| File | Change |
|------|--------|
| `apps/web/src/lib/landing-visit.client.ts` | New — `setVisitedCookie(slug)` helper |
| `apps/web/src/db/queries.ts` | Added `PopularItem` type + `getPopularItems` CTE query |
| `apps/web/src/app/[tenant]/landing-screen.tsx` | New — full client component |
| `apps/web/src/app/[tenant]/page.tsx` | Cookie read, conditional parallel fetch, landing branch after visibility gate |
| `docs/superpowers/specs/2026-05-13-per-tenant-homepage-design.md` | Spec (v2, reviewed) |
| `docs/superpowers/plans/2026-05-13-per-tenant-homepage.md` | Plan (v2, reviewed) |
| `docs/remaining_work.md` | §5.17 marked complete |

## Test plan

- [ ] Open `/<tenant>` in a private/incognito window → landing screen appears (crest, hours, popular items or empty row if no order history)
- [ ] Click "Browse Catalogue →" → cookie set, RSC refreshes, catalogue grid appears
- [ ] Reload same window → catalogue directly, no landing
- [ ] Open second tenant in another private window → correct accent colour + data
- [ ] Hidden tenant → 404 on first visit (visibility gate respected)
- [ ] Platform-admin email → sees landing for any tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)