### PR TITLE
feat(catalog): admin drag-to-reorder (§3.12)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,9 @@
     "print-qa": "node tests/print/print-qa.mjs"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@gravity-ui/icons": "^2.18.0",
     "@heroui-pro/react": "1.0.0-beta.2",
     "@heroui/react": "^3.0.3",

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -45,6 +45,7 @@ export function CatalogTable({
 
   const handleDelete = async (id: string, name: string) => {
     if (!confirm(`Remove "${name}" from the catalog?`)) return;
+    pendingRef.current = true;
     const previous = items;
     setTableError("");
     setItems((prev) => prev.filter((it) => it.id !== id));
@@ -58,6 +59,8 @@ export function CatalogTable({
       console.error("Delete failed:", err);
       setItems(previous);
       setTableError(err instanceof Error ? err.message : "Failed to delete item.");
+    } finally {
+      pendingRef.current = false;
     }
   };
 
@@ -108,7 +111,7 @@ export function CatalogTable({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          tenantSlug: tenant.id,
+          tenantSlug: tenant.id, // tenant.id is the slug ("nsbh") in this codebase
           orderedIds: reordered.map((it) => it.id),
         }),
       });

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import Image from "next/image";
 import {
@@ -37,6 +37,7 @@ export function CatalogTable({
   tenant: Tenant;
 }) {
   const [tableError, setTableError] = useState("");
+  const pendingRef = useRef(false);
   const [drawer, setDrawer] = useState<
     | { open: false }
     | { open: true; mode: "edit"; item: CatalogItemWithVariants }
@@ -89,6 +90,11 @@ export function CatalogTable({
     const newIndex = items.findIndex((it) => it.id === over.id);
     if (oldIndex < 0 || newIndex < 0) return;
 
+    if (pendingRef.current) return;
+    pendingRef.current = true;
+
+    // Snapshot before mutation; safe because handleDelete uses setItems((prev) => ...)
+    // and React only batches across await points — no overlap window in synchronous path.
     const previous = items;
     const reordered = arrayMove(items, oldIndex, newIndex).map((it, i) => ({
       ...it,
@@ -122,17 +128,20 @@ export function CatalogTable({
       const isStale =
         err instanceof Error &&
         (err as Error & { isStale?: boolean }).isStale === true;
-      setTableError(
-        err instanceof Error ? `Reorder failed: ${err.message}` : "Reorder failed.",
-      );
       if (isStale) {
         // Server rejected our premise (set membership changed) — previous
         // snapshot is also stale, so let refresh() be the sole source of truth.
+        setTableError("Catalog changed — please refresh.");
         await refresh();
       } else {
         // Transient failure — roll back optimistic reorder.
+        setTableError(
+          err instanceof Error ? `Reorder failed: ${err.message}` : "Reorder failed.",
+        );
         setItems(previous);
       }
+    } finally {
+      pendingRef.current = false;
     }
   };
 

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -125,7 +125,7 @@ export function CatalogTable({
         const err = new Error(
           isStale
             ? "Catalog changed — please refresh."
-            : data?.message ?? data?.error ?? "Reorder failed.",
+            : data?.message ?? data?.error ?? "An unknown error occurred.",
         );
         (err as Error & { isStale?: boolean }).isStale = isStale;
         throw err;

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -45,6 +45,10 @@ export function CatalogTable({
 
   const handleDelete = async (id: string, name: string) => {
     if (!confirm(`Remove "${name}" from the catalog?`)) return;
+    if (pendingRef.current) {
+      setTableError("Another operation is in progress — please wait.");
+      return;
+    }
     pendingRef.current = true;
     const previous = items;
     setTableError("");

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -1,7 +1,25 @@
 "use client";
 
 import { Dispatch, SetStateAction, useState } from "react";
+import type { CSSProperties } from "react";
 import Image from "next/image";
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { GarmentVector } from "@/components/garment";
 import { ItemDrawer, type ItemDrawerInitial } from "./item-drawer";
 import type { Tenant, ItemCategory } from "@/lib/data";
@@ -58,6 +76,66 @@ export function CatalogTable({
     })),
   });
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = items.findIndex((it) => it.id === active.id);
+    const newIndex = items.findIndex((it) => it.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+
+    const previous = items;
+    const reordered = arrayMove(items, oldIndex, newIndex).map((it, i) => ({
+      ...it,
+      sortOrder: i,
+    }));
+    setItems(reordered);
+    setTableError("");
+
+    try {
+      const res = await fetch("/api/catalog/reorder", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tenantSlug: tenant.id,
+          orderedIds: reordered.map((it) => it.id),
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        const isStale = data?.error === "stale_set";
+        const err = new Error(
+          isStale
+            ? "Catalog changed — please refresh."
+            : data?.message ?? data?.error ?? "Reorder failed.",
+        );
+        (err as Error & { isStale?: boolean }).isStale = isStale;
+        throw err;
+      }
+    } catch (err) {
+      console.error("Reorder failed:", err);
+      const isStale =
+        err instanceof Error &&
+        (err as Error & { isStale?: boolean }).isStale === true;
+      setTableError(
+        err instanceof Error ? `Reorder failed: ${err.message}` : "Reorder failed.",
+      );
+      if (isStale) {
+        // Server rejected our premise (set membership changed) — previous
+        // snapshot is also stale, so let refresh() be the sole source of truth.
+        await refresh();
+      } else {
+        // Transient failure — roll back optimistic reorder.
+        setItems(previous);
+      }
+    }
+  };
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden p-6">
       {tableError && (
@@ -65,89 +143,54 @@ export function CatalogTable({
           {tableError}
         </div>
       )}
-
-      <div className="flex-1 overflow-auto rounded-md border" style={{ borderColor: "var(--color-rule)" }}>
-        <table className="w-full text-[13px]">
-          <thead className="bg-white sticky top-0">
-            <tr className="text-left" style={{ color: "var(--color-ink-dim)" }}>
-              <th className="px-2 py-2 w-[28px]" aria-label="Reorder"></th>
-              <th className="px-3 py-2 w-[60px]">Image</th>
-              <th className="px-3 py-2">Name</th>
-              <th className="px-3 py-2 w-[110px]">Category</th>
-              <th className="px-3 py-2 w-[100px]">Variants</th>
-              <th className="px-3 py-2 w-[80px]">Active</th>
-              <th className="px-3 py-2 w-[60px]"></th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((it) => (
-              <tr
-                key={it.id}
-                className="border-t cursor-pointer hover:bg-[var(--color-parchment)]"
-                style={{ borderColor: "var(--color-rule)" }}
-                onClick={() => setDrawer({ open: true, mode: "edit", item: it })}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="flex-1 overflow-auto rounded-md border" style={{ borderColor: "var(--color-rule)" }}>
+          <table className="w-full text-[13px]">
+            <thead className="bg-white sticky top-0">
+              <tr className="text-left" style={{ color: "var(--color-ink-dim)" }}>
+                <th className="px-2 py-2 w-[28px]" aria-label="Reorder"></th>
+                <th className="px-3 py-2 w-[60px]">Image</th>
+                <th className="px-3 py-2">Name</th>
+                <th className="px-3 py-2 w-[110px]">Category</th>
+                <th className="px-3 py-2 w-[100px]">Variants</th>
+                <th className="px-3 py-2 w-[80px]">Active</th>
+                <th className="px-3 py-2 w-[60px]"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <SortableContext
+                items={items.map((it) => it.id)}
+                strategy={verticalListSortingStrategy}
               >
-                <td
-                  className="px-2 py-2"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <span
-                    aria-label={`Reorder ${it.name}`}
-                    className="inline-flex items-center justify-center w-5 h-5 select-none"
-                    style={{ color: "var(--color-ink-dim)", cursor: "grab" }}
+                {items.map((it) => (
+                  <SortableRow
+                    key={it.id}
+                    item={it}
+                    tenant={tenant}
+                    onOpenDrawer={(item) => setDrawer({ open: true, mode: "edit", item })}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </SortableContext>
+              {items.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={7}
+                    className="px-3 py-6 text-center"
+                    style={{ color: "var(--color-ink-dim)" }}
                   >
-                    ⠿
-                  </span>
-                </td>
-                <td className="px-3 py-2">
-                  {it.imageUrl ? (
-                    <Image
-                      src={it.imageUrl}
-                      alt={it.name}
-                      width={40}
-                      height={40}
-                      className="rounded-sm object-cover"
-                    />
-                  ) : (
-                    <GarmentVector itemId={it.id} category={it.category as ItemCategory} accent={tenant.accent} size={40} />
-                  )}
-                </td>
-                <td className="px-3 py-2 font-medium">{it.name}</td>
-                <td className="px-3 py-2">{it.category}</td>
-                <td className="px-3 py-2 tnum">{it.variants.length}</td>
-                <td className="px-3 py-2">
-                  {it.active ? (
-                    <span className="text-emerald-700">●</span>
-                  ) : (
-                    <span style={{ color: "var(--color-ink-dim)" }}>○</span>
-                  )}
-                </td>
-                <td
-                  className="px-3 py-2 text-right"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <button
-                    type="button"
-                    className="text-[12px] underline"
-                    onClick={() => handleDelete(it.id, it.name)}
-                    style={{ color: tenant.accent }}
-                  >
-                    Delete
-                  </button>
-                </td>
-              </tr>
-            ))}
-            {items.length === 0 && (
-              <tr>
-                <td colSpan={7} className="px-3 py-6 text-center" style={{ color: "var(--color-ink-dim)" }}>
-                  No items yet. Click "Add item" to create one.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-
+                    No items yet. Click "Add item" to create one.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </DndContext>
       {drawer.open && (
         <ItemDrawer
           tenant={tenant}
@@ -159,5 +202,100 @@ export function CatalogTable({
         />
       )}
     </div>
+  );
+}
+
+function SortableRow({
+  item,
+  tenant,
+  onOpenDrawer,
+  onDelete,
+}: {
+  item: CatalogItemWithVariants;
+  tenant: Tenant;
+  onOpenDrawer: (it: CatalogItemWithVariants) => void;
+  onDelete: (id: string, name: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+    boxShadow: isDragging ? "0 4px 12px rgba(0,0,0,0.12)" : undefined,
+    borderColor: "var(--color-rule)",
+  };
+
+  return (
+    <tr
+      ref={setNodeRef}
+      style={style}
+      className="border-t cursor-pointer hover:bg-[var(--color-parchment)]"
+      onClick={() => onOpenDrawer(item)}
+    >
+      <td
+        className="px-2 py-2"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          aria-label={`Reorder ${item.name}`}
+          className="inline-flex items-center justify-center w-5 h-5 select-none"
+          style={{ color: "var(--color-ink-dim)", cursor: "grab", touchAction: "none" }}
+          {...attributes}
+          {...listeners}
+        >
+          ⠿
+        </button>
+      </td>
+      <td className="px-3 py-2">
+        {item.imageUrl ? (
+          <Image
+            src={item.imageUrl}
+            alt={item.name}
+            width={40}
+            height={40}
+            className="rounded-sm object-cover"
+          />
+        ) : (
+          <GarmentVector
+            itemId={item.id}
+            category={item.category as ItemCategory}
+            accent={tenant.accent}
+            size={40}
+          />
+        )}
+      </td>
+      <td className="px-3 py-2 font-medium">{item.name}</td>
+      <td className="px-3 py-2">{item.category}</td>
+      <td className="px-3 py-2 tnum">{item.variants.length}</td>
+      <td className="px-3 py-2">
+        {item.active ? (
+          <span className="text-emerald-700">●</span>
+        ) : (
+          <span style={{ color: "var(--color-ink-dim)" }}>○</span>
+        )}
+      </td>
+      <td
+        className="px-3 py-2 text-right"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          className="text-[12px] underline"
+          onClick={() => onDelete(item.id, item.name)}
+          style={{ color: tenant.accent }}
+        >
+          Delete
+        </button>
+      </td>
+    </tr>
   );
 }

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -96,7 +96,7 @@ export function CatalogTable({
                     className="inline-flex items-center justify-center w-5 h-5 select-none"
                     style={{ color: "var(--color-ink-dim)", cursor: "grab" }}
                   >
-                    ::
+                    ⠿
                   </span>
                 </td>
                 <td className="px-3 py-2">

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -70,6 +70,7 @@ export function CatalogTable({
         <table className="w-full text-[13px]">
           <thead className="bg-white sticky top-0">
             <tr className="text-left" style={{ color: "var(--color-ink-dim)" }}>
+              <th className="px-2 py-2 w-[28px]" aria-label="Reorder"></th>
               <th className="px-3 py-2 w-[60px]">Image</th>
               <th className="px-3 py-2">Name</th>
               <th className="px-3 py-2 w-[110px]">Category</th>
@@ -86,6 +87,18 @@ export function CatalogTable({
                 style={{ borderColor: "var(--color-rule)" }}
                 onClick={() => setDrawer({ open: true, mode: "edit", item: it })}
               >
+                <td
+                  className="px-2 py-2"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <span
+                    aria-label={`Reorder ${it.name}`}
+                    className="inline-flex items-center justify-center w-5 h-5 select-none"
+                    style={{ color: "var(--color-ink-dim)", cursor: "grab" }}
+                  >
+                    ::
+                  </span>
+                </td>
                 <td className="px-3 py-2">
                   {it.imageUrl ? (
                     <Image
@@ -126,8 +139,8 @@ export function CatalogTable({
             ))}
             {items.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-3 py-6 text-center" style={{ color: "var(--color-ink-dim)" }}>
-                  No items yet. Click “Add item” to create one.
+                <td colSpan={7} className="px-3 py-6 text-center" style={{ color: "var(--color-ink-dim)" }}>
+                  No items yet. Click "Add item" to create one.
                 </td>
               </tr>
             )}

--- a/apps/web/src/app/api/catalog/reorder/route.ts
+++ b/apps/web/src/app/api/catalog/reorder/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
 
     if (incomingIds.size !== orderedIds.length) {
       return NextResponse.json(
-        { error: "duplicate_ids" },
+        { error: "duplicate_ids", message: "Duplicate item IDs in request." },
         { status: 400 },
       );
     }

--- a/apps/web/src/app/api/catalog/reorder/route.ts
+++ b/apps/web/src/app/api/catalog/reorder/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getCatalogByTenant,
+  reorderCatalogItems,
+} from "@/db/queries";
+import {
+  ensureTenantAccess,
+  isPlatformAdminEmail,
+  requireSessionUser,
+} from "@/lib/auth/authorization";
+import { requireTenantApproved } from "@/lib/auth/require-tenant-approved";
+import { catalogReorderSchema } from "@/lib/schemas/catalog";
+import { applyRateLimit } from "@/lib/rate-limit";
+import { logAuditEvent } from "@/lib/audit/log";
+
+// POST /api/catalog/reorder
+// Body: { tenantSlug: string, orderedIds: string[] }
+// Atomically renumber a tenant's catalog items to dense 0..N-1 order.
+export async function POST(req: NextRequest) {
+  try {
+    const preAuthRl = applyRateLimit(req, "catalog:reorder:anon", {
+      limit: 30,
+      windowMs: 60_000,
+    });
+    if (preAuthRl) return preAuthRl;
+
+    const authResult = await requireSessionUser();
+    if ("response" in authResult) return authResult.response;
+
+    const userRl = applyRateLimit(
+      req,
+      `catalog:reorder:${authResult.user.id}`,
+      { limit: 20, windowMs: 60_000 },
+    );
+    if (userRl) return userRl;
+
+    const body = await req.json();
+    const parsed = catalogReorderSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validation_failed", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+    const { tenantSlug, orderedIds } = parsed.data;
+
+    // requireTenantApproved resolves the tenant by slug (the slug doubles as
+    // the PK in this codebase) AND enforces approval gating in one round-trip.
+    const approval = await requireTenantApproved(tenantSlug);
+    if ("response" in approval) return approval.response;
+    const { tenant } = approval;
+
+    const accessDenied = ensureTenantAccess(authResult.user, tenant.shopEmail);
+    if (accessDenied) return accessDenied;
+
+    // Exhaustive-set check: orderedIds must equal the full set of catalog item
+    // IDs for this tenant. This catches concurrent add/delete by another
+    // operator and any client/server drift. Use getCatalogByTenant (not the
+    // active-only variant) so inactive items participate in ordering.
+    const currentItems = await getCatalogByTenant(tenant.id);
+    const currentIds = new Set(currentItems.map((it) => it.id));
+    const incomingIds = new Set(orderedIds);
+
+    if (incomingIds.size !== orderedIds.length) {
+      return NextResponse.json(
+        { error: "duplicate_ids" },
+        { status: 400 },
+      );
+    }
+    if (orderedIds.length !== currentIds.size) {
+      return NextResponse.json(
+        { error: "stale_set", message: "Catalog changed — please refresh." },
+        { status: 400 },
+      );
+    }
+    for (const id of incomingIds) {
+      if (!currentIds.has(id)) {
+        return NextResponse.json(
+          { error: "stale_set", message: "Catalog changed — please refresh." },
+          { status: 400 },
+        );
+      }
+    }
+
+    await reorderCatalogItems(tenant.id, orderedIds);
+
+    await logAuditEvent({
+      tenantId: tenant.id,
+      actorEmail: authResult.user.email,
+      actorRole: isPlatformAdminEmail(authResult.user.email)
+        ? "platform_admin"
+        : "operator",
+      action: "catalog.reordered",
+      targetType: "tenant",
+      targetId: tenant.id,
+      payload: { itemCount: orderedIds.length },
+    });
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    console.error("POST /api/catalog/reorder failed:", err);
+    return NextResponse.json(
+      { error: "internal_error" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -684,7 +684,7 @@ export async function reorderCatalogItems(
   const statements = orderedIds.map((id, index) =>
     db
       .update(catalogItems)
-      .set({ sortOrder: index })
+      .set({ sortOrder: index, updatedAt: new Date() })
       .where(and(eq(catalogItems.id, id), eq(catalogItems.tenantId, tenantId))),
   );
   // neon-http: db.batch accepts a tuple of queries; we cast for the variadic shape.

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -670,6 +670,9 @@ export async function updateCatalogItem(
 /**
  * Bulk-renumber a tenant's catalog items to dense 0..N-1 order.
  * Uses db.batch (neon-http) — not db.transaction (unsupported on neon-http).
+ * db.batch is a pipeline, not a transaction: individual statements can succeed
+ * independently. A partial failure leaves sort_order in a mixed state;
+ * re-dragging recovers. Revisit if neon pooled mode (transactions) is adopted.
  * Caller must have already validated that `orderedIds` is the exhaustive set
  * of catalog item IDs for this tenant.
  */

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -667,6 +667,27 @@ export async function updateCatalogItem(
   await db.batch(stmts);
 }
 
+/**
+ * Bulk-renumber a tenant's catalog items to dense 0..N-1 order.
+ * Uses db.batch (neon-http) — not db.transaction (unsupported on neon-http).
+ * Caller must have already validated that `orderedIds` is the exhaustive set
+ * of catalog item IDs for this tenant.
+ */
+export async function reorderCatalogItems(
+  tenantId: string,
+  orderedIds: string[],
+): Promise<void> {
+  if (orderedIds.length === 0) return;
+  const statements = orderedIds.map((id, index) =>
+    db
+      .update(catalogItems)
+      .set({ sortOrder: index })
+      .where(and(eq(catalogItems.id, id), eq(catalogItems.tenantId, tenantId))),
+  );
+  // neon-http: db.batch accepts a tuple of queries; we cast for the variadic shape.
+  await db.batch(statements as unknown as Parameters<typeof db.batch>[0]);
+}
+
 export async function deleteCatalogItem(itemId: string) {
   return db
     .delete(catalogItems)

--- a/apps/web/src/lib/schemas/catalog.ts
+++ b/apps/web/src/lib/schemas/catalog.ts
@@ -56,7 +56,7 @@ export type CatalogVariantInput = z.infer<typeof catalogVariantInputSchema>;
 
 export const catalogReorderSchema = z.object({
   tenantSlug: z.string().min(1).max(64),
-  orderedIds: z.array(z.string().uuid()).min(1).max(500, "Catalog too large to reorder in one request — contact support"),
+  orderedIds: z.array(z.string().min(1)).min(1).max(500, "Catalog too large to reorder in one request — contact support"),
 });
 
 export type CatalogReorderInput = z.infer<typeof catalogReorderSchema>;

--- a/apps/web/src/lib/schemas/catalog.ts
+++ b/apps/web/src/lib/schemas/catalog.ts
@@ -53,3 +53,10 @@ export const catalogItemPatchSchema = catalogItemInputSchema
 export type CatalogItemInput = z.infer<typeof catalogItemInputSchema>;
 export type CatalogItemPatch = z.infer<typeof catalogItemPatchSchema>;
 export type CatalogVariantInput = z.infer<typeof catalogVariantInputSchema>;
+
+export const catalogReorderSchema = z.object({
+  tenantSlug: z.string().min(1).max(64),
+  orderedIds: z.array(z.string().uuid()).min(1).max(500),
+});
+
+export type CatalogReorderInput = z.infer<typeof catalogReorderSchema>;

--- a/apps/web/src/lib/schemas/catalog.ts
+++ b/apps/web/src/lib/schemas/catalog.ts
@@ -56,7 +56,7 @@ export type CatalogVariantInput = z.infer<typeof catalogVariantInputSchema>;
 
 export const catalogReorderSchema = z.object({
   tenantSlug: z.string().min(1).max(64),
-  orderedIds: z.array(z.string().uuid()).min(1).max(500),
+  orderedIds: z.array(z.string().uuid()).min(1).max(500, "Catalog too large to reorder in one request — contact support"),
 });
 
 export type CatalogReorderInput = z.infer<typeof catalogReorderSchema>;

--- a/docs/completed.md
+++ b/docs/completed.md
@@ -604,6 +604,17 @@ Post-review fixes: `console.error` in `getPopularItems` catch block; `rawSlug.to
 
 Spec: `docs/superpowers/specs/2026-05-13-per-tenant-homepage-design.md`. Plan: `docs/superpowers/plans/2026-05-13-per-tenant-homepage.md`.
 
+### 4.33 Admin catalog drag-to-reorder (§3.12, drag half) ✅
+
+Shipped 2026-05-14.
+
+`@dnd-kit/sortable` wired into `app/admin/[tenant]/catalog/catalog-table.tsx`. Each row gains a leading `⠿` grip column; rest of the row continues to open the edit drawer on click. On drop, the table renumbers items optimistically and POSTs the new `orderedIds[]` to a new bulk endpoint at `app/api/catalog/reorder/route.ts`. Server validates the set is exhaustive for the tenant (catches concurrent add/delete), then runs a single `db.batch` of `UPDATE catalog_items SET sort_order = $i` per item, plus one `logAuditEvent` row with `action: "catalog.reordered"`. On failure (offline, stale set, auth), client snaps back to previous order and surfaces an inline banner; stale-set additionally pulls fresh state via the existing `refresh()` prop. An in-flight guard (`pendingRef`) prevents a second drag racing the first fetch.
+
+Dense renumber `0..N-1` on every drop — sparse spacing rejected as YAGNI at ≤100 SKUs/tenant. Keyboard-accessible via dnd-kit's `KeyboardSensor`. No DB migration (column already existed). Size-guide editor (the other half of §3.12) deferred to a separate spec.
+
+Spec: `docs/superpowers/specs/2026-05-13-catalog-drag-reorder-design.md`.
+Plan: `docs/superpowers/plans/2026-05-14-catalog-drag-reorder.md`.
+
 ---
 
 ## Outstanding items (tracked in `docs/remaining_work.md`)

--- a/docs/remaining_work.md
+++ b/docs/remaining_work.md
@@ -173,7 +173,7 @@ Sourced from `my_doc/NSBH/gap-analysis.md` §5 — items not bug-class (those li
 
 - [x] **Shop hours on pickup option pre-purchase (gap-analysis §5.9).** ✅ shipped. Read `tenant.shopHours` in `app/[tenant]/checkout/page.tsx`, thread to `CheckoutScreen`. In `checkout-screen.tsx:415` replace the literal `"Free · Ready in 1–2 school days"` copy on the pickup `DeliveryOption` card with `tenant.shopHours` when set, fall back to existing copy otherwise. ~1h.
 
-- [ ] **Admin drag-to-reorder + size-guide editor (gap-analysis §5.12).** `catalog_items.sortOrder` exists (`db/schema.ts:107`) and `getActiveCatalog` already sorts by it (`db/queries.ts:947`), but no DnD UI on `app/admin/[tenant]/catalog/catalog-table.tsx`. Add `@dnd-kit/sortable` + drag handle column; persist via PATCH `/api/catalog/[itemId]`. Same drawer should gain a size-guide editor: `catalog_items.sizeGuide jsonb` is rendered on PDP but only seeded via `lib/data.ts`. Column headers as comma-list, rows as a tabular grid with add/remove. ~1.5d for both. (Note: also covered loosely by §4.7 "Catalog sortable / drag-to-reorder" — supersede that line when done.)
+- [ ] **Admin size-guide editor (gap-analysis §5.12 — drag-to-reorder portion ✅ shipped).** Drag-to-reorder shipped via `@dnd-kit/sortable` on `catalog-table.tsx` + new `POST /api/catalog/reorder` bulk endpoint; see `completed.md` §4.33. Size-guide editor still outstanding: `catalog_items.sizeGuide jsonb` is rendered on PDP but only seeded via `lib/data.ts`. Same drawer should gain a tabular editor — column headers as comma-list, rows as a grid with add/remove. ~½d.
 
 - [x] **PDP photo support — read `item.imageUrl` + UploadThing in admin drawer (gap-analysis §5.13).** ✅ shipped (PR #31, squash `10a50c0`). See `completed.md` §4.30.
 

--- a/docs/superpowers/plans/2026-05-14-catalog-drag-reorder.md
+++ b/docs/superpowers/plans/2026-05-14-catalog-drag-reorder.md
@@ -1,0 +1,778 @@
+# Catalog Drag-to-Reorder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add drag-to-reorder UI to the admin catalog table and persist the new `sortOrder` via a new bulk endpoint.
+
+**Architecture:** `@dnd-kit/sortable` wraps `<tbody>` in `catalog-table.tsx`; each row has a grip cell that initiates drag. On drop, client optimistically reorders, fires `POST /api/catalog/reorder` with the full `orderedIds[]`, and snaps back on error. Server validates the set is exhaustive for the tenant, dense-renumbers `0..N-1` via `db.batch`, and writes one `logAuditEvent` row.
+
+**Tech Stack:** Next.js 16 App Router (RSC + client islands), Drizzle ORM + neon-http (no transactions, `db.batch` only), `@dnd-kit/core` + `@dnd-kit/sortable`, Zod for body validation, Tailwind v4 tokens.
+
+**Spec:** `docs/superpowers/specs/2026-05-13-catalog-drag-reorder-design.md`
+
+**Testing note:** This repo has no test runner. The correctness gate per CLAUDE.md is `pnpm check-types:web`. Manual verification follows §10 of the spec. Plan reflects this — no `pytest`/`vitest`-style steps, but every task ends with `pnpm check-types:web` + a manual check.
+
+**File map:**
+
+| File | Action | Responsibility |
+|---|---|---|
+| `apps/web/package.json` | Modify | Add `@dnd-kit/core` + `@dnd-kit/sortable` deps |
+| `apps/web/src/db/queries.ts` | Modify | New `reorderCatalogItems(tenantId, orderedIds)` helper using `db.batch` |
+| `apps/web/src/lib/schemas/catalog.ts` | Modify | New `catalogReorderSchema` Zod schema |
+| `apps/web/src/app/api/catalog/reorder/route.ts` | Create | `POST` handler — auth, set-equality validation, batched UPDATE, audit log |
+| `apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx` | Modify | Wrap in `DndContext`/`SortableContext`; extract `SortableRow`; add grip column; optimistic POST + rollback |
+
+---
+
+## Task 1: Add `@dnd-kit` dependencies
+
+**Files:**
+- Modify: `apps/web/package.json` (dependencies block)
+
+- [ ] **Step 1: Add the two packages**
+
+Run from repo root:
+```bash
+pnpm --filter web add @dnd-kit/core @dnd-kit/sortable
+```
+
+Expected: `package.json` gets two new `dependencies` entries; `pnpm-lock.yaml` updates.
+
+- [ ] **Step 2: Verify install succeeded**
+
+Run:
+```bash
+pnpm --filter web ls @dnd-kit/core @dnd-kit/sortable
+```
+
+Expected: both resolve to a concrete version (≥ 6.x for core, ≥ 8.x for sortable).
+
+- [ ] **Step 3: Type-check baseline**
+
+Run:
+```bash
+pnpm check-types:web
+```
+
+Expected: passes (no source changes yet, just deps).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/package.json pnpm-lock.yaml
+git commit -m "feat(catalog): add @dnd-kit deps for drag-to-reorder"
+```
+
+---
+
+## Task 2: `reorderCatalogItems` query helper
+
+**Files:**
+- Modify: `apps/web/src/db/queries.ts` (append a new export near the existing catalog mutations — `updateCatalogItem` lives around line 580; place the new helper right after it for proximity)
+
+- [ ] **Step 1: Read context for placement**
+
+Open `apps/web/src/db/queries.ts` and locate `updateCatalogItem` (search for `export async function updateCatalogItem`). The new helper goes immediately after its closing brace.
+
+Confirm at the top of the file that `db`, `catalogItems`, and `eq`/`and` are imported (they are — `updateCatalogItem` already uses them). Confirm `sql` from `drizzle-orm` is imported (it should be; if not, add it).
+
+- [ ] **Step 2: Add the helper**
+
+Append this function right after `updateCatalogItem`:
+
+```ts
+/**
+ * Bulk-renumber a tenant's catalog items to dense 0..N-1 order.
+ * Uses db.batch (neon-http) — not db.transaction (unsupported on neon-http).
+ * Caller must have already validated that `orderedIds` is the exhaustive set
+ * of catalog item IDs for this tenant.
+ */
+export async function reorderCatalogItems(
+  tenantId: string,
+  orderedIds: string[],
+): Promise<void> {
+  if (orderedIds.length === 0) return;
+  const statements = orderedIds.map((id, index) =>
+    db
+      .update(catalogItems)
+      .set({ sortOrder: index })
+      .where(and(eq(catalogItems.id, id), eq(catalogItems.tenantId, tenantId))),
+  );
+  // neon-http: db.batch accepts a tuple of queries; we cast for the variadic shape.
+  await db.batch(statements as unknown as Parameters<typeof db.batch>[0]);
+}
+```
+
+The cast is necessary because Drizzle's `db.batch` types require a non-empty tuple, but the array length is dynamic here. This matches how other dynamic batches are typed elsewhere in this file.
+
+- [ ] **Step 3: Type-check**
+
+Run:
+```bash
+pnpm check-types:web
+```
+
+Expected: passes. If it fails on the `db.batch` cast, grep for an existing dynamic-batch site (`grep -n "db.batch" apps/web/src/db/queries.ts`) and copy its exact cast shape.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/db/queries.ts
+git commit -m "feat(catalog): reorderCatalogItems batched query helper"
+```
+
+---
+
+## Task 3: Zod schema for the reorder request body
+
+**Files:**
+- Modify: `apps/web/src/lib/schemas/catalog.ts` (append a new export)
+
+- [ ] **Step 1: Add the schema**
+
+Open `apps/web/src/lib/schemas/catalog.ts`. Confirm `z` is imported at the top (it is — the existing `catalogItemPatchSchema` uses it). Append:
+
+```ts
+export const catalogReorderSchema = z.object({
+  tenantSlug: z.string().min(1).max(64),
+  orderedIds: z.array(z.string().uuid()).min(1).max(500),
+});
+
+export type CatalogReorderInput = z.infer<typeof catalogReorderSchema>;
+```
+
+The `max(500)` cap is a soft DoS guard — catalog sizes are <100 in practice; 500 leaves headroom without inviting abuse.
+
+- [ ] **Step 2: Type-check**
+
+Run:
+```bash
+pnpm check-types:web
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/schemas/catalog.ts
+git commit -m "feat(catalog): catalogReorderSchema for bulk reorder body"
+```
+
+---
+
+## Task 4: `POST /api/catalog/reorder` route
+
+**Files:**
+- Create: `apps/web/src/app/api/catalog/reorder/route.ts`
+
+- [ ] **Step 1: Make the directory**
+
+Run:
+```bash
+mkdir -p apps/web/src/app/api/catalog/reorder
+```
+
+- [ ] **Step 2: Write the route handler**
+
+Create `apps/web/src/app/api/catalog/reorder/route.ts` with this exact content:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getTenant,
+  getCatalogItems,
+  reorderCatalogItems,
+} from "@/db/queries";
+import {
+  ensureTenantAccess,
+  requireSessionUser,
+} from "@/lib/auth/authorization";
+import { requireTenantApproved } from "@/lib/auth/require-tenant-approved";
+import { catalogReorderSchema } from "@/lib/schemas/catalog";
+import { applyRateLimit } from "@/lib/rate-limit";
+import { logAuditEvent } from "@/lib/audit/log";
+
+// POST /api/catalog/reorder
+// Body: { tenantSlug: string, orderedIds: string[] }
+// Atomically renumber a tenant's catalog items to dense 0..N-1 order.
+export async function POST(req: NextRequest) {
+  try {
+    const preAuthRl = applyRateLimit(req, "catalog:reorder:anon", {
+      limit: 30,
+      windowMs: 60_000,
+    });
+    if (preAuthRl) return preAuthRl;
+
+    const authResult = await requireSessionUser();
+    if ("response" in authResult) return authResult.response;
+
+    const userRl = applyRateLimit(
+      req,
+      `catalog:reorder:${authResult.user.id}`,
+      { limit: 20, windowMs: 60_000 },
+    );
+    if (userRl) return userRl;
+
+    const body = await req.json();
+    const parsed = catalogReorderSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "validation_failed", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+    const { tenantSlug, orderedIds } = parsed.data;
+
+    const tenant = await getTenant(tenantSlug);
+    if (!tenant) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
+
+    const approval = await requireTenantApproved(tenant.id);
+    if ("response" in approval) return approval.response;
+
+    const accessDenied = ensureTenantAccess(authResult.user, tenant.shopEmail);
+    if (accessDenied) return accessDenied;
+
+    // Exhaustive-set check: orderedIds must equal the full set of catalog item
+    // IDs for this tenant. This catches concurrent add/delete by another
+    // operator and any client/server drift.
+    const currentItems = await getCatalogItems(tenant.id);
+    const currentIds = new Set(currentItems.map((it) => it.id));
+    const incomingIds = new Set(orderedIds);
+
+    if (orderedIds.length !== currentIds.size) {
+      return NextResponse.json(
+        { error: "stale_set", message: "Catalog changed — please refresh." },
+        { status: 400 },
+      );
+    }
+    if (incomingIds.size !== orderedIds.length) {
+      return NextResponse.json(
+        { error: "duplicate_ids" },
+        { status: 400 },
+      );
+    }
+    for (const id of incomingIds) {
+      if (!currentIds.has(id)) {
+        return NextResponse.json(
+          { error: "stale_set", message: "Catalog changed — please refresh." },
+          { status: 400 },
+        );
+      }
+    }
+
+    await reorderCatalogItems(tenant.id, orderedIds);
+
+    await logAuditEvent({
+      tenantId: tenant.id,
+      actorRole: "operator",
+      actorEmail: authResult.user.email ?? null,
+      action: "catalog.reordered",
+      targetType: "tenant",
+      targetId: tenant.id,
+      metadata: { itemCount: orderedIds.length },
+    });
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    console.error("POST /api/catalog/reorder failed:", err);
+    return NextResponse.json(
+      { error: "internal_error" },
+      { status: 500 },
+    );
+  }
+}
+```
+
+If `getCatalogItems` doesn't exist (it should — used elsewhere), confirm the actual name by running `grep -n "export async function getCatalog" apps/web/src/db/queries.ts` and substitute the right one. The function we want returns all catalog items for a tenant (active **and** inactive — match what the admin table fetches).
+
+If `logAuditEvent`'s parameter shape doesn't match (e.g. `metadata` is `actorMetadata`), open `apps/web/src/lib/audit/log.ts` and adjust the call to its exact signature. Match the call shape used at `apps/web/src/app/api/catalog/[itemId]/route.ts:133`.
+
+- [ ] **Step 3: Type-check**
+
+Run:
+```bash
+pnpm check-types:web
+```
+
+Expected: passes. Likely failures + fixes:
+- `getCatalogItems` not found → use whatever the admin page calls (search `apps/web/src/app/admin/[tenant]/catalog/page.tsx`).
+- `logAuditEvent` field mismatch → mirror the call in `[itemId]/route.ts:133`.
+- `actorRole` must be a specific union → mirror the same call.
+
+Fix and re-run until green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/app/api/catalog/reorder/route.ts
+git commit -m "feat(catalog): POST /api/catalog/reorder bulk endpoint"
+```
+
+---
+
+## Task 5: Extract `SortableRow` and add grip column to the catalog table
+
+**Files:**
+- Modify: `apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx`
+
+This task focuses on the **DOM/structure** changes (grip column + row extraction). The actual drag wiring lands in Task 6.
+
+- [ ] **Step 1: Bump empty-state colSpan and add the grip header**
+
+In `catalog-table.tsx`, find the `<thead>` (currently at lines 71-80) and prepend a new `<th>`:
+
+```tsx
+<thead className="bg-white sticky top-0">
+  <tr className="text-left" style={{ color: "var(--color-ink-dim)" }}>
+    <th className="px-2 py-2 w-[28px]" aria-label="Reorder"></th>
+    <th className="px-3 py-2 w-[60px]">Image</th>
+    <th className="px-3 py-2">Name</th>
+    <th className="px-3 py-2 w-[110px]">Category</th>
+    <th className="px-3 py-2 w-[100px]">Variants</th>
+    <th className="px-3 py-2 w-[80px]">Active</th>
+    <th className="px-3 py-2 w-[60px]"></th>
+  </tr>
+</thead>
+```
+
+Find the empty-state `<tr>` (currently `colSpan={6}` around line 129) and change to `colSpan={7}`.
+
+- [ ] **Step 2: Add the grip `<td>` to every data row, no drag wiring yet**
+
+Inside the `items.map((it) => ...)` block, add a new leading `<td>` before the existing `<td>` that holds the image. Stop click propagation so the cell never opens the drawer:
+
+```tsx
+<td
+  className="px-2 py-2"
+  onClick={(e) => e.stopPropagation()}
+>
+  <span
+    aria-label={`Reorder ${it.name}`}
+    className="inline-flex items-center justify-center w-5 h-5 select-none"
+    style={{ color: "var(--color-ink-dim)", cursor: "grab" }}
+  >
+    ⠿
+  </span>
+</td>
+```
+
+The `cursor: "grab"` is cosmetic for now; Task 6 replaces this `<span>` with the `useSortable`-driven handle.
+
+- [ ] **Step 3: Type-check + manual smoke**
+
+Run:
+```bash
+pnpm check-types:web
+```
+
+Expected: passes.
+
+Then run `pnpm dev:web` and visit `/admin/nsbh/catalog` (after logging in as operator). Confirm:
+- Header row shows 7 columns.
+- Each row shows a `⠿` grip glyph on the left.
+- Clicking the grip cell does **not** open the drawer.
+- Clicking elsewhere on the row still opens the drawer.
+
+Kill `pnpm dev:web` when done.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+git commit -m "feat(catalog): add static grip column (no drag wiring yet)"
+```
+
+---
+
+## Task 6: Wire `@dnd-kit` for actual drag-to-reorder
+
+**Files:**
+- Modify: `apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx`
+
+- [ ] **Step 1: Add imports**
+
+At the top of `catalog-table.tsx`, alongside existing imports:
+
+```tsx
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+```
+
+- [ ] **Step 2: Add a `SortableRow` component below the `CatalogTable` export**
+
+At the bottom of the file (after the closing `}` of `CatalogTable`), add:
+
+```tsx
+function SortableRow({
+  item,
+  tenant,
+  onOpenDrawer,
+  onDelete,
+}: {
+  item: CatalogItemWithVariants;
+  tenant: Tenant;
+  onOpenDrawer: (it: CatalogItemWithVariants) => void;
+  onDelete: (id: string, name: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+    boxShadow: isDragging ? "0 4px 12px rgba(0,0,0,0.12)" : undefined,
+    borderColor: "var(--color-rule)",
+  };
+
+  return (
+    <tr
+      ref={setNodeRef}
+      style={style}
+      className="border-t cursor-pointer hover:bg-[var(--color-parchment)]"
+      onClick={() => onOpenDrawer(item)}
+    >
+      <td
+        className="px-2 py-2"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          aria-label={`Reorder ${item.name}`}
+          className="inline-flex items-center justify-center w-5 h-5 select-none"
+          style={{ color: "var(--color-ink-dim)", cursor: "grab", touchAction: "none" }}
+          {...attributes}
+          {...listeners}
+        >
+          ⠿
+        </button>
+      </td>
+      <td className="px-3 py-2">
+        {item.imageUrl ? (
+          <Image
+            src={item.imageUrl}
+            alt={item.name}
+            width={40}
+            height={40}
+            className="rounded-sm object-cover"
+          />
+        ) : (
+          <GarmentVector
+            itemId={item.id}
+            category={item.category as ItemCategory}
+            accent={tenant.accent}
+            size={40}
+          />
+        )}
+      </td>
+      <td className="px-3 py-2 font-medium">{item.name}</td>
+      <td className="px-3 py-2">{item.category}</td>
+      <td className="px-3 py-2 tnum">{item.variants.length}</td>
+      <td className="px-3 py-2">
+        {item.active ? (
+          <span className="text-emerald-700">●</span>
+        ) : (
+          <span style={{ color: "var(--color-ink-dim)" }}>○</span>
+        )}
+      </td>
+      <td
+        className="px-3 py-2 text-right"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          className="text-[12px] underline"
+          onClick={() => onDelete(item.id, item.name)}
+          style={{ color: tenant.accent }}
+        >
+          Delete
+        </button>
+      </td>
+    </tr>
+  );
+}
+```
+
+This component mirrors the existing row markup exactly — the only behavioural additions are the `useSortable` hook, the ref/transform/listeners on the grip button, and the click handlers being parameterised via props.
+
+- [ ] **Step 3: Replace the inline `<tr>` map with `SortableRow` and wrap in DnD providers**
+
+Inside `CatalogTable`, replace the entire `<tbody>` block (which currently inlines the `items.map` `<tr>` directly) with:
+
+```tsx
+<tbody>
+  <SortableContext
+    items={items.map((it) => it.id)}
+    strategy={verticalListSortingStrategy}
+  >
+    {items.map((it) => (
+      <SortableRow
+        key={it.id}
+        item={it}
+        tenant={tenant}
+        onOpenDrawer={(item) => setDrawer({ open: true, mode: "edit", item })}
+        onDelete={handleDelete}
+      />
+    ))}
+  </SortableContext>
+  {items.length === 0 && (
+    <tr>
+      <td
+        colSpan={7}
+        className="px-3 py-6 text-center"
+        style={{ color: "var(--color-ink-dim)" }}
+      >
+        No items yet. Click "Add item" to create one.
+      </td>
+    </tr>
+  )}
+</tbody>
+```
+
+Then wrap the entire `<div className="flex-1 overflow-auto rounded-md border" ...>` block in a `<DndContext>`. Define sensors and the `onDragEnd` handler just before the `return`:
+
+```tsx
+const sensors = useSensors(
+  useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+  useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+);
+
+const handleDragEnd = async (event: DragEndEvent) => {
+  const { active, over } = event;
+  if (!over || active.id === over.id) return;
+
+  const oldIndex = items.findIndex((it) => it.id === active.id);
+  const newIndex = items.findIndex((it) => it.id === over.id);
+  if (oldIndex < 0 || newIndex < 0) return;
+
+  const previous = items;
+  const reordered = arrayMove(items, oldIndex, newIndex).map((it, i) => ({
+    ...it,
+    sortOrder: i,
+  }));
+  setItems(reordered);
+  setTableError("");
+
+  try {
+    const res = await fetch("/api/catalog/reorder", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tenantSlug: tenant.id,
+        orderedIds: reordered.map((it) => it.id),
+      }),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => null);
+      const isStale = data?.error === "stale_set";
+      throw new Error(
+        isStale
+          ? "Catalog changed — please refresh."
+          : data?.message ?? data?.error ?? "Reorder failed.",
+      );
+    }
+  } catch (err) {
+    console.error("Reorder failed:", err);
+    setItems(previous);
+    setTableError(
+      err instanceof Error ? `Reorder failed: ${err.message}` : "Reorder failed.",
+    );
+    // Pull authoritative state from the server in case it changed under us.
+    await refresh();
+  }
+};
+```
+
+Note: `tenant.id` on the `Tenant` type from `lib/data.ts` IS the slug (`"nsbh"` / `"rgsh"`) — `getTenant(slug)` in `db/queries.ts` accepts this same value. Confirm with a quick `grep -n "id:" apps/web/src/lib/data.ts | head -5` if uncertain.
+
+Wrap the table div:
+
+```tsx
+return (
+  <div className="flex-1 flex flex-col overflow-hidden p-6">
+    {tableError && (
+      <div className="mb-3 text-[12.5px] px-3 py-2 rounded" style={{ background: "#FEF2F2", color: "#B91C1C" }}>
+        {tableError}
+      </div>
+    )}
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="flex-1 overflow-auto rounded-md border" style={{ borderColor: "var(--color-rule)" }}>
+        <table className="w-full text-[13px]">
+          {/* thead + tbody from previous task / step */}
+        </table>
+      </div>
+    </DndContext>
+    {drawer.open && (
+      <ItemDrawer
+        tenant={tenant}
+        open={drawer.open}
+        mode={{ kind: "edit", itemId: drawer.item.id }}
+        initial={initialFromItem(drawer.item)}
+        onClose={() => setDrawer({ open: false })}
+        onSaved={refresh}
+      />
+    )}
+  </div>
+);
+```
+
+- [ ] **Step 4: Type-check**
+
+Run:
+```bash
+pnpm check-types:web
+```
+
+Expected: passes. Common failures:
+- `React.CSSProperties` not imported → add `import { ... type CSSProperties } from "react"` or use inline `as React.CSSProperties` (already used).
+- `DragEndEvent` import path wrong → it lives in `@dnd-kit/core` (already shown above).
+
+- [ ] **Step 5: Manual verification — happy path**
+
+Run `pnpm dev:web`, visit `/admin/nsbh/catalog` as operator. Then:
+
+1. Drag a row down 3 positions by holding the `⠿` grip. Drop. The row stays in the new position.
+2. Open DevTools → Network. Confirm a single `POST /api/catalog/reorder` returned `200 { ok: true }`.
+3. Hard refresh the page. Order persists.
+4. Visit `/nsbh` (parent shop) in another tab. Catalog renders in the new order.
+
+- [ ] **Step 6: Manual verification — error path**
+
+Still on `/admin/nsbh/catalog`:
+
+1. DevTools → Network → toggle **Offline** *before* dropping.
+2. Drag a row, release. The row snaps back. Inline red error banner appears: "Reorder failed: …".
+3. Toggle back online; drag again; success.
+
+- [ ] **Step 7: Manual verification — no-op drop**
+
+Pick up a row and drop it in the same slot. Confirm no POST fires (Network tab stays empty for `/api/catalog/reorder`).
+
+- [ ] **Step 8: Manual verification — keyboard**
+
+Tab to a grip handle. Press Space. Arrow Down twice. Press Space. Order changes; POST fires; success.
+
+- [ ] **Step 9: Manual verification — stale-set (concurrent edit)**
+
+In a second browser session (incognito, also signed in as the same operator), delete a catalog item via the existing Delete button. In the first window — without refreshing — drag a row. The POST returns 400 `stale_set`; banner shows "Reorder failed: Catalog changed — please refresh."; the table is repulled by the `await refresh()` and now reflects the deletion.
+
+- [ ] **Step 10: Kill dev server, commit**
+
+```bash
+git add apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+git commit -m "feat(catalog): drag-to-reorder via @dnd-kit + optimistic POST"
+```
+
+---
+
+## Task 7: Update `remaining_work.md` and `completed.md`
+
+**Files:**
+- Modify: `docs/remaining_work.md`
+- Modify: `docs/completed.md`
+
+- [ ] **Step 1: Mark the drag-to-reorder half of §3.12 done**
+
+In `docs/remaining_work.md` §3.12, the entry currently reads:
+
+```
+- [ ] **Admin drag-to-reorder + size-guide editor (gap-analysis §5.12).** ...
+```
+
+Replace with:
+
+```
+- [ ] **Admin size-guide editor (gap-analysis §5.12 — drag-to-reorder portion ✅ shipped).** Drag-to-reorder shipped via `@dnd-kit/sortable` on `catalog-table.tsx` + new `POST /api/catalog/reorder` bulk endpoint; see `completed.md` §4.33. Size-guide editor still outstanding: `catalog_items.sizeGuide jsonb` is rendered on PDP but only seeded via `lib/data.ts`. Same drawer should gain a tabular editor — column headers as comma-list, rows as a grid with add/remove. ~½d.
+```
+
+Section-number §4.33 is provisional — pick the next free number under §4 in `completed.md`.
+
+- [ ] **Step 2: Add the §4.33 entry to `completed.md`**
+
+Find the last §4.x entry in `docs/completed.md` (currently §4.32 per the recent commit log). Append:
+
+```markdown
+### §4.33 — Admin catalog drag-to-reorder
+
+Shipped 2026-05-14.
+
+`@dnd-kit/sortable` wired into `app/admin/[tenant]/catalog/catalog-table.tsx`. Each row gains a leading `⠿` grip column; rest of the row continues to open the edit drawer on click. On drop, the table renumbers items optimistically and POSTs the new `orderedIds[]` to a new bulk endpoint at `app/api/catalog/reorder/route.ts`. Server validates the set is exhaustive for the tenant (catches concurrent add/delete), then runs a single `db.batch` of `UPDATE catalog_items SET sort_order = $i` per item, plus one `logAuditEvent` row with `action: "catalog.reordered"`. On failure (offline, stale set, auth), client snaps back to previous order and surfaces an inline banner; stale-set additionally pulls fresh state via the existing `refresh()` prop.
+
+Dense renumber `0..N-1` on every drop — sparse spacing rejected as YAGNI at ≤100 SKUs/tenant. Keyboard-accessible via dnd-kit's `KeyboardSensor`. No DB migration (column already existed). Size-guide editor (the other half of remaining_work.md §3.12) deferred to a separate spec.
+
+Spec: `docs/superpowers/specs/2026-05-13-catalog-drag-reorder-design.md`.
+Plan: `docs/superpowers/plans/2026-05-14-catalog-drag-reorder.md`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/remaining_work.md docs/completed.md
+git commit -m "docs: mark §3.12 drag-to-reorder half complete; add §4.33"
+```
+
+---
+
+## Self-Review
+
+Ran against the spec:
+
+**Spec coverage:**
+- §2 Goal → Tasks 5+6 (UI), Task 4 (server)
+- §4.1/4.2/4.3 UX → Task 5 (column + colSpan), Task 6 (drag, snap-back, banner, no-save-button, single ordered list)
+- §5.1 endpoint contract → Task 4 (body shape, auth, set-equality, db.batch, audit, response codes)
+- §5.2 query helper → Task 2
+- §6.1 deps → Task 1
+- §6.2 client wiring → Task 6 (DndContext, SortableContext, onDragEnd, optimistic + rollback, sortOrder mutation in local state)
+- §6.3 concurrent-edit handling → Task 4 server check + Task 6 `await refresh()` on failure
+- §7 file map → matches the File map at the top of this plan
+- §8 edge cases → Task 6 steps 5-9 cover every row in the table
+- §9 a11y → Task 6 Step 2 (`aria-label` on grip), Step 3 (`KeyboardSensor` + `sortableKeyboardCoordinates`), manual check in Step 8
+- §10 testing → distributed across Task 1 Step 3, Task 5 Step 3, Task 6 Steps 5-9
+- §11 out-of-scope → Task 7 Step 1 explicitly carves out the size-guide editor
+
+**Placeholder scan:** no "TBD"/"TODO"/"add appropriate X". All code blocks contain real code. Section number §4.33 in Task 7 flagged as provisional (with instructions to verify the next free number).
+
+**Type consistency:** `reorderCatalogItems(tenantId, orderedIds)` signature matches between Tasks 2 and 4. `tenantSlug` + `orderedIds` body shape matches between Tasks 3, 4, and 6. `tenant.id` is the slug-string consistently.
+
+No issues found.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-14-catalog-drag-reorder.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, fast iteration. Best for this plan because Tasks 2/3/4 are independent file additions that can be reviewed in isolation, and Task 6 is meaty enough to deserve focused attention.
+
+**2. Inline Execution** — execute tasks in this session using `executing-plans`, batch with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-14-catalog-drag-reorder.md
+++ b/docs/superpowers/plans/2026-05-14-catalog-drag-reorder.md
@@ -16,7 +16,7 @@
 
 | File | Action | Responsibility |
 |---|---|---|
-| `apps/web/package.json` | Modify | Add `@dnd-kit/core` + `@dnd-kit/sortable` deps |
+| `apps/web/package.json` | Modify | Add `@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities` deps |
 | `apps/web/src/db/queries.ts` | Modify | New `reorderCatalogItems(tenantId, orderedIds)` helper using `db.batch` |
 | `apps/web/src/lib/schemas/catalog.ts` | Modify | New `catalogReorderSchema` Zod schema |
 | `apps/web/src/app/api/catalog/reorder/route.ts` | Create | `POST` handler — auth, set-equality validation, batched UPDATE, audit log |
@@ -33,19 +33,21 @@
 
 Run from repo root:
 ```bash
-pnpm --filter web add @dnd-kit/core @dnd-kit/sortable
+pnpm --filter web add @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
 ```
 
-Expected: `package.json` gets two new `dependencies` entries; `pnpm-lock.yaml` updates.
+`@dnd-kit/utilities` is a regular (non-peer) dependency of `@dnd-kit/sortable`. Under pnpm's strict resolution, transitive deps are not directly importable from the consumer package, so we add it explicitly — Task 6 imports `CSS` from it.
+
+Expected: `package.json` gets three new `dependencies` entries; `pnpm-lock.yaml` updates.
 
 - [ ] **Step 2: Verify install succeeded**
 
 Run:
 ```bash
-pnpm --filter web ls @dnd-kit/core @dnd-kit/sortable
+pnpm --filter web ls @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
 ```
 
-Expected: both resolve to a concrete version (≥ 6.x for core, ≥ 8.x for sortable).
+Expected: all three resolve to a concrete version (≥ 6.x for core, ≥ 8.x for sortable, ≥ 3.x for utilities).
 
 - [ ] **Step 3: Type-check baseline**
 
@@ -60,7 +62,7 @@ Expected: passes (no source changes yet, just deps).
 
 ```bash
 git add apps/web/package.json pnpm-lock.yaml
-git commit -m "feat(catalog): add @dnd-kit deps for drag-to-reorder"
+git commit -m "feat(catalog): add @dnd-kit/core+sortable+utilities deps"
 ```
 
 ---
@@ -180,12 +182,12 @@ Create `apps/web/src/app/api/catalog/reorder/route.ts` with this exact content:
 ```ts
 import { NextRequest, NextResponse } from "next/server";
 import {
-  getTenant,
-  getCatalogItems,
+  getCatalogByTenant,
   reorderCatalogItems,
 } from "@/db/queries";
 import {
   ensureTenantAccess,
+  isPlatformAdminEmail,
   requireSessionUser,
 } from "@/lib/auth/authorization";
 import { requireTenantApproved } from "@/lib/auth/require-tenant-approved";
@@ -224,33 +226,33 @@ export async function POST(req: NextRequest) {
     }
     const { tenantSlug, orderedIds } = parsed.data;
 
-    const tenant = await getTenant(tenantSlug);
-    if (!tenant) {
-      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
-    }
-
-    const approval = await requireTenantApproved(tenant.id);
+    // requireTenantApproved resolves the tenant by slug (the slug doubles as
+    // the PK in this codebase) AND enforces approval gating in one round-trip.
+    const approval = await requireTenantApproved(tenantSlug);
     if ("response" in approval) return approval.response;
+    const { tenant } = approval;
 
     const accessDenied = ensureTenantAccess(authResult.user, tenant.shopEmail);
     if (accessDenied) return accessDenied;
 
     // Exhaustive-set check: orderedIds must equal the full set of catalog item
     // IDs for this tenant. This catches concurrent add/delete by another
-    // operator and any client/server drift.
-    const currentItems = await getCatalogItems(tenant.id);
+    // operator and any client/server drift. Use getCatalogByTenant (not the
+    // active-only variant) so inactive items participate in ordering — see
+    // spec §4.3.
+    const currentItems = await getCatalogByTenant(tenant.id);
     const currentIds = new Set(currentItems.map((it) => it.id));
     const incomingIds = new Set(orderedIds);
 
-    if (orderedIds.length !== currentIds.size) {
-      return NextResponse.json(
-        { error: "stale_set", message: "Catalog changed — please refresh." },
-        { status: 400 },
-      );
-    }
     if (incomingIds.size !== orderedIds.length) {
       return NextResponse.json(
         { error: "duplicate_ids" },
+        { status: 400 },
+      );
+    }
+    if (orderedIds.length !== currentIds.size) {
+      return NextResponse.json(
+        { error: "stale_set", message: "Catalog changed — please refresh." },
         { status: 400 },
       );
     }
@@ -267,12 +269,14 @@ export async function POST(req: NextRequest) {
 
     await logAuditEvent({
       tenantId: tenant.id,
-      actorRole: "operator",
-      actorEmail: authResult.user.email ?? null,
+      actorEmail: authResult.user.email,
+      actorRole: isPlatformAdminEmail(authResult.user.email)
+        ? "platform_admin"
+        : "operator",
       action: "catalog.reordered",
       targetType: "tenant",
       targetId: tenant.id,
-      metadata: { itemCount: orderedIds.length },
+      payload: { itemCount: orderedIds.length },
     });
 
     return NextResponse.json({ ok: true }, { status: 200 });
@@ -286,9 +290,12 @@ export async function POST(req: NextRequest) {
 }
 ```
 
-If `getCatalogItems` doesn't exist (it should — used elsewhere), confirm the actual name by running `grep -n "export async function getCatalog" apps/web/src/db/queries.ts` and substitute the right one. The function we want returns all catalog items for a tenant (active **and** inactive — match what the admin table fetches).
-
-If `logAuditEvent`'s parameter shape doesn't match (e.g. `metadata` is `actorMetadata`), open `apps/web/src/lib/audit/log.ts` and adjust the call to its exact signature. Match the call shape used at `apps/web/src/app/api/catalog/[itemId]/route.ts:133`.
+Field-name confirmations (against the actual codebase, verified during plan review):
+- `logAuditEvent` field is `payload` (`lib/audit/types.ts` — `LogAuditEventInput.payload?: Record<string, unknown>`), **not** `metadata`.
+- `actorEmail` is `string` (not nullable); pass `authResult.user.email` directly.
+- `actorRole` mirrors the conditional at `[itemId]/route.ts:135-137` so platform-admin reorders are correctly attributed.
+- Query helper is `getCatalogByTenant(tenantId)` at `queries.ts:488` — returns active + inactive — **not** `getCatalogItems`.
+- `requireTenantApproved` returns `{ tenant }` on success; reuse it rather than calling `getTenant(slug)` separately.
 
 - [ ] **Step 3: Type-check**
 
@@ -297,12 +304,7 @@ Run:
 pnpm check-types:web
 ```
 
-Expected: passes. Likely failures + fixes:
-- `getCatalogItems` not found → use whatever the admin page calls (search `apps/web/src/app/admin/[tenant]/catalog/page.tsx`).
-- `logAuditEvent` field mismatch → mirror the call in `[itemId]/route.ts:133`.
-- `actorRole` must be a specific union → mirror the same call.
-
-Fix and re-run until green.
+Expected: passes. If a name still doesn't resolve, mirror the import/call shape at `apps/web/src/app/api/catalog/[itemId]/route.ts:1-15, 31-50, 133-142`.
 
 - [ ] **Step 4: Commit**
 
@@ -589,20 +591,33 @@ const handleDragEnd = async (event: DragEndEvent) => {
     if (!res.ok) {
       const data = await res.json().catch(() => null);
       const isStale = data?.error === "stale_set";
-      throw new Error(
+      const err = new Error(
         isStale
           ? "Catalog changed — please refresh."
           : data?.message ?? data?.error ?? "Reorder failed.",
       );
+      // Marker so the catch block can branch without re-parsing.
+      (err as Error & { isStale?: boolean }).isStale = isStale;
+      throw err;
     }
   } catch (err) {
     console.error("Reorder failed:", err);
-    setItems(previous);
+    const isStale =
+      err instanceof Error &&
+      (err as Error & { isStale?: boolean }).isStale === true;
     setTableError(
       err instanceof Error ? `Reorder failed: ${err.message}` : "Reorder failed.",
     );
-    // Pull authoritative state from the server in case it changed under us.
-    await refresh();
+    if (isStale) {
+      // Server authoritatively rejected our premise (set membership changed).
+      // The `previous` snapshot is also stale — skip the optimistic rollback
+      // and let refresh() be the sole source of truth.
+      await refresh();
+    } else {
+      // Transient failure (offline, 500, auth). Roll back the optimistic
+      // reorder so the user sees the order they had before the drag.
+      setItems(previous);
+    }
   }
 };
 ```

--- a/docs/superpowers/specs/2026-05-13-catalog-drag-reorder-design.md
+++ b/docs/superpowers/specs/2026-05-13-catalog-drag-reorder-design.md
@@ -27,7 +27,7 @@ Give school admins a direct-manipulation UI to reorder catalogue items, with the
 
 ### 4.1 Visual
 
-A new leftmost column (~28px) on the catalog table contains a small `⠿` grip glyph rendered in `var(--color-ink-dim)`. On hover the glyph darkens to ink-primary; cursor switches to `grab`. Active drag switches to `grabbing` and applies dnd-kit's transform to the row.
+A new leftmost column (~28px) on the catalog table contains a small `⠿` grip glyph rendered in `var(--color-ink-dim)`. This adds a 7th column: the existing `<thead>` row (`catalog-table.tsx:73-79`) gets a new leading `<th className="w-[28px]"></th>` and every `<tr>` gets a matching leading `<td>` housing the grip handle. Empty-state row's `colSpan` bumps from 6 to 7. On hover the glyph darkens to ink-primary; cursor switches to `grab`. Active drag switches to `grabbing` and applies dnd-kit's transform to the row.
 
 The rest of the row continues to be clickable to open the edit drawer (existing behaviour at `catalog-table.tsx:87`). The handle column has its own pointer target and stops propagation, so dragging the handle never opens the drawer and clicking elsewhere on the row never starts a drag.
 
@@ -59,7 +59,7 @@ The rest of the row continues to be clickable to open the edit drawer (existing 
 **Route placement:** `apps/web/src/app/api/catalog/reorder/route.ts` (sibling of the existing `apps/web/src/app/api/catalog/[itemId]/route.ts`). Tenant is supplied in the body rather than the URL because there is no single `itemId` to derive it from, and adding a `[tenant]` path segment would diverge from the existing `/api/catalog/*` shape.
 
 **Validation:**
-- Auth: `requireSessionUser` → resolve tenant via `getTenantBySlug(tenantSlug)` (same helper used elsewhere) → `ensureTenantAccess(user, tenant.shopEmail)`. Platform-admin emails pass via the same path the PATCH route uses.
+- Auth: `requireSessionUser` → resolve tenant via `getTenantBySlug(tenantSlug)` (same helper used elsewhere) → `ensureTenantAccess(user, tenant.shopEmail)`. `ensureTenantAccess` already handles platform-admin pass-through (confirmed at `app/api/catalog/[itemId]/route.ts:50` — the single call covers both operator and platform-admin paths). Do not add a separate `isPlatformAdminEmail` check.
 - `orderedIds` must be a non-empty `string[]` of UUIDs.
 - The set of `orderedIds` must equal the full set of catalog item IDs for the tenant — no missing IDs, no extras, no duplicates. Mismatch returns `400 { error: "stale_set" }`.
 
@@ -88,7 +88,7 @@ Add to `apps/web/package.json`:
 - `@dnd-kit/core`
 - `@dnd-kit/sortable`
 
-Both work fine under React Server Components when used inside a `"use client"` boundary (the table is already a client component). Combined bundle impact ≈ 10kb gz.
+Both work fine under React Server Components when used inside a `"use client"` boundary (the table is already a client component). Combined bundle impact ≈ 15–20kb gz; only loads on the admin catalog route.
 
 ### 6.2 Component changes
 
@@ -99,7 +99,7 @@ Both work fine under React Server Components when used inside a `"use client"` b
 2. Compute new order with `arrayMove(items, oldIndex, newIndex)`.
 3. Capture `previousItems = items` for rollback.
 4. Call `setItems(newOrder.map((it, i) => ({ ...it, sortOrder: i })))` — keeps in-memory `sortOrder` consistent so the drawer's `initialFromItem` reads the right number.
-5. `fetch('/api/catalog/reorder', { method: 'POST', body: JSON.stringify({ orderedIds: newOrder.map(it => it.id) }) })`.
+5. `fetch('/api/catalog/reorder', { method: 'POST', body: JSON.stringify({ tenantSlug: tenant.slug, orderedIds: newOrder.map(it => it.id) }) })`.
 6. On non-ok response or thrown error: `setItems(previousItems)` + `setTableError("Reorder failed: " + msg)`.
 
 ### 6.3 Concurrent-edit handling
@@ -144,7 +144,7 @@ No unit tests (project has no test runner — CLAUDE.md: "`check-types` is the c
 1. Open `/admin/nsbh/catalog` as operator. Drag a row down by 3 positions; refresh the page; order persists.
 2. Open `/nsbh` parent shop in another tab; reordered item appears in the new position after `revalidate`/next visit.
 3. Drag and drop in the same position — DevTools Network shows no POST.
-4. Throttle network in DevTools, drag a row, immediately fail the request (offline toggle): row snaps back + error banner appears.
+4. Toggle DevTools to **Offline before the drop**, then drag a row and release: the POST fails immediately, row snaps back, error banner appears. (Toggling offline mid-flight does not cancel an already-dispatched fetch — set offline first.)
 5. With two browser sessions on the same tenant: A drags while B deletes a row; A sees "Catalog changed — please retry" and refreshes cleanly.
 6. Keyboard-only: tab to grip, Space, arrow down, Space — order changes and persists.
 7. `pnpm check-types:web` passes.

--- a/docs/superpowers/specs/2026-05-13-catalog-drag-reorder-design.md
+++ b/docs/superpowers/specs/2026-05-13-catalog-drag-reorder-design.md
@@ -1,0 +1,161 @@
+# Catalog Drag-to-Reorder — Design Spec
+
+**Date:** 2026-05-13
+**Status:** Approved
+**Scope:** Admin portal catalog page only
+**Backlog source:** `docs/remaining_work.md` §3.12 (gap-analysis §5.12), drag-to-reorder portion only. Size-guide editor — also bundled in that backlog entry — is **deferred** to a separate spec.
+
+---
+
+## 1. Problem
+
+`catalog_items.sortOrder` already exists (`db/schema.ts:107`) and is honoured by `getActiveCatalog` (`db/queries.ts:947`) and the admin read path (`db/queries.ts:889`). But there is no UI to change it — `app/admin/[tenant]/catalog/catalog-table.tsx` renders items in stored order with no reorder affordance. Operators today cannot change parent-shop catalogue order without a DB edit.
+
+## 2. Goal
+
+Give school admins a direct-manipulation UI to reorder catalogue items, with the new order persisted atomically to the server and immediately reflected on the parent shop on next page load.
+
+## 3. Non-goals
+
+- Reordering variants within an item (no current ask).
+- Drag-and-drop in any other admin table (orders, bulk-upload preview, etc.).
+- Size-guide editing (separate spec — see §11).
+- Cross-tenant moves (architecturally impossible — table is tenant-scoped).
+- Per-collection ordering (collections feature isn't shipped yet — §3.12 phase 1 backlog item).
+
+## 4. UX
+
+### 4.1 Visual
+
+A new leftmost column (~28px) on the catalog table contains a small `⠿` grip glyph rendered in `var(--color-ink-dim)`. On hover the glyph darkens to ink-primary; cursor switches to `grab`. Active drag switches to `grabbing` and applies dnd-kit's transform to the row.
+
+The rest of the row continues to be clickable to open the edit drawer (existing behaviour at `catalog-table.tsx:87`). The handle column has its own pointer target and stops propagation, so dragging the handle never opens the drawer and clicking elsewhere on the row never starts a drag.
+
+### 4.2 Interaction
+
+1. Operator presses on the grip and drags vertically.
+2. dnd-kit shows the dragged row floating with a subtle shadow; other rows shift to make space (animated via dnd-kit's default `verticalListSortingStrategy`).
+3. On drop the optimistic order is committed to local state immediately. A `POST /api/catalog/reorder` fires in the background.
+4. On success: no visible feedback (silent success is fine — the visual reorder is the feedback).
+5. On error: order snaps back to the pre-drag state and an inline error banner appears at the top of the table using the existing `tableError` slot (`catalog-table.tsx:63`). Message: `"Reorder failed: <server message>"`.
+
+### 4.3 Affordances
+
+- **Inactive items are draggable** — they participate in the same single ordered list. Lets the operator position an item where it should appear when re-activated.
+- **Single-item catalogue** — handle still renders but no useful drag; acceptable.
+- **No "save order" button** — every drop persists. There is no draft/pending order state in the table.
+
+## 5. Server contract
+
+### 5.1 New endpoint
+
+`POST /api/catalog/reorder`
+
+**Request body:**
+```ts
+{ tenantSlug: string; orderedIds: string[] }
+```
+
+**Route placement:** `apps/web/src/app/api/catalog/reorder/route.ts` (sibling of the existing `apps/web/src/app/api/catalog/[itemId]/route.ts`). Tenant is supplied in the body rather than the URL because there is no single `itemId` to derive it from, and adding a `[tenant]` path segment would diverge from the existing `/api/catalog/*` shape.
+
+**Validation:**
+- Auth: `requireSessionUser` → resolve tenant via `getTenantBySlug(tenantSlug)` (same helper used elsewhere) → `ensureTenantAccess(user, tenant.shopEmail)`. Platform-admin emails pass via the same path the PATCH route uses.
+- `orderedIds` must be a non-empty `string[]` of UUIDs.
+- The set of `orderedIds` must equal the full set of catalog item IDs for the tenant — no missing IDs, no extras, no duplicates. Mismatch returns `400 { error: "stale_set" }`.
+
+**Write:**
+- One `db.batch([...])` running `UPDATE catalog_items SET sort_order = $i WHERE id = $id AND tenant_id = $tenantId` per item. `db.batch` (not `db.transaction`) per CLAUDE.md neon-http note.
+- All rows renumbered to dense `0..N-1` on every drop. Simple, predictable, no gaps. At realistic catalogue sizes (≤100 SKUs per tenant) the batch round-trip is sub-100ms.
+
+**Audit:**
+- One `logAuditEvent` call with `action: "catalog.reordered"`, `actorRole: "operator"`, `actorEmail: session.user.email`, `targetType: "tenant"`, `targetId: tenantId`, `metadata: { itemCount: orderedIds.length }`. **Not** one entry per row — reorder is a single user intent.
+
+**Response:** `200 { ok: true }`.
+
+### 5.2 Query helper
+
+New helper in `apps/web/src/db/queries.ts`:
+```ts
+export async function reorderCatalogItems(tenantId: string, orderedIds: string[]): Promise<void>
+```
+Builds and executes the batch update. Caller is responsible for auth + set-validity check.
+
+## 6. Client wiring
+
+### 6.1 Dependencies
+
+Add to `apps/web/package.json`:
+- `@dnd-kit/core`
+- `@dnd-kit/sortable`
+
+Both work fine under React Server Components when used inside a `"use client"` boundary (the table is already a client component). Combined bundle impact ≈ 10kb gz.
+
+### 6.2 Component changes
+
+`catalog-table.tsx` is wrapped in `<DndContext>` + `<SortableContext items={items.map(i => i.id)} strategy={verticalListSortingStrategy}>`. Each `<tr>` becomes a `SortableRow` child component that calls `useSortable({ id: item.id })` and applies transform/transition styles. The grip cell uses `{...attributes} {...listeners}` so only it initiates the drag.
+
+`onDragEnd` handler:
+1. If `active.id === over?.id` (no movement), return.
+2. Compute new order with `arrayMove(items, oldIndex, newIndex)`.
+3. Capture `previousItems = items` for rollback.
+4. Call `setItems(newOrder.map((it, i) => ({ ...it, sortOrder: i })))` — keeps in-memory `sortOrder` consistent so the drawer's `initialFromItem` reads the right number.
+5. `fetch('/api/catalog/reorder', { method: 'POST', body: JSON.stringify({ orderedIds: newOrder.map(it => it.id) }) })`.
+6. On non-ok response or thrown error: `setItems(previousItems)` + `setTableError("Reorder failed: " + msg)`.
+
+### 6.3 Concurrent-edit handling
+
+If operator A drags while operator B deletes an item, the server's stale-set check fires `400 { error: "stale_set" }`. Client surfaces "Catalog changed — please retry" via `tableError` and calls the parent's `refresh()` to pull current state. No silent state divergence.
+
+## 7. Files touched
+
+| File | Change |
+|---|---|
+| `apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx` | DnD wiring, grip column, `SortableRow` extraction |
+| `apps/web/src/app/api/catalog/reorder/route.ts` | **New** — bulk reorder endpoint |
+| `apps/web/src/db/queries.ts` | New `reorderCatalogItems(tenantId, orderedIds)` helper |
+| `apps/web/package.json` | Add `@dnd-kit/core`, `@dnd-kit/sortable` |
+
+No DB migration. No schema change. No changes to read paths (`getActiveCatalog`, parent shop) — they already honour `sortOrder`.
+
+## 8. Edge cases
+
+| Case | Behaviour |
+|---|---|
+| Drop in the same slot (no movement) | Skip the API call (early return on `active.id === over?.id`) |
+| Single-item catalogue | Handle still renders; drag does nothing meaningful; not blocked |
+| Empty catalogue | Existing empty-state row renders; no DnD context needed but harmless |
+| Operator session expires mid-drag | API returns 401; client snaps back + surfaces "Session expired" |
+| Concurrent delete by another operator | Server 400 `stale_set`; client refreshes from server + surfaces toast |
+| Concurrent add by another operator | Same — server's set-equality check rejects; client refreshes |
+| Inactive item drag | Allowed; visual treatment of inactive rows unchanged (the existing `●` / `○` indicator stays) |
+
+## 9. Accessibility
+
+dnd-kit provides keyboard support out of the box via `KeyboardSensor`:
+- Tab to the grip handle → Space/Enter to pick up → Arrow up/down to move → Space/Enter to drop → Esc to cancel.
+- Live region announcements ("Picked up item X", "Moved over item Y") are built into dnd-kit's defaults; we accept defaults rather than customising.
+
+The grip cell has `aria-label="Reorder ${item.name}"`. Tab order: grip cell first, then row content (handled naturally by column order).
+
+## 10. Testing
+
+No unit tests (project has no test runner — CLAUDE.md: "`check-types` is the correctness gate"). Manual verification:
+
+1. Open `/admin/nsbh/catalog` as operator. Drag a row down by 3 positions; refresh the page; order persists.
+2. Open `/nsbh` parent shop in another tab; reordered item appears in the new position after `revalidate`/next visit.
+3. Drag and drop in the same position — DevTools Network shows no POST.
+4. Throttle network in DevTools, drag a row, immediately fail the request (offline toggle): row snaps back + error banner appears.
+5. With two browser sessions on the same tenant: A drags while B deletes a row; A sees "Catalog changed — please retry" and refreshes cleanly.
+6. Keyboard-only: tab to grip, Space, arrow down, Space — order changes and persists.
+7. `pnpm check-types:web` passes.
+
+## 11. Out of scope (deferred)
+
+- **Size-guide editor** — the other half of remaining_work.md §3.12. Tabular grid on `item-drawer.tsx` editing `catalog_items.sizeGuide` jsonb. Separate spec when next prioritised. The size-guide PDP render path already exists, so this is a pure form-UI add.
+- **Sparse-spacing + collision rebalancing.** Considered and rejected: at ≤100 SKUs per tenant, dense renumber is <100ms in one batch round-trip; sparse spacing adds ~30 lines of route code and an extra branch to test for headroom that won't be exercised at this scale. Re-evaluate at first tenant >300 SKUs.
+- **Bulk select + move to position N.** Power-user feature; no current ask.
+- **Reorder via drawer (numeric `sortOrder` input).** Considered; DnD is faster and obviates the input. The field stays on the schema and continues to be set programmatically by the reorder route.
+
+## 12. Open questions
+
+None at design freeze. Ready for plan.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.5)
       '@gravity-ui/icons':
         specifier: ^2.18.0
         version: 2.18.0(react@19.2.5)
@@ -258,6 +267,28 @@ packages:
       tailwind-merge: '>=2.6.0'
       tailwindcss: '>=3.0.0'
       zod: '>=3.0.0'
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -3521,6 +3552,31 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
 
   '@drizzle-team/brocli@0.10.2': {}
 


### PR DESCRIPTION
## Summary

- **UI:** `⠿` grip column on admin catalog table (`catalog-table.tsx`); rows sortable via `@dnd-kit/sortable` with optimistic update and error rollback
- **API:** New `POST /api/catalog/reorder` endpoint — validates exhaustive `orderedIds` set for tenant, dense-renumbers `sort_order` via `db.batch`, writes one `logAuditEvent` row per reorder
- **Persistence:** `catalog_items.sort_order` column (already existed, now operator-controlled); no DB migration needed; parent shop already sorted by this column

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-13-catalog-drag-reorder-design.md`
- Plan: `docs/superpowers/plans/2026-05-14-catalog-drag-reorder.md`

## Key Decisions

- Dense renumber `0..N-1` on every drop (YAGNI over sparse spacing at ≤100 SKUs/tenant)
- `db.batch` not `db.transaction` (neon-http constraint)
- Exhaustive-set validation: server rejects if `orderedIds ≠` full tenant catalog (catches concurrent add/delete)
- Stale-set error triggers `refresh()` only (not rollback — `previous` snapshot is also stale)
- `pendingRef` in-flight guard on both `handleDragEnd` and `handleDelete` to prevent concurrent mutations

## Test Plan

- [ ] Drag a row down 3 positions → `POST /api/catalog/reorder` 200 → hard refresh → order persists
- [ ] Visit `/nsbh` parent shop → catalog renders in new order
- [ ] Go offline before drop → row snaps back → error banner "Reorder failed: …"
- [ ] Same-slot drop → no POST fires (DevTools Network stays empty)
- [ ] Keyboard: Tab to grip → Space → Arrow Down × 2 → Space → order changes and persists
- [ ] Open drawer on any row (click outside grip) → still opens normally
- [ ] Delete a row while holding a drag → banner "Catalog changed — please refresh." → table refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)