### PR TITLE
fix: server-side per-line price snapshot (#40) + bounded confirmation-email retries (#42)

### DIFF
--- a/apps/web/drizzle/0017_pending_order_snapshots.sql
+++ b/apps/web/drizzle/0017_pending_order_snapshots.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS "pending_order_snapshots" (
+	"payment_intent_id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL REFERENCES "tenants"("id") ON DELETE cascade,
+	"user_id" uuid,
+	"fulfilment_method" "order_fulfilment_method" NOT NULL,
+	"subtotal" numeric(10, 2) NOT NULL,
+	"gst" numeric(10, 2) NOT NULL,
+	"total" numeric(10, 2) NOT NULL,
+	"lines_json" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "pending_order_snapshots"
+	ADD CONSTRAINT "pending_order_snapshots_user_id_user_id_fk"
+	FOREIGN KEY ("user_id") REFERENCES "neon_auth"."user"("id")
+	ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_pending_order_snapshots_created_at"
+	ON "pending_order_snapshots" ("created_at");

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1781740800001,
       "tag": "0016_catalog_variants_unique_label",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1781740800002,
+      "tag": "0017_pending_order_snapshots",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/app/[tenant]/checkout/checkout-screen.tsx
+++ b/apps/web/src/app/[tenant]/checkout/checkout-screen.tsx
@@ -218,9 +218,12 @@ export function CheckoutScreen({
           tenantId: tenant.id,
           amount: total,
           currency: "aud",
+          // `size` is included so the server-side per-line snapshot written at
+          // PI creation carries the full line (it is not price-bearing).
           lines: lines.map((l) => ({
             itemId: l.itemId,
             variantLabel: l.variantLabel,
+            size: l.size,
             unitPrice: l.price,
             qty: l.qty,
           })),

--- a/apps/web/src/app/admin/[tenant]/orders/order-card.tsx
+++ b/apps/web/src/app/admin/[tenant]/orders/order-card.tsx
@@ -45,10 +45,19 @@ export function OrderCard({
 }
 
 function BadgeRow({ order, mode }: { order: BoardOrder; mode: WorkflowMode }) {
-  const emails = (order.emailsSent ?? {}) as Record<
-    string,
-    "queued" | "sent" | "failed" | undefined
-  >;
+  // `ready`/`hold` slots hold a plain status string; `confirmation` holds an
+  // object ({sentAt,messageId} when sent, {status:"failed",…} when terminally
+  // failed — see lib/email/index.ts).
+  const emails = (order.emailsSent ?? {}) as Record<string, unknown>;
+  const status = (key: string): string | undefined => {
+    const slot = emails[key];
+    if (typeof slot === "string") return slot;
+    if (slot && typeof slot === "object" && "status" in slot) {
+      const s = (slot as { status?: unknown }).status;
+      return typeof s === "string" ? s : undefined;
+    }
+    return undefined;
+  };
   return (
     <div className="mt-2 flex flex-wrap gap-1 text-[10px]">
       {order.paymentStatus !== "pending" &&
@@ -57,13 +66,16 @@ function BadgeRow({ order, mode }: { order: BoardOrder; mode: WorkflowMode }) {
           <Badge label="Paid" tone="green" />
         )}
       {order.pickSlipPrintedAt && <Badge label="Printed" tone="muted" />}
-      {mode === "standard" && emails.ready === "sent" && (
+      {status("confirmation") === "failed" && (
+        <Badge label="Confirmation failed" tone="red" />
+      )}
+      {mode === "standard" && status("ready") === "sent" && (
         <Badge label="Email sent" tone="muted" />
       )}
-      {mode === "standard" && emails.ready === "failed" && (
+      {mode === "standard" && status("ready") === "failed" && (
         <Badge label="Email failed" tone="red" />
       )}
-      {mode === "standard" && emails.hold === "sent" && (
+      {mode === "standard" && status("hold") === "sent" && (
         <Badge label="Hold notice sent" tone="amber" />
       )}
       {order.paymentStatus === "refunded" && (

--- a/apps/web/src/app/api/orders/route.ts
+++ b/apps/web/src/app/api/orders/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { db, orders, orderLines, tenants } from "@/db";
+import { db, orders, orderLines, tenants, pendingOrderSnapshots } from "@/db";
+import type { PendingOrderLineSnapshot } from "@/db/schema";
 import {
   getOrdersByTenant,
   getOrdersByTenantAndParentEmail,
@@ -195,9 +196,10 @@ export async function POST(req: NextRequest) {
     // authoritative total and derive the rest server-side.
     //
     // Structural validation (qty, unitPrice types) stays — we still want to
-    // refuse garbage payloads. The per-line unitPrice we persist is the client
-    // PI-snapshot value (not a live-catalog re-read); this is fine because the
-    // total is bounded by what Stripe actually charged.
+    // refuse garbage payloads. The per-line prices we PERSIST come from the
+    // server-side snapshot written at PI creation (see the snapshot block
+    // below), so the client `lines` here are only a fallback for PaymentIntents
+    // that predate that table.
     const piTypeError = (() => {
       if (!Array.isArray(lines) || lines.length === 0) return "lines_invalid";
       for (const l of lines) {
@@ -300,24 +302,84 @@ export async function POST(req: NextRequest) {
       total: round2(authoritativeTotal),
     };
 
-    // Per-line price snapshot: persist the client-supplied unitPrice — the exact
-    // figure the parent saw and that backed the PaymentIntent — NOT a live-catalog
-    // re-read. A live re-read could diverge from the stored (Stripe-locked) subtotal
-    // if an operator edited a price between PI creation and order POST. Each
-    // unitPrice is already validated as a finite number upstream, and the TOTAL is
-    // Stripe-locked, so a tampered per-line price cannot change what was charged.
-    // We soft-assert Σ(line) ≈ subtotal below and log drift without blocking a paid order.
+    // ─── Per-line price snapshot ──────────────────────────────────────────
+    //
+    // The authoritative breakdown is the snapshot written at PI creation from
+    // catalog prices validated by `assertTotalsMatch` — exactly what backed the
+    // charge. Reading it here means the client `lines` in this (post-payment)
+    // body are never trusted for price, quantity or item name: a caller can no
+    // longer reshuffle prices across lines with the sum left intact and shape
+    // the amounts that drive receipts and partial-refund math.
+    //
+    // Fallback: a PaymentIntent created before this table existed (or whose
+    // snapshot insert failed) has no row. Those orders are already paid, so we
+    // keep the previous behaviour — persist the client PI-snapshot prices and
+    // soft-assert Σ(line) ≈ subtotal — rather than rejecting a paid order.
+    const [snapshot] = await db
+      .select({
+        linesJson: pendingOrderSnapshots.linesJson,
+        tenantId: pendingOrderSnapshots.tenantId,
+        userId: pendingOrderSnapshots.userId,
+      })
+      .from(pendingOrderSnapshots)
+      .where(
+        eq(pendingOrderSnapshots.paymentIntentId, normalizedStripePaymentIntentId),
+      )
+      .limit(1);
+
+    // A snapshot from a different tenant or a different parent means the PI id
+    // was not minted for this order — refuse rather than silently falling back
+    // to the client lines.
+    if (
+      snapshot &&
+      (snapshot.tenantId !== tenantId ||
+        (snapshot.userId !== null && snapshot.userId !== authResult.user.id))
+    ) {
+      return NextResponse.json(
+        { error: "payment_intent_snapshot_mismatch" },
+        { status: 403 },
+      );
+    }
+
+    const snapshotLines: PendingOrderLineSnapshot[] | null =
+      snapshot && Array.isArray(snapshot.linesJson) && snapshot.linesJson.length > 0
+        ? snapshot.linesJson
+        : null;
+
+    const persistedLines: PendingOrderLineSnapshot[] = snapshotLines ?? lines.map(
+      (l: {
+        itemId: string;
+        itemName: string;
+        variantLabel: string;
+        size?: string | null;
+        qty: number;
+        unitPrice: number;
+      }) => ({
+        itemId: l.itemId,
+        itemName: l.itemName,
+        variantLabel: l.variantLabel,
+        size: typeof l.size === "string" && l.size.trim() ? l.size.trim() : null,
+        qty: l.qty,
+        unitPrice: l.unitPrice,
+      }),
+    );
+
     const lineSubtotal = round2(
-      lines.reduce((s, l) => s + l.unitPrice * l.qty, 0)
+      persistedLines.reduce((s, l) => s + l.unitPrice * l.qty, 0)
     );
     if (Math.abs(lineSubtotal - verifiedTotals.subtotal) > 0.01) {
-      // Drift between the client line prices and the Stripe-locked subtotal. The
-      // customer already paid the correct total, so we do NOT reject — we surface
-      // the discrepancy for reconciliation and continue writing the paid order.
+      // Drift between the persisted line prices and the Stripe-locked subtotal.
+      // The customer already paid the correct total, so we do NOT reject — we
+      // surface the discrepancy for reconciliation and write the paid order.
       await serverCaptureException(
         "api-orders-post",
         new Error("line_subtotal_drift"),
-        { tenantId, lineSubtotal, subtotal: verifiedTotals.subtotal }
+        {
+          tenantId,
+          lineSubtotal,
+          subtotal: verifiedTotals.subtotal,
+          source: snapshotLines ? "pi_snapshot" : "client_lines",
+        }
       );
     }
 
@@ -378,21 +440,16 @@ export async function POST(req: NextRequest) {
         legalVersionId,
       });
       const linesInsert = db.insert(orderLines).values(
-        lines.map((line) => {
-          // Persist the client PI-snapshot price (see block comment above). The
-          // total is Stripe-locked, so this cannot change what was charged.
-          const unitPrice = line.unitPrice;
-          return {
-            orderId,
-            itemId: line.itemId,
-            itemName: line.itemName,
-            variantLabel: line.variantLabel,
-            size: line.size?.trim() || null,
-            qty: line.qty,
-            unitPrice: String(unitPrice),
-            lineTotal: String(round2(unitPrice * line.qty)),
-          };
-        })
+        persistedLines.map((line) => ({
+          orderId,
+          itemId: line.itemId,
+          itemName: line.itemName,
+          variantLabel: line.variantLabel,
+          size: line.size,
+          qty: line.qty,
+          unitPrice: String(line.unitPrice),
+          lineTotal: String(round2(line.unitPrice * line.qty)),
+        }))
       );
       await db.batch([orderInsert, linesInsert]);
     };
@@ -438,6 +495,24 @@ export async function POST(req: NextRequest) {
       throw new Error("Unable to generate a unique order ID");
     }
 
+    // The snapshot has served its purpose — the authoritative copy now lives in
+    // order_lines. Best-effort: a stale row is harmless (the PI id is already
+    // consumed, and the orders idempotency check short-circuits any replay).
+    if (snapshot) {
+      try {
+        await db
+          .delete(pendingOrderSnapshots)
+          .where(
+            eq(
+              pendingOrderSnapshots.paymentIntentId,
+              normalizedStripePaymentIntentId,
+            ),
+          );
+      } catch (err) {
+        console.error("Failed to clear pending order snapshot", err);
+      }
+    }
+
     await serverCapture(authResult.user.id, "order_placed", {
       order_id: createdOrderId,
       tenant_id: tenantId,
@@ -448,7 +523,7 @@ export async function POST(req: NextRequest) {
       // PostHog revenue even though the charge and persisted order are correct.
       total: verifiedTotals.total,
       subtotal: verifiedTotals.subtotal,
-      item_count: lines.length,
+      item_count: persistedLines.length,
       $set: { email: normalizedParentEmail },
     });
 

--- a/apps/web/src/app/api/stripe/payment-intent/route.ts
+++ b/apps/web/src/app/api/stripe/payment-intent/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
 import { getStripe } from "@/lib/stripe";
-import { getCatalogPriceLookup, getTenant } from "@/db/queries";
+import { getCatalogLineLookup, getTenant } from "@/db/queries";
+import { db, pendingOrderSnapshots } from "@/db";
+import type { PendingOrderLineSnapshot } from "@/db/schema";
 import {
   assertTotalsMatch,
+  priceLookupKey,
   TotalsMismatchError,
 } from "@/lib/order-totals";
 import { requireSessionUser } from "@/lib/auth/authorization";
@@ -86,17 +89,23 @@ export async function POST(req: NextRequest) {
     }
 
     // Build catalog price lookup and assert server-authoritative totals.
-    const priceLookup = await getCatalogPriceLookup(tenantId);
+    const catalogLookup = await getCatalogLineLookup(tenantId);
+    const priceLookup = new Map(
+      Array.from(catalogLookup, ([key, value]) => [key, value.price]),
+    );
+
+    const clientLines = lines as Array<{
+      itemId: string;
+      variantLabel: string;
+      unitPrice: number;
+      qty: number;
+      size?: unknown;
+    }>;
 
     let verified;
     try {
       verified = assertTotalsMatch({
-        lines: lines as Array<{
-          itemId: string;
-          variantLabel: string;
-          unitPrice: number;
-          qty: number;
-        }>,
+        lines: clientLines,
         delivery: delivery === "ship" ? "ship" : "pickup",
         received: { subtotal, gst, total: amountNumber },
         priceLookup,
@@ -159,6 +168,59 @@ export async function POST(req: NextRequest) {
     };
 
     const paymentIntent = await stripe.paymentIntents.create(intentParams);
+
+    // Persist the server-authoritative per-line snapshot, keyed by the
+    // PaymentIntent. POST /api/orders reads this instead of trusting the client
+    // `lines` it is handed after payment: the total is Stripe-locked, but
+    // without a stored snapshot the per-line breakdown (which drives receipts
+    // and partial-refund math) could be reshuffled by the client with the sum
+    // left intact. Prices/names come from the catalog rows just validated by
+    // `assertTotalsMatch`, so they are exactly what backed the charge — and,
+    // unlike a live re-read at order-POST time, they cannot drift if an
+    // operator edits a price in between.
+    //
+    // `size` is a non-price-bearing display field with no catalog counterpart,
+    // so it is carried through from the client as-is.
+    const lineSnapshot: PendingOrderLineSnapshot[] = clientLines.map((line) => {
+      // Non-null: assertTotalsMatch already threw 'unknown_variant' otherwise.
+      const catalogLine = catalogLookup.get(
+        priceLookupKey(line.itemId, line.variantLabel),
+      )!;
+      const size = typeof line.size === "string" ? line.size.trim() : "";
+      return {
+        itemId: line.itemId,
+        itemName: catalogLine.itemName,
+        variantLabel: line.variantLabel,
+        size: size.length > 0 ? size : null,
+        qty: line.qty,
+        unitPrice: catalogLine.price,
+      };
+    });
+
+    try {
+      await db
+        .insert(pendingOrderSnapshots)
+        .values({
+          paymentIntentId: paymentIntent.id,
+          tenantId,
+          userId: authResult.user.id,
+          fulfilmentMethod,
+          subtotal: String(verified.subtotal),
+          gst: String(verified.gst),
+          total: String(verified.total),
+          linesJson: lineSnapshot,
+        })
+        .onConflictDoNothing({ target: pendingOrderSnapshots.paymentIntentId });
+    } catch (err) {
+      // Never fail PI creation over the snapshot: the parent would be blocked
+      // from paying. The order POST falls back to the client lines (with drift
+      // logging) when no snapshot row exists.
+      console.error(
+        "Failed to persist pending order snapshot for",
+        paymentIntent.id,
+        err,
+      );
+    }
 
     return NextResponse.json({
       clientSecret: paymentIntent.client_secret,

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -994,6 +994,43 @@ export const getCatalogPriceLookup = cache(async (tenantId: string): Promise<Map
 });
 
 /**
+ * Same keying as getCatalogPriceLookup, but also carries the catalog item name
+ * so /api/stripe/payment-intent can persist a fully server-derived per-line
+ * snapshot (price AND display name) rather than trusting the client's copy.
+ */
+export const getCatalogLineLookup = cache(
+  async (
+    tenantId: string,
+  ): Promise<Map<string, { price: number; itemName: string }>> => {
+    const rows = await db
+      .select({
+        itemId: catalogItems.id,
+        itemName: catalogItems.name,
+        varLabel: catalogVariants.label,
+        varPrice: catalogVariants.price,
+      })
+      .from(catalogItems)
+      .innerJoin(catalogVariants, eq(catalogVariants.itemId, catalogItems.id))
+      .where(
+        and(
+          eq(catalogItems.tenantId, tenantId),
+          eq(catalogItems.active, true),
+          eq(catalogVariants.active, true),
+        ),
+      );
+
+    const lookup = new Map<string, { price: number; itemName: string }>();
+    for (const r of rows) {
+      lookup.set(`${r.itemId}::${r.varLabel}`, {
+        price: Number(r.varPrice),
+        itemName: r.itemName,
+      });
+    }
+    return lookup;
+  },
+);
+
+/**
  * Single catalog item in the parent UI's `CatalogItem` shape, or null if
  * not found / inactive. Re-uses getActiveCatalog for request-scoped dedup.
  */

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -173,6 +173,56 @@ export const catalogVariants = pgTable(
   }),
 );
 
+// ─── Pending order snapshots ─────────────────────────────────────────────────
+/**
+ * Server-authoritative per-line price snapshot, written at PaymentIntent
+ * creation and consumed by POST /api/orders when the order is finalised.
+ *
+ * The order TOTAL is Stripe-locked (verified against the PaymentIntent), but
+ * without this table the per-line breakdown could only come from the client
+ * body — letting a caller reshuffle prices across lines (sum unchanged) and
+ * shape the amounts that drive receipts and partial-refund math. The prices
+ * here are the catalog prices `assertTotalsMatch` validated at PI creation, so
+ * they are exactly what backed the charge — and, unlike a live catalog re-read
+ * at order-POST time, they cannot drift if an operator edits a price in between.
+ */
+export type PendingOrderLineSnapshot = {
+  itemId: string;
+  itemName: string;
+  variantLabel: string;
+  size: string | null;
+  qty: number;
+  /** Catalog price in AUD dollars at PI creation. */
+  unitPrice: number;
+};
+
+export const pendingOrderSnapshots = pgTable(
+  "pending_order_snapshots",
+  {
+    paymentIntentId: text("payment_intent_id").primaryKey(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: uuid("user_id").references(() => neonAuthUsers.id, {
+      onDelete: "cascade",
+    }),
+    fulfilmentMethod: orderFulfilmentMethodEnum("fulfilment_method").notNull(),
+    subtotal: numeric("subtotal", { precision: 10, scale: 2 }).notNull(),
+    gst: numeric("gst", { precision: 10, scale: 2 }).notNull(),
+    total: numeric("total", { precision: 10, scale: 2 }).notNull(),
+    linesJson: jsonb("lines_json")
+      .$type<PendingOrderLineSnapshot[]>()
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    // Abandoned checkouts leave rows behind; index the age so they can be swept.
+    createdAtIdx: index("idx_pending_order_snapshots_created_at").on(t.createdAt),
+  }),
+);
+
 // ─── Orders ──────────────────────────────────────────────────────────────────
 export const orders = pgTable(
   "orders",

--- a/apps/web/src/lib/email/index.ts
+++ b/apps/web/src/lib/email/index.ts
@@ -7,15 +7,38 @@ import { OrderReadyEmail } from "./templates/OrderReady";
 import { OrderHold } from "./templates/OrderHold";
 import { OrderRefund } from "./templates/OrderRefund";
 import { enqueueNotification, type EnqueueResult } from "./dispatch";
+import { serverCaptureException } from "@/lib/analytics/server";
 import React from "react";
 
 function requireAppUrl(): string {
   const url = process.env.NEXT_PUBLIC_APP_URL;
   if (!url) {
-    throw new Error("NEXT_PUBLIC_APP_URL is required to render email links");
+    throw new PermanentEmailError(
+      "NEXT_PUBLIC_APP_URL is required to render email links",
+    );
   }
   return url;
 }
+
+/**
+ * A failure that retrying cannot fix: missing config, an unrenderable template,
+ * a malformed recipient, or a provider 4xx. Callers stamp a terminal
+ * `failed` marker for these instead of releasing the claim for another attempt.
+ */
+export class PermanentEmailError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PermanentEmailError";
+  }
+}
+
+/**
+ * How many times a *transient* confirmation send may be retried across Stripe
+ * webhook redeliveries before the slot is marked terminally failed. Without a
+ * cap, a provider that keeps 5xx-ing (or a request that keeps timing out) would
+ * be re-attempted on every redelivery forever with no actionable failed state.
+ */
+const CONFIRMATION_MAX_ATTEMPTS = 5;
 
 /**
  * Helper to fetch order with its line items and tenant information.
@@ -46,17 +69,89 @@ async function getOrderForEmail(orderId: string) {
 }
 
 /**
- * Releases a previously-claimed confirmation slot so a later delivery can retry.
- * Removes the `confirmation` key entirely (back to the un-claimed state).
+ * Marks a claimed confirmation slot as retryable so a later delivery re-claims
+ * it. Keeps the attempt counter so the retry budget is enforced across
+ * deliveries (the slot is never emptied — an empty slot would reset the count).
  */
-async function releaseConfirmationClaim(orderId: string) {
+async function markConfirmationRetry(
+  orderId: string,
+  attempts: number,
+  reason: string,
+) {
   await db
     .update(orders)
     .set({
-      emailsSent: sql`COALESCE(${orders.emailsSent}, '{}'::jsonb) - 'confirmation'`,
+      emailsSent: sql`jsonb_set(
+        COALESCE(${orders.emailsSent}, '{}'::jsonb),
+        '{confirmation}',
+        ${JSON.stringify({
+          status: "retry",
+          attempts,
+          lastError: reason.slice(0, 500),
+          lastAttemptAt: new Date().toISOString(),
+        })}::jsonb
+      )`,
       updatedAt: new Date(),
     })
     .where(eq(orders.id, orderId));
+}
+
+/**
+ * Marks the confirmation slot terminally failed. The slot stays non-null and
+ * non-`retry`, so the atomic claim below will never re-claim it: redeliveries
+ * stop re-attempting a send that cannot succeed, and the admin order card
+ * surfaces a "Confirmation failed" badge for manual follow-up.
+ */
+async function markConfirmationFailed(
+  orderId: string,
+  attempts: number,
+  reason: string,
+) {
+  // Dead-letter signal: every terminal confirmation failure is reported once,
+  // including the paths that do not throw out of the send.
+  await serverCaptureException(
+    "confirmation-email",
+    new Error(`confirmation_email_failed_permanently: ${reason}`),
+    { orderId, attempts },
+  );
+  await db
+    .update(orders)
+    .set({
+      emailsSent: sql`jsonb_set(
+        COALESCE(${orders.emailsSent}, '{}'::jsonb),
+        '{confirmation}',
+        ${JSON.stringify({
+          status: "failed",
+          attempts,
+          reason: reason.slice(0, 500),
+          failedAt: new Date().toISOString(),
+        })}::jsonb
+      )`,
+      updatedAt: new Date(),
+    })
+    .where(eq(orders.id, orderId));
+}
+
+/**
+ * Records a failed send attempt: terminal for permanent failures or once the
+ * retry budget is spent, retryable otherwise.
+ */
+async function recordConfirmationFailure(
+  orderId: string,
+  attempts: number,
+  err: unknown,
+) {
+  const reason = err instanceof Error ? err.message : String(err);
+  const permanent = err instanceof PermanentEmailError;
+  if (permanent || attempts >= CONFIRMATION_MAX_ATTEMPTS) {
+    await markConfirmationFailed(
+      orderId,
+      attempts,
+      permanent ? reason : `max_attempts_exceeded: ${reason}`,
+    );
+    return;
+  }
+  await markConfirmationRetry(orderId, attempts, reason);
 }
 
 /**
@@ -69,38 +164,88 @@ async function releaseConfirmationClaim(orderId: string) {
  * stamps it, and the parent receives two emails. Instead we ATOMICALLY claim the
  * slot: a single conditional UPDATE flips a still-empty slot to a `pending`
  * marker, and only the caller whose UPDATE actually changed a row (RETURNING
- * non-empty) proceeds to send. On failure the claim is released so the next
- * delivery retries — preserving the prior "retry until sent once" behaviour.
+ * non-empty) proceeds to send.
+ *
+ * Failure handling is state-machined through the same slot so redeliveries stay
+ * bounded (issue #42):
+ *
+ *   absent                                  → claimable
+ *   {status:"pending", attempts}            → a send is in flight
+ *   {status:"retry", attempts, lastError}   → transient failure, re-claimable
+ *                                             while attempts < MAX
+ *   {status:"failed", attempts, reason}     → terminal; never re-claimed
+ *   {sentAt, messageId}                     → sent
+ *
+ * A permanent failure (missing config, unrenderable template, malformed
+ * recipient, provider 4xx) goes straight to `failed`; a transient one burns one
+ * attempt and lands on `failed` once the budget is spent. Either way the slot
+ * stops being re-claimed, so a config-broken deployment no longer re-attempts
+ * on every Stripe redelivery forever, and the failed state is visible to admins.
  */
 export async function sendOrderConfirmationEmail(orderId: string) {
-  // Atomic claim: only one concurrent caller can flip null -> pending.
+  // Atomic claim: only one concurrent caller can take the slot. Claimable when
+  // never attempted, or left `retry` with attempts still under budget. The
+  // attempt counter is carried forward so the budget spans redeliveries.
   const claimed = await db
     .update(orders)
     .set({
-      emailsSent: sql`jsonb_set(COALESCE(${orders.emailsSent}, '{}'::jsonb), '{confirmation}', '{"status":"pending"}'::jsonb)`,
+      emailsSent: sql`jsonb_set(
+        COALESCE(${orders.emailsSent}, '{}'::jsonb),
+        '{confirmation}',
+        jsonb_build_object(
+          'status', 'pending',
+          'attempts',
+          COALESCE((${orders.emailsSent} -> 'confirmation' ->> 'attempts')::int, 0) + 1
+        )
+      )`,
       updatedAt: new Date(),
     })
     .where(
-      sql`${orders.id} = ${orderId} AND (COALESCE(${orders.emailsSent}, '{}'::jsonb) -> 'confirmation') IS NULL`
+      sql`${orders.id} = ${orderId} AND (
+        (COALESCE(${orders.emailsSent}, '{}'::jsonb) -> 'confirmation') IS NULL
+        OR (
+          COALESCE(${orders.emailsSent} -> 'confirmation' ->> 'status', '') = 'retry'
+          AND COALESCE((${orders.emailsSent} -> 'confirmation' ->> 'attempts')::int, 0)
+              < ${CONFIRMATION_MAX_ATTEMPTS}
+        )
+      )`
     )
-    .returning({ id: orders.id });
+    .returning({ emailsSent: orders.emailsSent });
 
   if (claimed.length === 0) {
-    // Already claimed/sent by a concurrent or prior caller — nothing to do.
+    // Already sent, in flight, or terminally failed — nothing to do.
     return;
   }
 
+  const attempts =
+    Number(
+      (claimed[0].emailsSent as { confirmation?: { attempts?: number } })
+        ?.confirmation?.attempts,
+    ) || 1;
+
   const data = await getOrderForEmail(orderId);
   if (!data) {
+    // The order row is gone (or its tenant is): no amount of retrying helps,
+    // and there is no row left to stamp — log and stop.
     console.error(`[email] Order ${orderId} not found for confirmation email`);
-    await releaseConfirmationClaim(orderId);
+    await markConfirmationFailed(orderId, attempts, "order_not_found");
     return;
   }
 
   const { order, tenant, lines } = data;
 
+  // requireAppUrl() throws PermanentEmailError when NEXT_PUBLIC_APP_URL is
+  // unset — a config fault that every redelivery would hit identically.
+  let appUrl: string;
+  try {
+    appUrl = requireAppUrl();
+  } catch (err) {
+    await recordConfirmationFailure(orderId, attempts, err);
+    throw err;
+  }
+
   const refundPolicyUrl = tenant.currentLegalVersionId
-    ? `${requireAppUrl()}/${tenant.id}/refund-policy`
+    ? `${appUrl}/${tenant.id}/refund-policy`
     : null;
 
   const props = {
@@ -119,7 +264,7 @@ export async function sendOrderConfirmationEmail(orderId: string) {
     })),
     totalAmount: Number(order.total),
     shopEmail: tenant.shopEmail,
-    orderUrl: `${requireAppUrl()}/orders/${order.id}`,
+    orderUrl: `${appUrl}/orders/${order.id}`,
     refundPolicyUrl,
   };
 
@@ -131,13 +276,19 @@ export async function sendOrderConfirmationEmail(orderId: string) {
       plainText: true,
     });
   } catch (err) {
-    // Render failed before send — release the claim so a redelivery retries.
-    await releaseConfirmationClaim(orderId);
+    // The template failed to render for this order's data — deterministic, so
+    // retrying the same order would fail the same way. Terminal.
+    const failure = new PermanentEmailError(
+      `render_failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    await recordConfirmationFailure(orderId, attempts, failure);
     throw err;
   }
 
   let result: Awaited<ReturnType<typeof sendEmail>>;
   try {
+    // sendEmail throws only for 5xx / timeout (transient) and returns null for
+    // permanent rejections (malformed recipient, provider 4xx).
     result = await sendEmail({
       to: order.parentEmail,
       subject: `Order Confirmation #${order.id} - ${tenant.name}`,
@@ -145,7 +296,7 @@ export async function sendOrderConfirmationEmail(orderId: string) {
       text,
     });
   } catch (err) {
-    await releaseConfirmationClaim(orderId);
+    await recordConfirmationFailure(orderId, attempts, err);
     throw err;
   }
 
@@ -165,9 +316,14 @@ export async function sendOrderConfirmationEmail(orderId: string) {
       })
       .where(eq(orders.id, orderId));
   } else {
-    // Provider returned no id => not actually delivered. Release the claim so a
-    // later delivery can retry, matching the prior stamp-on-success behaviour.
-    await releaseConfirmationClaim(orderId);
+    // A null result means the provider permanently rejected the send (malformed
+    // recipient or a 4xx) — retrying is futile, so mark the slot failed and
+    // surface it rather than re-attempting on every redelivery.
+    await markConfirmationFailed(
+      orderId,
+      attempts,
+      "provider_rejected: no message id returned",
+    );
   }
 }
 

--- a/apps/web/src/lib/orders/record-order-paid.ts
+++ b/apps/web/src/lib/orders/record-order-paid.ts
@@ -33,8 +33,12 @@ type RecordOrderPaidArgs = {
  *  - `sendOrderConfirmationEmail` is self-idempotent under concurrency: it
  *    atomically CLAIMS the order's `emailsSent.confirmation` slot (a single
  *    conditional UPDATE flips an empty slot to `pending`), so only one of two
- *    concurrent callers sends. A send that failed on an earlier delivery
- *    releases the claim and is retried on the next, but only ever sends once.
+ *    concurrent callers sends. A transient failure leaves the slot `retry` and
+ *    the next delivery re-claims it, but only ever sends once. Retries are
+ *    bounded: a permanent failure (missing config, unrenderable template,
+ *    provider 4xx) — or exhausting the retry budget — stamps a terminal
+ *    `failed` marker that is never re-claimed, so a broken config cannot drive
+ *    unbounded futile re-sends across Stripe redeliveries.
  */
 export async function recordOrderPaid({
   orderId,


### PR DESCRIPTION
Fixes both open issues from the `/code-review high` pass on PR #39.

## #40 — Persist per-line price snapshot at PI-creation (MEDIUM)

`POST /api/orders` persisted the **client-supplied** per-line `unitPrice`. The order total is Stripe-locked, but the breakdown was only soft-checked (`line_subtotal_drift` logged, then continue) — so a client could reshuffle prices across line items with the sum unchanged and shape the amounts that drive receipts and partial-refund math.

- New `pending_order_snapshots` table (migration `0017`), keyed by PaymentIntent id.
- `/api/stripe/payment-intent` writes the snapshot after PI creation, holding the catalog prices **and** item names just validated by `assertTotalsMatch` — exactly what backed the charge. Unlike a live catalog re-read at order-POST time, it cannot drift if an operator edits a price in between.
- `/api/orders` reads that snapshot and builds `order_lines` from it. The client `lines` are no longer trusted for price, qty, or item name. A snapshot belonging to a different tenant or parent is rejected `403`; the row is deleted once consumed.
- **Fallback:** a PaymentIntent created before this table exists (or whose snapshot insert failed) has no row — those keep the previous behaviour (client prices + drift logging) rather than rejecting an already-paid order.
- Checkout now sends `size` at PI creation so the snapshot line is complete (`size` is not price-bearing and has no catalog counterpart, so it is carried through from the client).

Closes #40

## #42 — Confirmation email: handle permanent send failures (LOW–MEDIUM)

A failed send released its claim, so every Stripe redelivery re-claimed and re-attempted. For a permanent failure (unset `NEXT_PUBLIC_APP_URL`, unrenderable template, malformed recipient, provider 4xx) that meant unbounded futile retries, no delivery, and no actionable failed state.

`emailsSent.confirmation` is now a state machine:

```
absent                                → claimable
{status:"pending", attempts}          → send in flight
{status:"retry", attempts, lastError} → transient failure, re-claimable while attempts < 5
{status:"failed", attempts, reason}   → terminal; never re-claimed
{sentAt, messageId}                   → sent
```

- The attempt counter is carried forward through the claim UPDATE, so the retry budget spans redeliveries (an emptied slot would reset it).
- Permanent failures go straight to `failed`; transient ones land there once the budget is spent. `requireAppUrl()` now throws a `PermanentEmailError`, and a null `sendEmail` result (malformed recipient / provider 4xx) is treated as permanent instead of retryable.
- Every terminal failure emits a dead-letter `serverCaptureException` — including the paths that do not throw out of the send.
- The admin order card renders a red **Confirmation failed** badge. Its badge reader now handles both slot shapes (`ready`/`hold` are plain strings, `confirmation` is an object).

Closes #42

## Verification

- `pnpm check-types:web` — clean
- `pnpm build:web` — clean
- Claim / retry / failed JSONB predicates run against the dev Postgres to confirm each transition, including that a `sent` slot is not re-claimable
- No live Stripe checkout was run end-to-end

## Deploy note

Migration `0017_pending_order_snapshots` is applied to the **dev** Neon DB only (journal row inserted manually per the drizzle-kit workaround). Production Neon is not provisioned yet — it needs applying when prod comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeuHkFdrZfKJgxFJgCo2yJ