### PR TITLE
fix: verified analytics totals (#43) + webhook PI/order tenant cross-check (#41)

### DIFF
--- a/apps/web/src/app/api/orders/route.ts
+++ b/apps/web/src/app/api/orders/route.ts
@@ -443,8 +443,11 @@ export async function POST(req: NextRequest) {
       tenant_id: tenantId,
       delivery: fulfilmentMethod === "shipping" ? "ship" : "pickup",
       fulfilment_method: fulfilmentMethod,
-      total,
-      subtotal,
+      // Report the server-verified totals, not the raw client body. `subtotal` is
+      // otherwise unvalidated (only typeof-checked), so a crafted body could skew
+      // PostHog revenue even though the charge and persisted order are correct.
+      total: verifiedTotals.total,
+      subtotal: verifiedTotals.subtotal,
       item_count: lines.length,
       $set: { email: normalizedParentEmail },
     });

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -87,6 +87,28 @@ export async function POST(req: NextRequest) {
     }
 
     if (resolved) {
+      // Defense-in-depth: the order is matched only by stripePaymentIntentId, but
+      // the PI's tenantId is server-pinned at creation (anti-tamper). Cross-check
+      // that the resolved order belongs to the tenant the PI was minted for before
+      // firing paid side-effects. A mismatch should be impossible in normal
+      // operation, so we skip + alert rather than email/record under the wrong
+      // tenant. Older PIs without pinned metadata (piTenantId null) are exempt.
+      const piTenantId =
+        typeof pi.metadata?.tenantId === "string" ? pi.metadata.tenantId : null;
+      if (piTenantId && piTenantId !== resolved.tenantId) {
+        console.error("stripe webhook: PI/order tenant mismatch", {
+          paymentIntentId: pi.id,
+          piTenantId,
+          orderTenantId: resolved.tenantId,
+        });
+        await serverCaptureException(
+          "stripe-webhook",
+          new Error("pi_order_tenant_mismatch"),
+          { paymentIntentId: pi.id, piTenantId, orderTenantId: resolved.tenantId }
+        );
+        return NextResponse.json({ received: true, ignored: "tenant mismatch" });
+      }
+
       // Idempotent record of the payment: order_paid audit event (deduped by the
       // partial unique index), analytics once, and the confirmation email
       // (self-idempotent). Shared with the order POST so whichever path runs —


### PR DESCRIPTION
Two small hardening fixes from the `/code-review high` pass on PR #39 (the cheap, low-risk ones; #40 and #42 remain tracked follow-ups).

## #43 — `order_placed` analytics used raw client totals
`api/orders/route.ts` reported the destructured body `total`/`subtotal` to PostHog. `subtotal` is only `typeof`-checked, so a crafted request body could skew analytics revenue even though the charge and persisted order are correct. Now reports `verifiedTotals.{total,subtotal}`. Closes #43.

## #41 — webhook never validated PI tenant metadata
`payment_intent.succeeded` matched the order solely by `stripePaymentIntentId` and ignored `pi.metadata.tenantId` (server-pinned at PI creation as anti-tamper) — the pin had no consumer. Now cross-checks it against the resolved order's `tenantId` before firing paid side-effects; on mismatch, skips + `serverCaptureException` rather than emailing/recording under the wrong tenant. PIs without pinned metadata are exempt (backward-compatible). Closes #41.

## Verification
- `pnpm check-types:web` green
- No behaviour change for the normal (matching-tenant) path; the analytics change is a value swap to the already-verified totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)