### PR TITLE
feat(catalog): admin size-guide editor

### DIFF
--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -75,6 +75,7 @@ export function CatalogTable({
     imageUrl: it.imageUrl ?? undefined,
     active: it.active,
     sortOrder: it.sortOrder,
+    sizeGuide: (it.sizeGuide as { unit: string; cols: string[]; rows: string[][] } | null) ?? null,
     variants: it.variants.map((v) => ({
       id: v.id,
       label: v.label,

--- a/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/catalog-table.tsx
@@ -22,7 +22,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { GarmentVector } from "@/components/garment";
 import { ItemDrawer, type ItemDrawerInitial } from "./item-drawer";
-import type { Tenant, ItemCategory } from "@/lib/data";
+import type { Tenant, ItemCategory, SizeGuide } from "@/lib/data";
 import type { CatalogItemWithVariants } from "@/db/queries";
 
 export function CatalogTable({
@@ -75,7 +75,7 @@ export function CatalogTable({
     imageUrl: it.imageUrl ?? undefined,
     active: it.active,
     sortOrder: it.sortOrder,
-    sizeGuide: (it.sizeGuide as { unit: string; cols: string[]; rows: string[][] } | null) ?? null,
+    sizeGuide: it.sizeGuide as SizeGuide | null,
     variants: it.variants.map((v) => ({
       id: v.id,
       label: v.label,

--- a/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import { UploadDropzone } from "@/components/uploadthing";
 import { GarmentVector } from "@/components/garment";
-import type { Tenant } from "@/lib/data";
+import type { Tenant, SizeGuide } from "@/lib/data";
 import { ITEM_CATEGORIES } from "@/lib/schemas/catalog";
 
 type ZodFlatten = {
@@ -55,7 +55,7 @@ export type ItemDrawerInitial = {
   active?: boolean;
   sortOrder?: number;
   variants?: InitialVariant[];
-  sizeGuide?: { unit: string; cols: string[]; rows: string[][] } | null;
+  sizeGuide?: SizeGuide | null;
 };
 
 type SizeGuideForm = {

--- a/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
+++ b/apps/web/src/app/admin/[tenant]/catalog/item-drawer.tsx
@@ -55,7 +55,40 @@ export type ItemDrawerInitial = {
   active?: boolean;
   sortOrder?: number;
   variants?: InitialVariant[];
+  sizeGuide?: { unit: string; cols: string[]; rows: string[][] } | null;
 };
+
+type SizeGuideForm = {
+  unit: string;
+  colsRaw: string;
+  rows: string[][];
+};
+
+function parseCols(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function syncRows(rows: string[][], newColCount: number): string[][] {
+  return rows.map((row) => {
+    if (row.length === newColCount) return row;
+    if (row.length < newColCount) {
+      return [...row, ...Array(newColCount - row.length).fill("") as string[]];
+    }
+    return row.slice(0, newColCount);
+  });
+}
+
+function toSizeGuidePayload(
+  form: SizeGuideForm,
+): { unit: string; cols: string[]; rows: string[][] } | null {
+  const cols = parseCols(form.colsRaw);
+  if (cols.length === 0 || form.rows.length === 0) return null;
+  const rows = form.rows.map((r) => syncRows([r], cols.length)[0]);
+  return { unit: form.unit.trim() || "cm", cols, rows };
+}
 
 export function ItemDrawer({
   tenant,
@@ -78,6 +111,12 @@ export function ItemDrawer({
   const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
   const [active, setActive] = useState(true);
   const [variants, setVariants] = useState<Variant[]>([{ label: "", price: "", sizes: "" }]);
+  const [sizeGuide, setSizeGuide] = useState<SizeGuideForm>({
+    unit: "cm",
+    colsRaw: "",
+    rows: [],
+  });
+  const [sizeGuideOpen, setSizeGuideOpen] = useState<boolean>(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -101,6 +140,18 @@ export function ItemDrawer({
         : [{ label: "", price: "", sizes: "" }]
     );
     setError(null);
+    const sg = initial?.sizeGuide;
+    if (sg) {
+      setSizeGuide({
+        unit: sg.unit,
+        colsRaw: sg.cols.join(", "),
+        rows: sg.rows.map((r) => [...r]),
+      });
+      setSizeGuideOpen(true);
+    } else {
+      setSizeGuide({ unit: "cm", colsRaw: "", rows: [] });
+      setSizeGuideOpen(false);
+    }
   }, [open, initial]);
 
   const setVariant = (i: number, patch: Partial<Variant>) =>
@@ -142,6 +193,7 @@ export function ItemDrawer({
             .filter(Boolean),
           active: v.active,
         })),
+        sizeGuide: toSizeGuidePayload(sizeGuide),
       };
 
       const url =
@@ -378,6 +430,157 @@ export function ItemDrawer({
             >
               + Add variant
             </button>
+          </section>
+
+          {/* Size guide */}
+          <section>
+            <button
+              type="button"
+              onClick={() => setSizeGuideOpen((v) => !v)}
+              aria-expanded={sizeGuideOpen}
+              className="w-full flex items-center justify-between text-[11px] font-bold uppercase tracking-[0.4px]"
+            >
+              <span>Size guide (optional)</span>
+              <span aria-hidden style={{ color: "var(--color-ink-dim)" }}>
+                {sizeGuideOpen ? "−" : "+"}
+              </span>
+            </button>
+
+            {sizeGuideOpen && (
+              <div className="mt-3 space-y-3">
+                <div>
+                  <label className="text-[11px] block mb-1" style={{ color: "var(--color-ink-dim)" }}>
+                    Unit
+                  </label>
+                  <input
+                    type="text"
+                    value={sizeGuide.unit}
+                    onChange={(e) =>
+                      setSizeGuide((s) => ({ ...s, unit: e.target.value }))
+                    }
+                    placeholder="cm"
+                    className="w-full border rounded px-2 py-1 text-[13px]"
+                    style={{ borderColor: "var(--color-rule)" }}
+                  />
+                </div>
+
+                <div>
+                  <label className="text-[11px] block mb-1" style={{ color: "var(--color-ink-dim)" }}>
+                    Columns (comma-separated)
+                  </label>
+                  <input
+                    type="text"
+                    value={sizeGuide.colsRaw}
+                    onChange={(e) => {
+                      const newRaw = e.target.value;
+                      setSizeGuide((s) => {
+                        const newCount = parseCols(newRaw).length;
+                        return {
+                          ...s,
+                          colsRaw: newRaw,
+                          rows: syncRows(s.rows, newCount),
+                        };
+                      });
+                    }}
+                    placeholder="Size, Chest, Length"
+                    className="w-full border rounded px-2 py-1 text-[13px]"
+                    style={{ borderColor: "var(--color-rule)" }}
+                  />
+                </div>
+
+                {(() => {
+                  const cols = parseCols(sizeGuide.colsRaw);
+                  if (cols.length === 0) return null;
+                  return (
+                    <div className="space-y-1">
+                      <div className="text-[11px]" style={{ color: "var(--color-ink-dim)" }}>
+                        Rows
+                      </div>
+                      <table className="w-full text-[12px] tnum">
+                        <thead>
+                          <tr style={{ color: "var(--color-ink-dim)" }}>
+                            {cols.map((c, ci) => (
+                              <th key={ci} className="text-left font-semibold py-1 pr-2">{c}</th>
+                            ))}
+                            <th aria-hidden />
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {sizeGuide.rows.map((row, ri) => (
+                            <tr key={ri}>
+                              {row.map((cell, ci) => (
+                                <td key={ci} className="py-1 pr-2">
+                                  <input
+                                    type="text"
+                                    value={cell}
+                                    aria-label={`${cols[ci] ?? `Column ${ci + 1}`}, row ${ri + 1}`}
+                                    onChange={(e) => {
+                                      const newVal = e.target.value;
+                                      setSizeGuide((s) => {
+                                        const rows = s.rows.map((r) => [...r]);
+                                        rows[ri][ci] = newVal;
+                                        return { ...s, rows };
+                                      });
+                                    }}
+                                    className="w-full border rounded px-2 py-1 text-[12px]"
+                                    style={{ borderColor: "var(--color-rule)" }}
+                                  />
+                                </td>
+                              ))}
+                              <td className="py-1 pl-1">
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setSizeGuide((s) => ({
+                                      ...s,
+                                      rows: s.rows.filter((_, i) => i !== ri),
+                                    }))
+                                  }
+                                  aria-label={`Remove row ${ri + 1}`}
+                                  className="text-[14px]"
+                                  style={{ color: "var(--color-ink-dim)" }}
+                                >
+                                  ✕
+                                </button>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setSizeGuide((s) => {
+                            const colCount = parseCols(s.colsRaw).length;
+                            return {
+                              ...s,
+                              rows: [...s.rows, Array(colCount).fill("") as string[]],
+                            };
+                          })
+                        }
+                        className="text-[12px] underline mt-1"
+                        style={{ color: tenant.accent }}
+                      >
+                        + Add row
+                      </button>
+                    </div>
+                  );
+                })()}
+
+                {(sizeGuide.colsRaw.length > 0 || sizeGuide.rows.length > 0) && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setSizeGuide({ unit: "cm", colsRaw: "", rows: [] })
+                    }
+                    className="text-[12px] underline"
+                    style={{ color: "var(--color-ink-dim)" }}
+                  >
+                    Remove size guide
+                  </button>
+                )}
+              </div>
+            )}
           </section>
 
           {/* Active toggle */}

--- a/apps/web/src/app/api/catalog/[itemId]/route.ts
+++ b/apps/web/src/app/api/catalog/[itemId]/route.ts
@@ -87,6 +87,8 @@ export async function PATCH(
       // Normalize key order before comparing: PostgreSQL jsonb returns keys alphabetically
       // ({cols, rows, unit}) while the client sends {unit, cols, rows}. Comparing raw
       // JSON.stringify strings without normalization always fires, even on no-op saves.
+      // Shallow normalization is sufficient: cols/rows are arrays whose element order
+      // is preserved by jsonb, so only the top-level key order needs fixing.
       const normalizeGuide = (g: unknown) => {
         if (!g) return null;
         const { unit, cols, rows } = g as { unit: string; cols: string[]; rows: string[][] };

--- a/apps/web/src/app/api/catalog/[itemId]/route.ts
+++ b/apps/web/src/app/api/catalog/[itemId]/route.ts
@@ -84,8 +84,16 @@ export async function PATCH(
       }
     }
     if (fields.sizeGuide !== undefined) {
-      const existingJson = JSON.stringify(item.sizeGuide ?? null);
-      const incomingJson = JSON.stringify(fields.sizeGuide ?? null);
+      // Normalize key order before comparing: PostgreSQL jsonb returns keys alphabetically
+      // ({cols, rows, unit}) while the client sends {unit, cols, rows}. Comparing raw
+      // JSON.stringify strings without normalization always fires, even on no-op saves.
+      const normalizeGuide = (g: unknown) => {
+        if (!g) return null;
+        const { unit, cols, rows } = g as { unit: string; cols: string[]; rows: string[][] };
+        return { unit, cols, rows };
+      };
+      const existingJson = JSON.stringify(normalizeGuide(item.sizeGuide ?? null));
+      const incomingJson = JSON.stringify(normalizeGuide(fields.sizeGuide ?? null));
       if (existingJson !== incomingJson) changedFields.push("sizeGuide");
     }
     if (variants !== undefined) {

--- a/apps/web/src/app/api/catalog/[itemId]/route.ts
+++ b/apps/web/src/app/api/catalog/[itemId]/route.ts
@@ -83,6 +83,11 @@ export async function PATCH(
         changedFields.push(f);
       }
     }
+    if (fields.sizeGuide !== undefined) {
+      const existingJson = JSON.stringify(item.sizeGuide ?? null);
+      const incomingJson = JSON.stringify(fields.sizeGuide ?? null);
+      if (existingJson !== incomingJson) changedFields.push("sizeGuide");
+    }
     if (variants !== undefined) {
       const existingVariantKey = item.variants
         .map((v) => `${v.id}|${v.label}|${String(v.price)}|${v.active}|${[...(v.sizes ?? [])].sort().join(";")}`)

--- a/apps/web/src/app/api/catalog/route.ts
+++ b/apps/web/src/app/api/catalog/route.ts
@@ -88,6 +88,7 @@ export async function POST(req: NextRequest) {
       imageUrl: input.imageUrl,
       active: input.active,
       sortOrder: input.sortOrder,
+      sizeGuide: input.sizeGuide ?? null,
       variants: input.variants.map((v) => ({
         label: v.label,
         price: v.price,

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -2,7 +2,7 @@ import { db, orders, orderLines, catalogItems, catalogVariants, tenants, orderRe
 import { and, eq, desc, or, gte, inArray, lt, sql, sum, isNotNull } from "drizzle-orm";
 import type { BatchItem } from "drizzle-orm/batch";
 import { cache } from "react";
-import type { CatalogItem, Tenant } from "@/lib/data";
+import type { CatalogItem, SizeGuide, Tenant } from "@/lib/data";
 
 export type LiveOrderStatus = "pending_payment" | "new" | "packing" | "ready" | "collected" | "partially_refunded" | "refunded";
 
@@ -532,6 +532,7 @@ export async function addCatalogItem(data: {
   category: string;
   description?: string | null;
   imageUrl?: string | null;
+  sizeGuide?: SizeGuide | null;
   active?: boolean;
   sortOrder?: number;
   variants: { label: string; price: number; active?: boolean; sizes?: string[] }[];
@@ -545,6 +546,7 @@ export async function addCatalogItem(data: {
     category: data.category,
     description: data.description ?? null,
     imageUrl: data.imageUrl ?? null,
+    sizeGuide: data.sizeGuide ?? null,
     active: data.active ?? true,
     sortOrder: data.sortOrder ?? 0,
   });
@@ -582,6 +584,7 @@ export async function updateCatalogItem(
     category?: string;
     description?: string | null;
     imageUrl?: string | null;
+    sizeGuide?: SizeGuide | null;
     active?: boolean;
     sortOrder?: number;
   },
@@ -603,6 +606,7 @@ export async function updateCatalogItem(
   if (fields.category !== undefined) updates.category = fields.category;
   if (fields.description !== undefined) updates.description = fields.description;
   if (fields.imageUrl !== undefined) updates.imageUrl = fields.imageUrl;
+  if (fields.sizeGuide !== undefined) updates.sizeGuide = fields.sizeGuide;
   if (fields.active !== undefined) updates.active = fields.active;
   if (fields.sortOrder !== undefined) updates.sortOrder = fields.sortOrder;
 

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -102,7 +102,7 @@ export const catalogItems = pgTable("catalog_items", {
   category: text("category").notNull(), // "Winter" | "Summer" | "Sports" | "Formal" | "Bags" | "Stationery"
   description: text("description"),
   imageUrl: text("image_url"),
-  sizeGuide: jsonb("size_guide"), // array of {label, chest, waist, hip}
+  sizeGuide: jsonb("size_guide"), // { unit: string; cols: string[]; rows: string[][] } | null
   active: boolean("active").notNull().default(true),
   sortOrder: integer("sort_order").notNull().default(0),
   createdAt: timestamp("created_at").defaultNow(),

--- a/apps/web/src/lib/schemas/catalog.ts
+++ b/apps/web/src/lib/schemas/catalog.ts
@@ -32,6 +32,21 @@ export const catalogVariantInputSchema = z.object({
   sizes: z.array(z.string().min(1).max(20)).max(40).default([]),
 });
 
+export const sizeGuideSchema = z
+  .object({
+    unit: z.string().trim().min(1).max(20),
+    cols: z.array(z.string().trim().min(1).max(40)).min(1).max(8),
+    rows: z
+      .array(z.array(z.string().trim().max(40)).min(1).max(8))
+      .min(1)
+      .max(50),
+  })
+  .refine((g) => g.rows.every((r) => r.length === g.cols.length), {
+    message: "Every row must have the same number of cells as columns",
+  });
+
+export type SizeGuideInput = z.infer<typeof sizeGuideSchema>;
+
 export const catalogItemInputSchema = z.object({
   tenantId: z.string().min(1),
   name: z.string().trim().min(1).max(80),
@@ -40,6 +55,7 @@ export const catalogItemInputSchema = z.object({
   imageUrl: catalogImageUrlSchema.nullable().optional(),
   active: z.boolean().default(true),
   sortOrder: z.number().int().min(0).default(0),
+  sizeGuide: sizeGuideSchema.nullable().optional(),
   variants: z.array(catalogVariantInputSchema).min(1),
 });
 
@@ -48,6 +64,7 @@ export const catalogItemPatchSchema = catalogItemInputSchema
   .partial()
   .extend({
     variants: z.array(catalogVariantInputSchema).min(1).optional(),
+    sizeGuide: sizeGuideSchema.nullable().optional(),
   });
 
 export type CatalogItemInput = z.infer<typeof catalogItemInputSchema>;

--- a/docs/completed.md
+++ b/docs/completed.md
@@ -629,6 +629,24 @@ Migrated the auth UI from the bundled `@neondatabase/auth/react/ui` subpath to t
 
 **Files:** `apps/web/src/app/auth/[[...path]]/page-client.tsx`, `apps/web/package.json`, `pnpm-lock.yaml`.
 
+### 4.35 Admin size-guide editor ✅
+
+**Source:** `remaining_work.md` §3.12 (gap-analysis §5.12) — shipped 2026-05-14 on branch `feat/admin-size-guide-editor` (6 feature commits + 1 bugfix).
+
+Adds a collapsible "Size guide (optional)" section to the existing catalog item drawer, backed by the pre-existing `catalog_items.size_guide jsonb` column (no migration). Operators can set free-text unit, comma-separated column headers, and an editable row grid; saving writes through `POST /api/catalog` and `PATCH /api/catalog/[itemId]`. PDP read path unchanged.
+
+**Key implementation points:**
+- `sizeGuideSchema` (Zod, with `refine` row-width check) threaded into `catalogItemInputSchema` + `catalogItemPatchSchema`.
+- `addCatalogItem` / `updateCatalogItem` extended; `SizeGuide` type imported from `lib/data`.
+- PATCH diff uses `JSON.stringify` with **key-order normalization** (PostgreSQL jsonb alphabetizes keys; omitting the normalization caused every save to be a false positive — caught and fixed in smoke, commit `f81c1a4`).
+- `initialFromItem` in `catalog-table.tsx` surfaces `sizeGuide` for edit-mode pre-fill.
+- Audit log reuses `catalog_item.updated` with `changedFields: ["sizeGuide"]` — no new event type.
+
+**Files:** `lib/schemas/catalog.ts`, `db/queries.ts`, `db/schema.ts` (comment fix), `api/catalog/route.ts`, `api/catalog/[itemId]/route.ts`, `admin/[tenant]/catalog/item-drawer.tsx`, `admin/[tenant]/catalog/catalog-table.tsx`.
+
+Spec: `docs/superpowers/specs/2026-05-14-admin-size-guide-editor-design.md`.
+Plan: `docs/superpowers/plans/2026-05-14-admin-size-guide-editor.md`.
+
 ---
 
 ## Outstanding items (tracked in `docs/remaining_work.md`)
@@ -637,4 +655,4 @@ The most material categories of open work, all tracked in `docs/remaining_work.m
 
 - **Production ops** — live Stripe keys, prod DB URL, Hostinger env, PostHog verification, Stripe webhook event subscriptions, Apple Pay domain verification (§2.8); UploadThing token + CSP + prod image smoke (§2.9); parent-account E2E on staging for both magic-link and Google (§2.11); prod NSBH catalog seed + RGSH catalog content (§2.12).
 - **Content** — refund-policy copy signed off per school (§3.2); GST report auditor sign-off (§3.6).
-- **Post-launch** — bulk "Email parents" real send (§4.3); i18n scaffolding (§4.4); catalog drag-to-reorder (§4.7); admin drag-to-reorder + size-guide editor, catalog collections, magic-link login, account deletion/export (§3.12).
+- **Post-launch** — bulk "Email parents" real send (§4.3); i18n scaffolding (§4.4); catalog drag-to-reorder (§4.7); catalog collections, magic-link login, account deletion/export (§3.12).

--- a/docs/remaining_work.md
+++ b/docs/remaining_work.md
@@ -173,7 +173,7 @@ Sourced from `my_doc/NSBH/gap-analysis.md` §5 — items not bug-class (those li
 
 - [x] **Shop hours on pickup option pre-purchase (gap-analysis §5.9).** ✅ shipped. Read `tenant.shopHours` in `app/[tenant]/checkout/page.tsx`, thread to `CheckoutScreen`. In `checkout-screen.tsx:415` replace the literal `"Free · Ready in 1–2 school days"` copy on the pickup `DeliveryOption` card with `tenant.shopHours` when set, fall back to existing copy otherwise. ~1h.
 
-- [ ] **Admin size-guide editor (gap-analysis §5.12 — drag-to-reorder portion ✅ shipped).** Drag-to-reorder shipped via `@dnd-kit/sortable` on `catalog-table.tsx` + new `POST /api/catalog/reorder` bulk endpoint; see `completed.md` §4.33. Size-guide editor still outstanding: `catalog_items.sizeGuide jsonb` is rendered on PDP but only seeded via `lib/data.ts`. Same drawer should gain a tabular editor — column headers as comma-list, rows as a grid with add/remove. ~½d.
+- [x] **Admin size-guide editor (gap-analysis §5.12 — drag-to-reorder portion ✅ shipped).** ✅ shipped (PR #N). See `completed.md` §4.35. Collapsible editor in item drawer; Zod schema + PATCH diff with key-order normalization; audit-log reuse; no migration needed.
 
 - [x] **PDP photo support — read `item.imageUrl` + UploadThing in admin drawer (gap-analysis §5.13).** ✅ shipped (PR #31, squash `10a50c0`). See `completed.md` §4.30.
 

--- a/docs/remaining_work.md
+++ b/docs/remaining_work.md
@@ -173,7 +173,7 @@ Sourced from `my_doc/NSBH/gap-analysis.md` §5 — items not bug-class (those li
 
 - [x] **Shop hours on pickup option pre-purchase (gap-analysis §5.9).** ✅ shipped. Read `tenant.shopHours` in `app/[tenant]/checkout/page.tsx`, thread to `CheckoutScreen`. In `checkout-screen.tsx:415` replace the literal `"Free · Ready in 1–2 school days"` copy on the pickup `DeliveryOption` card with `tenant.shopHours` when set, fall back to existing copy otherwise. ~1h.
 
-- [x] **Admin size-guide editor (gap-analysis §5.12 — drag-to-reorder portion ✅ shipped).** ✅ shipped (PR #N). See `completed.md` §4.35. Collapsible editor in item drawer; Zod schema + PATCH diff with key-order normalization; audit-log reuse; no migration needed.
+- [x] **Admin size-guide editor (gap-analysis §5.12 — drag-to-reorder portion ✅ shipped).** ✅ shipped (PR #36). See `completed.md` §4.35. Collapsible editor in item drawer; Zod schema + PATCH diff with key-order normalization; audit-log reuse; no migration needed.
 
 - [x] **PDP photo support — read `item.imageUrl` + UploadThing in admin drawer (gap-analysis §5.13).** ✅ shipped (PR #31, squash `10a50c0`). See `completed.md` §4.30.
 


### PR DESCRIPTION
## Summary

- Adds a collapsible **"Size guide (optional)"** editor to the catalog item drawer (`item-drawer.tsx`), backed by the pre-existing `catalog_items.size_guide jsonb` column — no migration needed
- Threads `sizeGuide` through Zod schemas, `addCatalogItem`/`updateCatalogItem`, and both API routes (`POST /api/catalog`, `PATCH /api/catalog/[itemId]`)
- PATCH diff uses JSON.stringify with **key-order normalization** — PostgreSQL alphabetizes jsonb keys on read, causing false positives without normalization (caught and fixed during smoke testing)
- Audit log reuses `catalog_item.updated` with `changedFields: ["sizeGuide"]`; no new event type

## Test Plan

- [x] `pnpm check-types:web` clean (0 errors)
- [x] Smoke step 1: section collapsed by default when guide is null ✅
- [x] Smoke step 2: add guide → save → reload → pre-fills correctly ✅
- [x] Smoke step 3: add column → existing rows gain empty cell (syncRows) ✅
- [x] Smoke step 4: Remove guide → save → `size_guide = NULL` in DB ✅
- [x] Smoke step 5: create new item with guide (POST 201) ✅
- [x] Smoke step 6: no-op PATCH short-circuit — both saves return `noop: true` ✅ (key-order bug found and fixed in `f81c1a4`)
- [x] Smoke step 7: real edit → audit row with `changedFields: ["sizeGuide"]` ✅
- [x] Smoke step 8: whitespace-only unit → `"cm"` fallback; noop detected ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)