### PR TITLE
fix(auth): restrict catch-all route — block GET-logout CSRF and 404 unknown views

### DIFF
--- a/apps/web/src/app/auth/[[...path]]/page-client.tsx
+++ b/apps/web/src/app/auth/[[...path]]/page-client.tsx
@@ -8,13 +8,22 @@ import Link from "next/link";
 import { authClient, useSession } from "@/lib/auth/client";
 import { clearActiveChildCookieClient } from "@/lib/active-child.client";
 
-// Only allow same-origin, non-auth, relative paths — avoids open-redirect
-// (//evil.com) and sign-in → sign-in loops.
+// Only allow same-origin, non-auth paths. We resolve `raw` against a sentinel
+// origin and reject anything that escapes it — this defends against the whole
+// open-redirect family (`//evil.com`, `/\evil.com`, embedded-tab tricks) that a
+// `startsWith("//")` string check misses, since the URL parser normalises
+// backslashes/control chars to `//host`. Also blocks /auth → sign-in loops.
 function safeCallbackPath(raw: string | null): string | null {
-  if (!raw) return null;
-  if (!raw.startsWith("/") || raw.startsWith("//")) return null;
-  if (raw.startsWith("/auth/") || raw === "/auth") return null;
-  return raw;
+  if (!raw || !raw.startsWith("/")) return null;
+  let url: URL;
+  try {
+    url = new URL(raw, "https://uo.invalid");
+  } catch {
+    return null;
+  }
+  if (url.origin !== "https://uo.invalid") return null;
+  if (url.pathname === "/auth" || url.pathname.startsWith("/auth/")) return null;
+  return url.pathname + url.search + url.hash;
 }
 
 export function AuthPageClient({
@@ -27,38 +36,25 @@ export function AuthPageClient({
   const router = useRouter();
   const session = useSession();
   const target = safeCallbackPath(callbackURL);
-  const previousSignedIn = useRef<boolean>(false);
+  const sessionData = session?.data;
+  const isPending = session?.isPending ?? false;
   const redirected = useRef<boolean>(false);
 
   useEffect(() => {
-    const data = session?.data;
-    if (data === null) {
+    // Clear the active-child cookie only once the session has resolved to
+    // signed-out. `data` is null while `isPending`, so an authenticated parent
+    // landing here mid-load must not lose their selected child.
+    if (!isPending && sessionData === null) {
       clearActiveChildCookieClient();
     }
-    const isSignedIn = !!data;
-    if (!previousSignedIn.current && isSignedIn && target && !redirected.current) {
+    // Bounce a visitor who is already signed in on mount to the validated
+    // deep-link. The fresh-sign-in / OAuth-callback cases are handled natively
+    // by the library via the `redirectTo` prop below.
+    if (sessionData && target && !redirected.current) {
       redirected.current = true;
       router.replace(target);
     }
-    previousSignedIn.current = isSignedIn;
-  }, [session?.data, target, router]);
-
-  // The library navigates to "/" after sign-in. If a callbackURL was passed,
-  // divert to it instead so deep-links into gated pages survive the auth round-trip.
-  const handleNavigate = (href: string) => {
-    if (target && href === "/") {
-      router.push(target);
-    } else {
-      router.push(href);
-    }
-  };
-  const handleReplace = (href: string) => {
-    if (target && href === "/") {
-      router.replace(target);
-    } else {
-      router.replace(href);
-    }
-  };
+  }, [sessionData, isPending, target, router]);
 
   return (
     <main
@@ -68,8 +64,13 @@ export function AuthPageClient({
       <div className="w-full max-w-md">
         <NeonAuthUIProvider
           authClient={authClient}
-          navigate={handleNavigate}
-          replace={handleReplace}
+          navigate={router.push}
+          replace={router.replace}
+          // Pass the validated target as the library's own post-auth redirect.
+          // An explicit prop takes precedence over the unguarded `?redirectTo=`
+          // query param the library would otherwise read, closing that
+          // open-redirect path; falls back to "/" when there is no callbackURL.
+          redirectTo={target ?? "/"}
           onSessionChange={router.refresh}
           Link={Link}
         >

--- a/apps/web/src/app/auth/[[...path]]/page-client.tsx
+++ b/apps/web/src/app/auth/[[...path]]/page-client.tsx
@@ -7,24 +7,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { authClient, useSession } from "@/lib/auth/client";
 import { clearActiveChildCookieClient } from "@/lib/active-child.client";
-
-// Only allow same-origin, non-auth paths. We resolve `raw` against a sentinel
-// origin and reject anything that escapes it — this defends against the whole
-// open-redirect family (`//evil.com`, `/\evil.com`, embedded-tab tricks) that a
-// `startsWith("//")` string check misses, since the URL parser normalises
-// backslashes/control chars to `//host`. Also blocks /auth → sign-in loops.
-function safeCallbackPath(raw: string | null): string | null {
-  if (!raw || !raw.startsWith("/")) return null;
-  let url: URL;
-  try {
-    url = new URL(raw, "https://uo.invalid");
-  } catch {
-    return null;
-  }
-  if (url.origin !== "https://uo.invalid") return null;
-  if (url.pathname === "/auth" || url.pathname.startsWith("/auth/")) return null;
-  return url.pathname + url.search + url.hash;
-}
+import { safeInternalPath } from "@/lib/auth/safe-redirect";
 
 export function AuthPageClient({
   path,
@@ -35,7 +18,7 @@ export function AuthPageClient({
 }) {
   const router = useRouter();
   const session = useSession();
-  const target = safeCallbackPath(callbackURL);
+  const target = safeInternalPath(callbackURL);
   const sessionData = session?.data;
   const isPending = session?.isPending ?? false;
   const redirected = useRef<boolean>(false);
@@ -66,15 +49,19 @@ export function AuthPageClient({
           authClient={authClient}
           navigate={router.push}
           replace={router.replace}
-          // Pass the validated target as the library's own post-auth redirect.
-          // An explicit prop takes precedence over the unguarded `?redirectTo=`
-          // query param the library would otherwise read, closing that
-          // open-redirect path; falls back to "/" when there is no callbackURL.
+          // Post-auth redirect target = the validated callbackURL (`/` default).
+          // The open redirect is closed primarily server-side (page.tsx strips an
+          // unsafe `?redirectTo=` before this mounts), so `getSearchParam(
+          // "redirectTo")` can never return an attacker value. We still pass the
+          // sanitized target on both the provider (context fallback) and <AuthView>
+          // (form-level `redirectToProp`, first in the library's
+          // `redirectToProp || getSearchParam("redirectTo") || contextRedirectTo`
+          // chain) as defense in depth.
           redirectTo={target ?? "/"}
           onSessionChange={router.refresh}
           Link={Link}
         >
-          <AuthView path={path} />
+          <AuthView path={path} redirectTo={target ?? "/"} />
         </NeonAuthUIProvider>
       </div>
     </main>

--- a/apps/web/src/app/auth/[[...path]]/page.tsx
+++ b/apps/web/src/app/auth/[[...path]]/page.tsx
@@ -1,5 +1,6 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { authViewPaths, getViewByPath } from "@neondatabase/auth-ui/server";
+import { safeInternalPath } from "@/lib/auth/safe-redirect";
 import { AuthPageClient } from "./page-client";
 
 export const dynamic = "force-dynamic";
@@ -9,7 +10,7 @@ export default async function AuthPage({
   searchParams,
 }: {
   params: Promise<{ path?: string[] }>;
-  searchParams: Promise<{ callbackURL?: string | string[] }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { path = [] } = await params;
   const sp = await searchParams;
@@ -31,6 +32,29 @@ export default async function AuthPage({
   const view = getViewByPath(authViewPaths, authPath);
   if (!view || view === "SIGN_OUT") {
     notFound();
+  }
+
+  // Neutralise an unsafe `?redirectTo=` BEFORE the client AuthView mounts. The
+  // library resolves its post-auth target from `getSearchParam("redirectTo")`
+  // (raw, unvalidated) and that wins over our sanitized prop in some flows — most
+  // notably the already-signed-in redirect, which is literally
+  // `getSearchParam("redirectTo") || redirectTo` — so passing a clean prop alone
+  // does NOT close the open redirect. Stripping it here, before any client code
+  // reads `window.location.search`, guarantees no `getSearchParam("redirectTo")`
+  // ever returns an attacker value (`?redirectTo=https://evil.example`). A
+  // legitimate same-origin value — e.g. the OAuth callback's own internal
+  // redirectTo — passes `safeInternalPath` and is preserved untouched.
+  const rawRedirect = Array.isArray(sp.redirectTo) ? sp.redirectTo[0] : sp.redirectTo;
+  if (rawRedirect !== undefined && safeInternalPath(rawRedirect) === null) {
+    const kept = new URLSearchParams();
+    for (const [key, value] of Object.entries(sp)) {
+      if (key === "redirectTo") continue;
+      if (Array.isArray(value)) value.forEach((v) => kept.append(key, v));
+      else if (value !== undefined) kept.append(key, value);
+    }
+    const basePath = path.length ? `/auth/${path.join("/")}` : "/auth";
+    const qs = kept.toString();
+    redirect(qs ? `${basePath}?${qs}` : basePath);
   }
 
   return <AuthPageClient path={authPath} callbackURL={rawCallback ?? null} />;

--- a/apps/web/src/app/auth/[[...path]]/page.tsx
+++ b/apps/web/src/app/auth/[[...path]]/page.tsx
@@ -1,3 +1,5 @@
+import { notFound } from "next/navigation";
+import { authViewPaths, getViewByPath } from "@neondatabase/auth-ui/server";
 import { AuthPageClient } from "./page-client";
 
 export const dynamic = "force-dynamic";
@@ -13,6 +15,23 @@ export default async function AuthPage({
   const sp = await searchParams;
   const authPath = path.join("/") || "sign-in";
   const rawCallback = Array.isArray(sp.callbackURL) ? sp.callbackURL[0] : sp.callbackURL;
+
+  // Resolve the requested path to a better-auth view exactly as the library does
+  // — getViewByPath is `for (key in authViewPaths) if (authViewPaths[key] === authPath) return key`,
+  // i.e. a case-sensitive, full-string match returning the view key or undefined —
+  // then gate server-side before mounting the client AuthView:
+  //   - unknown path  -> notFound(): a garbage segment no longer falls back to
+  //     SIGN_IN with a 200 (S3). `/auth/foo`, `/auth/Sign-In`, `/auth/account` 404.
+  //   - SIGN_OUT view -> notFound(): a bare GET to `/auth/sign-out` would
+  //     otherwise sign the user out from a mount effect with no POST/CSRF token
+  //     (S1). Logout is done explicitly via authClient.signOut(), never this route.
+  // The empty path (`/auth`) maps to "sign-in" above, so it stays a valid view.
+  // Imported from the package's "/server" entry — the bare package is
+  // "use client", so its exports would be opaque client references in an RSC.
+  const view = getViewByPath(authViewPaths, authPath);
+  if (!view || view === "SIGN_OUT") {
+    notFound();
+  }
 
   return <AuthPageClient path={authPath} callbackURL={rawCallback ?? null} />;
 }

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -38,7 +38,7 @@ export default function PrivacyPage() {
 
         <h2 className="font-serif text-xl mt-6">Your rights</h2>
         <p>
-          You can update or delete your account from <Link href="/auth/account" className="underline">your account settings</Link>.
+          You can update or delete your account from <Link href="/profile" className="underline">your account settings</Link>.
         </p>
         <p>
           For refund or shipping questions about a specific order, contact the school directly — the school is the seller of record.

--- a/apps/web/src/lib/auth/safe-redirect.ts
+++ b/apps/web/src/lib/auth/safe-redirect.ts
@@ -1,0 +1,24 @@
+/**
+ * Same-origin redirect validator shared by the auth route (server + client).
+ *
+ * Resolves `raw` against a sentinel origin and rejects anything that escapes it
+ * — this defends against the whole open-redirect family (`//evil.com`,
+ * `/\evil.com`, embedded-tab / control-char tricks) that a `startsWith("//")`
+ * string check misses, since the URL parser normalises backslashes/control
+ * chars to `//host`. Also rejects `/auth` and `/auth/*` to avoid sign-in loops.
+ *
+ * Returns the safe in-app path (pathname + search + hash), or null if `raw` is
+ * absent, not a root-relative path, off-origin, or an auth route.
+ */
+export function safeInternalPath(raw: string | null | undefined): string | null {
+  if (!raw || !raw.startsWith("/")) return null;
+  let url: URL;
+  try {
+    url = new URL(raw, "https://uo.invalid");
+  } catch {
+    return null;
+  }
+  if (url.origin !== "https://uo.invalid") return null;
+  if (url.pathname === "/auth" || url.pathname.startsWith("/auth/")) return null;
+  return url.pathname + url.search + url.hash;
+}


### PR DESCRIPTION
## What & why

The `/auth/[[...path]]` catch-all passed any path straight to `<AuthView>`, which resolves `view = getViewByPath(viewPaths, path) || "SIGN_IN"`. Two verified issues:

- **S1 — logout CSRF.** `/auth/sign-out` resolves to the `SIGN_OUT` view, whose component runs `authClient.signOut()` in a **mount effect**. A bare cross-site GET (an `<img>`, a prefetched `<Link>`, a crafted link) therefore logged the current user out with no POST / confirmation / CSRF token, since the session cookie is sent automatically.
- **S3 — SEO/correctness.** Any unknown segment (`/auth/foo`, `/auth/Sign-In`) fell back to the sign-in view and returned **HTTP 200** instead of `notFound()`. Sibling `[tenant]` layouts already `notFound()` on a bad slug; this route validated nothing.

## How

Validate the path **server-side** in `page.tsx` using the library's own matcher:

```ts
import { authViewPaths, getViewByPath } from "@neondatabase/auth-ui/server";
const view = getViewByPath(authViewPaths, authPath);
if (!view || view === "SIGN_OUT") notFound();
```

- Imported from the package's **`/server`** entry — the bare `@neondatabase/auth-ui` index is `"use client"`, so its non-component exports would be opaque client references in an RSC. The `/server` entry re-exports the same symbols with no `"use client"`.
- `getViewByPath` is an exact, case-sensitive, full-string match (`for (key in viewPaths) if (viewPaths[key] === path) return key`), so the server check mirrors what `<AuthView>` would render.
- `!view` → S3 (garbage/case/unknown → 404); `view === "SIGN_OUT"` → S1 (GET-logout → 404). Empty path `/auth` still maps to `sign-in` and stays valid.
- **Logout is unaffected** — it runs via explicit `authClient.signOut()` controls (profile, admin shell); nothing routed through `/auth/sign-out`.

Also repoints the privacy page's "your account settings" link from the dead `/auth/account` (never a valid `AuthView` — previously rendered sign-in, now 404s) to `/profile`, the real account screen.

`page-client.tsx` carries the companion open-redirect hardening from the same review (URL-parser callback validation + native `redirectTo` prop + cookie-clear fix).

## Verification

- `pnpm check-types:web` — green.
- HTTP probes **and** in-browser render (Chrome):

| Path | Result |
|---|---|
| `/auth`, `sign-in`, `sign-up`, `forgot-password`, `reset-password` (+`?token=`), `callback`, `magic-link`, `email-otp`, `two-factor`, `recover-account`, `accept-invitation` | **200** ✓ |
| `/auth/sign-out` | **404** ✓ (S1) |
| `/auth/foo`, `/auth/Sign-In`, `/auth/account`, multi-segment | **404** ✓ (S3) |
| `/privacy` → "your account settings" | link `href="/profile"` ✓ |
| `/profile` (signed out) | redirects → `sign-in?callbackURL=%2Fprofile` ✓ |

No dev-server or browser-console errors.

## Out of scope (separate follow-ups)

C5 (move already-signed-in redirect server-side), C7 (shared `signInUrl()`/`isSafeCallbackPath()` helper), C11 (force-dynamic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)