### PR TITLE
feat(admin): live dashboard and reports from paid Neon orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ HEROUI_PERSONAL_TOKEN.txt
 # Self-ver live captures (host via process 1300, then wipe — not a repo archive)
 .self-ver/
 
+# Per-worktree recorded origin (process 0100). Do not commit the live URL.
+.dev-local/web.url
+
 # Skill junk
 **/__pycache__/
 **/*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Neon PostgreSQL plus Drizzle backs live catalog, tenant settings, orders, and St
 - `lib/cart-store.ts`: cart localStorage store, key `uo:cart:v1`.
 - `lib/order-store.ts`: leftover localStorage orders plus `uo:student:v1`; checkout now writes orders to Neon.
 
-Admin dashboard (`/admin/[tenant]/dashboard`) and reports (`/admin/[tenant]/reports`) read paid Neon orders via `getLiveDashboardData` / `getLiveReportsData`. Sales KPIs exclude pending and fully refunded orders.
+Admin dashboard (`/admin/[tenant]/dashboard`) and reports (`/admin/[tenant]/reports`) read paid Neon orders via `getLiveDashboardData` / `getLiveReportsData`. Sales KPIs and recent orders exclude pending and fully refunded rows; revenue/GST net out `refundedAmountCents` on partially refunded sales.
 
 ## Server/Client Pattern
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,11 +73,11 @@ Neon PostgreSQL plus Drizzle backs live catalog, tenant settings, orders, and St
 - `src/db/preloved-queries.ts`: preloved settings, SKU, intake, write-off, donation-note, parent-shop, and paid-decrement helpers. Put preloved reads/writes here (keeps GST/report work in `queries.ts` from clashing).
 - `app/api/orders`, `app/api/catalog`, `app/api/tenant`, `app/api/stripe/*`: client-facing live write surfaces. Client code must check `res.ok` and surface errors.
 - `lib/data.ts`: tenant metadata, parent/child demo data, static fallback catalog, helpers.
-- `lib/admin-data.ts`: legacy mock admin orders and sales analytics.
+- `lib/admin-data.ts`: leftover mock orders used only by `order-store` (not dashboard/reports).
 - `lib/cart-store.ts`: cart localStorage store, key `uo:cart:v1`.
-- `lib/order-store.ts`: legacy localStorage orders plus `uo:student:v1`; checkout now writes orders to Neon.
+- `lib/order-store.ts`: leftover localStorage orders plus `uo:student:v1`; checkout now writes orders to Neon.
 
-Known gap: dashboard recent orders, reports, and sales KPIs still use mock data. See `docs/FEATURE_AUDIT.md`.
+Admin dashboard (`/admin/[tenant]/dashboard`) and reports (`/admin/[tenant]/reports`) read paid Neon orders via `getLiveDashboardData` / `getLiveReportsData`. Sales KPIs exclude pending and fully refunded orders.
 
 ## Server/Client Pattern
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "test:m04-donate-refund": "playwright test -c playwright.config.ts tests/preloved/m04-donate-refund.spec.ts",
     "test:m05-parent-preloved-shop": "playwright test -c playwright.config.ts tests/preloved/m05-parent-preloved-shop.spec.ts",
     "test:m06-preloved-fulfilment": "playwright test -c playwright.config.ts tests/preloved/m06-preloved-fulfilment.spec.ts",
+    "test:admin-dashboard": "playwright test -c playwright.admin.config.ts",
     "demo:seed:dry": "node ../../demo/demo_data/run.mjs seed --dry-run",
     "demo:seed": "node ../../demo/demo_data/run.mjs seed",
     "demo:cleanup": "node ../../demo/demo_data/run.mjs cleanup",

--- a/apps/web/playwright.admin.config.ts
+++ b/apps/web/playwright.admin.config.ts
@@ -1,0 +1,44 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { defineConfig } from "playwright/test";
+
+/**
+ * Admin dashboard / reports live-data gate. E2e never boots the app (process 0500).
+ * Bind this worktree: PLAYWRIGHT_BASE_URL, then `.dev-local/web.url`, then PORT.
+ */
+function resolveBaseURL(): string {
+  const fromEnv = process.env.PLAYWRIGHT_BASE_URL?.trim();
+  if (fromEnv) return fromEnv.replace(/\/$/, "");
+
+  for (const candidate of [
+    resolve(process.cwd(), ".dev-local/web.url"),
+    resolve(process.cwd(), "../.dev-local/web.url"),
+    resolve(process.cwd(), "../../.dev-local/web.url"),
+  ]) {
+    if (!existsSync(candidate)) continue;
+    const url = readFileSync(candidate, "utf8").trim();
+    if (url) return url.replace(/\/$/, "");
+  }
+
+  const port = process.env.PORT ?? process.env.WEB_PORT ?? "43173";
+  return `http://127.0.0.1:${port}`;
+}
+
+export default defineConfig({
+  testDir: "./tests/admin",
+  testMatch: /.*\.spec\.ts$/,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 60_000,
+  reporter: [["list"]],
+  use: {
+    baseURL: resolveBaseURL(),
+    browserName: "chromium",
+    viewport: { width: 1440, height: 900 },
+    screenshot: "off",
+    video: "off",
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+  },
+});

--- a/apps/web/src/app/admin/[tenant]/dashboard/dashboard-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/dashboard/dashboard-client.tsx
@@ -353,7 +353,7 @@ export function AdminDashboardClient({
                   className="py-4 text-[12px] text-center"
                   style={{ color: "var(--color-ink-dim)" }}
                 >
-                  No live orders yet.
+                  No paid orders yet.
                 </div>
               )}
             </div>

--- a/apps/web/src/app/admin/[tenant]/dashboard/dashboard-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/dashboard/dashboard-client.tsx
@@ -32,24 +32,34 @@ function StatusBadge({
   return <Chip tone={tone}>{label}</Chip>;
 }
 
+export type DashboardStripeStatus = {
+  linked: boolean;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+};
+
 export function AdminDashboardClient({
   tenant,
   dashboard,
+  stripe,
 }: {
   tenant: Tenant;
   dashboard: LiveDashboardData;
+  stripe: DashboardStripeStatus;
 }) {
   const stats = [
     {
+      id: "revenue",
       label: "Revenue · 30d",
       value: `$${dashboard.revenue.toLocaleString()}`,
-      delta: "Live orders",
+      delta: "Paid orders",
       tone: "pos" as const,
       spark: dashboard.spark,
     },
-    { label: "Orders · 30d", value: String(dashboard.orders), delta: "Live orders", tone: "pos" as const },
-    { label: "Avg order", value: `$${dashboard.avgOrder.toFixed(2)}`, delta: "Last 30 days", tone: "pos" as const },
+    { id: "orders", label: "Orders · 30d", value: String(dashboard.orders), delta: "Paid orders", tone: "pos" as const },
+    { id: "avg", label: "Avg order", value: `$${dashboard.avgOrder.toFixed(2)}`, delta: "Last 30 days", tone: "pos" as const },
     {
+      id: "awaiting",
       label: "Awaiting pickup",
       value: String(dashboard.awaitingPickup),
       delta: `${dashboard.readyOverSevenDays} over 7d`,
@@ -57,13 +67,18 @@ export function AdminDashboardClient({
     },
   ];
 
+  const stripeReady = stripe.linked && stripe.chargesEnabled && stripe.payoutsEnabled;
+  const hasAlerts =
+    dashboard.readyOverSevenDays > 0 || dashboard.needsAttention > 0 || !stripeReady;
+
   return (
-    <div className="flex-1 overflow-y-auto p-7">
+    <div data-testid="admin-dashboard" className="flex-1 overflow-y-auto p-7">
       {/* Stat cards */}
       <div className="grid grid-cols-4 gap-3.5 mb-6">
         {stats.map((s) => (
           <div
             key={s.label}
+            data-testid={`dashboard-kpi-${s.id}`}
             className="bg-white rounded-[10px] border p-4"
             style={{ borderColor: "var(--color-rule)" }}
           >
@@ -98,6 +113,15 @@ export function AdminDashboardClient({
           </div>
         ))}
       </div>
+      {dashboard.orders === 0 && (
+        <p
+          data-testid="dashboard-empty-sales"
+          className="text-[12px] mb-6"
+          style={{ color: "var(--color-ink-dim)" }}
+        >
+          No paid orders in the last 30 days.
+        </p>
+      )}
 
       {/* Main grid */}
       <div className="grid gap-3.5" style={{ gridTemplateColumns: "2fr 1fr" }}>
@@ -114,7 +138,7 @@ export function AdminDashboardClient({
               Last 30 days
             </span>
           </div>
-          <table className="w-full border-collapse text-[13px]">
+          <table data-testid="dashboard-top-items" className="w-full border-collapse text-[13px]">
             <thead>
               <tr
                 className="text-[10.5px] uppercase tracking-[0.6px]"
@@ -177,7 +201,12 @@ export function AdminDashboardClient({
               })}
               {dashboard.topItems.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="py-4 text-center text-[12px]" style={{ color: "var(--color-ink-dim)" }}>
+                  <td
+                    colSpan={4}
+                    data-testid="dashboard-top-items-empty"
+                    className="py-4 text-center text-[12px]"
+                    style={{ color: "var(--color-ink-dim)" }}
+                  >
                     No live order lines yet.
                   </td>
                 </tr>
@@ -195,49 +224,81 @@ export function AdminDashboardClient({
             <h3 className="font-serif text-[17px] font-medium m-0 mb-3" style={{ color: "var(--color-ink)" }}>
               Needs attention
             </h3>
-            <div className="flex flex-col gap-3">
-              <div
-                className="flex gap-2.5 p-2.5 rounded-md text-[12px] leading-[1.5]"
-                style={{ background: "#FBF1E5", border: "1px solid #E5D5AE" }}
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#7A5418" strokeWidth="1.7" strokeLinecap="round" className="flex-shrink-0 mt-0.5">
-                  <path d="M12 3 L22 20 H2 Z" />
-                  <path d="M12 10 V14" />
-                  <circle cx="12" cy="17" r="0.6" fill="#7A5418" stroke="none" />
-                </svg>
-                <div style={{ color: "var(--color-ink)" }}>
-                  <b>{dashboard.readyOverSevenDays} orders</b> ready for pickup over 7 days.{" "}
-                  <Link href={`/admin/${tenant.id}/orders`} className="font-semibold underline" style={{ color: tenant.accent }}>
-                    View orders →
-                  </Link>
+            <div data-testid="dashboard-attention" className="flex flex-col gap-3">
+              {dashboard.readyOverSevenDays > 0 && (
+                <div
+                  data-testid="dashboard-alert-stale-ready"
+                  className="flex gap-2.5 p-2.5 rounded-md text-[12px] leading-[1.5]"
+                  style={{ background: "#FBF1E5", border: "1px solid #E5D5AE" }}
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#7A5418" strokeWidth="1.7" strokeLinecap="round" className="flex-shrink-0 mt-0.5">
+                    <path d="M12 3 L22 20 H2 Z" />
+                    <path d="M12 10 V14" />
+                    <circle cx="12" cy="17" r="0.6" fill="#7A5418" stroke="none" />
+                  </svg>
+                  <div style={{ color: "var(--color-ink)" }}>
+                    <b>{dashboard.readyOverSevenDays} orders</b> ready for pickup over 7 days.{" "}
+                    <Link href={`/admin/${tenant.id}/orders`} className="font-semibold underline" style={{ color: tenant.accent }}>
+                      View orders →
+                    </Link>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="flex gap-2.5 p-2.5 rounded-md text-[12px] leading-[1.5]"
-                style={{ background: "#E2EAF3", border: "1px solid #C7D4E3" }}
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-navy-soft)" strokeWidth="1.7" strokeLinecap="round" className="flex-shrink-0 mt-0.5">
-                  <rect x="3" y="5" width="18" height="14" rx="1" />
-                  <path d="M3 7 L12 13 L21 7" />
-                </svg>
-                <div style={{ color: "var(--color-ink)" }}>
-                  <b>Term 2 catalog</b> ready for review.{" "}
-                  <Link href={`/admin/${tenant.id}/catalog`} className="font-semibold underline" style={{ color: tenant.accent }}>
-                    Review →
-                  </Link>
+              )}
+              {dashboard.needsAttention > 0 && (
+                <div
+                  data-testid="dashboard-alert-hold"
+                  className="flex gap-2.5 p-2.5 rounded-md text-[12px] leading-[1.5]"
+                  style={{ background: "#FBF1E5", border: "1px solid #E5D5AE" }}
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#7A5418" strokeWidth="1.7" strokeLinecap="round" className="flex-shrink-0 mt-0.5">
+                    <path d="M12 3 L22 20 H2 Z" />
+                    <path d="M12 10 V14" />
+                    <circle cx="12" cy="17" r="0.6" fill="#7A5418" stroke="none" />
+                  </svg>
+                  <div style={{ color: "var(--color-ink)" }}>
+                    <b>{dashboard.needsAttention} orders</b> on hold.{" "}
+                    <Link href={`/admin/${tenant.id}/orders`} className="font-semibold underline" style={{ color: tenant.accent }}>
+                      View orders →
+                    </Link>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="flex gap-2.5 p-2.5 rounded-md text-[12px] leading-[1.5]"
-                style={{ background: "#E5F0E7", border: "1px solid #C6DECB" }}
-              >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-success)" strokeWidth="1.7" strokeLinecap="round" className="flex-shrink-0 mt-0.5">
-                  <path d="M5 13 L10 18 L20 6" />
-                </svg>
-                <div style={{ color: "var(--color-ink)" }}>
-                  Stripe payout estimate from live orders: <b>${(dashboard.revenue * 0.26).toLocaleString()}</b>.
+              )}
+              {!stripeReady && (
+                <div
+                  data-testid="dashboard-alert-stripe"
+                  className="flex gap-2.5 p-2.5 rounded-md text-[12px] leading-[1.5]"
+                  style={{ background: "#E2EAF3", border: "1px solid #C7D4E3" }}
+                >
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--color-navy-soft)" strokeWidth="1.7" strokeLinecap="round" className="flex-shrink-0 mt-0.5">
+                    <rect x="3" y="5" width="18" height="14" rx="1" />
+                    <path d="M3 7 L12 13 L21 7" />
+                  </svg>
+                  <div style={{ color: "var(--color-ink)" }}>
+                    {!stripe.linked ? (
+                      <>
+                        Stripe Connect is not linked.{" "}
+                      </>
+                    ) : (
+                      <>
+                        Stripe is linked but{" "}
+                        {!stripe.chargesEnabled ? "charges are pending" : "payouts are pending"}.{" "}
+                      </>
+                    )}
+                    <Link href={`/admin/${tenant.id}/settings`} className="font-semibold underline" style={{ color: tenant.accent }}>
+                      Open settings →
+                    </Link>
+                  </div>
                 </div>
-              </div>
+              )}
+              {!hasAlerts && (
+                <p
+                  data-testid="dashboard-attention-clear"
+                  className="text-[12px] m-0"
+                  style={{ color: "var(--color-ink-dim)" }}
+                >
+                  No live issues right now.
+                </p>
+              )}
             </div>
           </div>
 
@@ -258,10 +319,13 @@ export function AdminDashboardClient({
                 View all
               </Link>
             </div>
-            <div className="flex flex-col">
+            <div data-testid="dashboard-recent-orders" className="flex flex-col">
               {dashboard.recentOrders.map((o, i) => (
-                <div
+                <Link
                   key={o.id}
+                  href={`/admin/${tenant.id}/orders/${o.id}`}
+                  data-testid="dashboard-recent-order"
+                  data-order-id={o.id}
                   className="flex items-center gap-3 py-2.5"
                   style={{
                     borderBottom: i < dashboard.recentOrders.length - 1 ? "1px solid var(--color-rule)" : "none",
@@ -281,10 +345,14 @@ export function AdminDashboardClient({
                       ${o.total.toFixed(0)}
                     </div>
                   </div>
-                </div>
+                </Link>
               ))}
               {dashboard.recentOrders.length === 0 && (
-                <div className="py-4 text-[12px] text-center" style={{ color: "var(--color-ink-dim)" }}>
+                <div
+                  data-testid="dashboard-recent-empty"
+                  className="py-4 text-[12px] text-center"
+                  style={{ color: "var(--color-ink-dim)" }}
+                >
                   No live orders yet.
                 </div>
               )}

--- a/apps/web/src/app/admin/[tenant]/dashboard/error.tsx
+++ b/apps/web/src/app/admin/[tenant]/dashboard/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { AdminLivePageError } from "@/components/admin-live-page-error";
+
+export default function AdminDashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <AdminLivePageError title="Dashboard could not load" error={error} reset={reset} />;
+}

--- a/apps/web/src/app/admin/[tenant]/dashboard/loading.tsx
+++ b/apps/web/src/app/admin/[tenant]/dashboard/loading.tsx
@@ -1,0 +1,49 @@
+import { AdminTopbar } from "@/components/admin-shell";
+
+function Pulse({ className }: { className: string }) {
+  return (
+    <div
+      className={`animate-pulse rounded-md ${className}`}
+      style={{ background: "var(--color-rule)" }}
+    />
+  );
+}
+
+export default function AdminDashboardLoading() {
+  return (
+    <>
+      <AdminTopbar kicker="Operator" title="Dashboard" />
+      <div
+        data-testid="admin-dashboard-loading"
+        className="flex-1 overflow-y-auto p-7"
+        aria-busy="true"
+        aria-live="polite"
+      >
+        <span className="sr-only">Loading live dashboard</span>
+        <div className="grid grid-cols-4 gap-3.5 mb-6">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div
+              key={i}
+              className="bg-white rounded-[10px] border p-4"
+              style={{ borderColor: "var(--color-rule)" }}
+            >
+              <Pulse className="h-3 w-24" />
+              <Pulse className="h-7 w-20 mt-3" />
+              <Pulse className="h-3 w-16 mt-2" />
+            </div>
+          ))}
+        </div>
+        <div className="grid gap-3.5" style={{ gridTemplateColumns: "2fr 1fr" }}>
+          <div className="bg-white rounded-[10px] border p-[18px] min-h-[220px]" style={{ borderColor: "var(--color-rule)" }}>
+            <Pulse className="h-5 w-40 mb-4" />
+            <Pulse className="h-32 w-full" />
+          </div>
+          <div className="bg-white rounded-[10px] border p-[18px] min-h-[220px]" style={{ borderColor: "var(--color-rule)" }}>
+            <Pulse className="h-5 w-32 mb-4" />
+            <Pulse className="h-32 w-full" />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/admin/[tenant]/dashboard/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/dashboard/page.tsx
@@ -29,7 +29,15 @@ export default async function AdminDashboardPage({ params }: { params: Promise<{
           </Link>
         }
       />
-      <AdminDashboardClient tenant={tenant} dashboard={dashboard} />
+      <AdminDashboardClient
+        tenant={tenant}
+        dashboard={dashboard}
+        stripe={{
+          linked: Boolean(tenantRecord.stripeAccountId),
+          chargesEnabled: tenantRecord.stripeChargesEnabled === true,
+          payoutsEnabled: tenantRecord.stripePayoutsEnabled === true,
+        }}
+      />
     </>
   );
 }

--- a/apps/web/src/app/admin/[tenant]/reports/error.tsx
+++ b/apps/web/src/app/admin/[tenant]/reports/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { AdminLivePageError } from "@/components/admin-live-page-error";
+
+export default function AdminReportsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <AdminLivePageError title="Reports could not load" error={error} reset={reset} />;
+}

--- a/apps/web/src/app/admin/[tenant]/reports/loading.tsx
+++ b/apps/web/src/app/admin/[tenant]/reports/loading.tsx
@@ -1,0 +1,42 @@
+import { AdminTopbar } from "@/components/admin-shell";
+
+function Pulse({ className }: { className: string }) {
+  return (
+    <div
+      className={`animate-pulse rounded-md ${className}`}
+      style={{ background: "var(--color-rule)" }}
+    />
+  );
+}
+
+export default function AdminReportsLoading() {
+  return (
+    <>
+      <AdminTopbar kicker="Operator" title="Reports" />
+      <div
+        data-testid="admin-reports-loading"
+        className="flex-1 overflow-y-auto p-7"
+        aria-busy="true"
+        aria-live="polite"
+      >
+        <span className="sr-only">Loading live reports</span>
+        <div className="grid grid-cols-4 gap-3.5 mb-6">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div
+              key={i}
+              className="bg-white rounded-[10px] border p-4"
+              style={{ borderColor: "var(--color-rule)" }}
+            >
+              <Pulse className="h-3 w-24" />
+              <Pulse className="h-7 w-20 mt-3" />
+            </div>
+          ))}
+        </div>
+        <div className="bg-white rounded-[10px] border p-[18px] min-h-[200px]" style={{ borderColor: "var(--color-rule)" }}>
+          <Pulse className="h-5 w-40 mb-4" />
+          <Pulse className="h-36 w-full" />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/admin/[tenant]/reports/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/reports/page.tsx
@@ -39,17 +39,18 @@ export default async function AdminReportsPage({ params }: { params: Promise<{ t
           </div>
         }
       />
-      <div className="flex-1 overflow-y-auto p-7">
+      <div data-testid="admin-reports" className="flex-1 overflow-y-auto p-7">
         {/* Summary cards */}
         <div className="grid grid-cols-4 gap-3.5 mb-6">
           {[
-            { label: "Total revenue", value: `$${reports.revenue.toLocaleString()}`, sub: "6 months" },
-            { label: "Total orders", value: String(reports.orders), sub: "6 months" },
-            { label: "Avg order value", value: `$${reports.avgOrder.toFixed(2)}`, sub: "6 months" },
-            { label: "GST collected", value: `$${reports.gst.toFixed(2)}`, sub: "Remittable" },
+            { id: "revenue", label: "Total revenue", value: `$${reports.revenue.toLocaleString()}`, sub: "6 months" },
+            { id: "orders", label: "Total orders", value: String(reports.orders), sub: "6 months" },
+            { id: "avg", label: "Avg order value", value: `$${reports.avgOrder.toFixed(2)}`, sub: "6 months" },
+            { id: "gst", label: "GST collected", value: `$${reports.gst.toFixed(2)}`, sub: "Remittable" },
           ].map((s) => (
             <div
               key={s.label}
+              data-testid={`reports-kpi-${s.id}`}
               className="bg-white rounded-[10px] border p-4"
               style={{ borderColor: "var(--color-rule)" }}
             >
@@ -63,6 +64,15 @@ export default async function AdminReportsPage({ params }: { params: Promise<{ t
             </div>
           ))}
         </div>
+        {reports.orders === 0 && (
+          <p
+            data-testid="reports-empty-sales"
+            className="text-[12px] mb-6"
+            style={{ color: "var(--color-ink-dim)" }}
+          >
+            No paid orders in the last 6 months.
+          </p>
+        )}
 
         <div className="grid gap-3.5" style={{ gridTemplateColumns: "2fr 1fr" }}>
           {/* Monthly revenue bar chart */}
@@ -114,7 +124,7 @@ export default async function AdminReportsPage({ params }: { params: Promise<{ t
               Revenue by category
             </h3>
             {reports.categoryRevenue.length === 0 ? (
-              <p className="text-[12px]" style={{ color: "var(--color-ink-dim)" }}>
+              <p data-testid="reports-category-empty" className="text-[12px]" style={{ color: "var(--color-ink-dim)" }}>
                 No live category sales yet.
               </p>
             ) : (
@@ -162,7 +172,7 @@ export default async function AdminReportsPage({ params }: { params: Promise<{ t
                     className="py-4 text-center text-[12px]"
                     style={{ color: "var(--color-ink-dim)" }}
                   >
-                    No live GST rows yet.
+                    <span data-testid="reports-gst-empty">No live GST rows yet.</span>
                   </td>
                 </tr>
               ) : (

--- a/apps/web/src/components/admin-live-page-error.tsx
+++ b/apps/web/src/components/admin-live-page-error.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect } from "react";
+import { captureException } from "@/lib/analytics/client";
+
+export function AdminLivePageError({
+  title,
+  error,
+  reset,
+}: {
+  title: string;
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(title, error);
+    captureException(error, { digest: error.digest, page: window.location.pathname });
+  }, [error, title]);
+
+  return (
+    <div
+      data-testid="admin-live-page-error"
+      className="flex-1 overflow-y-auto p-7"
+      role="alert"
+    >
+      <div
+        className="max-w-lg bg-white rounded-[10px] border p-[18px]"
+        style={{ borderColor: "var(--color-rule)" }}
+      >
+        <h2 className="font-serif text-[20px] font-medium m-0" style={{ color: "var(--color-ink)" }}>
+          {title}
+        </h2>
+        <p className="text-[13px] mt-2 mb-4" style={{ color: "var(--color-ink-dim)" }}>
+          Live shop data could not be loaded. Check the database connection and try again.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          className="h-9 px-3.5 text-[12.5px] font-semibold rounded-md text-white"
+          style={{ background: "var(--color-navy-deep)" }}
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -55,6 +55,7 @@ export type LiveDashboardData = {
   avgOrder: number;
   awaitingPickup: number;
   readyOverSevenDays: number;
+  needsAttention: number;
   spark: number[];
   topItems: LiveTopItem[];
   recentOrders: LiveRecentOrder[];
@@ -105,6 +106,11 @@ export function money(value: string | number | null | undefined) {
   const parsed = typeof value === "number" ? value : Number(value ?? 0);
   if (!Number.isFinite(parsed)) return 0;
   return Math.round((parsed + Number.EPSILON) * 100) / 100;
+}
+
+/** Paid shop sales that belong on dashboard KPIs and GST reports. Pending and fully refunded orders are excluded. */
+export function isRecognisedSale(paymentStatus: PaymentStatus) {
+  return paymentStatus === "paid" || paymentStatus === "partially_refunded";
 }
 
 const REPORTING_TIME_ZONE = "Australia/Sydney";
@@ -242,6 +248,7 @@ export async function getLiveDashboardData(tenantId: string): Promise<LiveDashbo
       avgOrder: 0,
       awaitingPickup: 0,
       readyOverSevenDays: 0,
+      needsAttention: 0,
       spark: Array.from({ length: 12 }, () => 0),
       topItems: [],
       recentOrders: [],
@@ -254,34 +261,35 @@ export async function getLiveDashboardData(tenantId: string): Promise<LiveDashbo
   const tomorrowStart = addSydneyDays(today, 1);
   const sevenDaysAgo = addSydneyDays(today, -7);
 
-  const last30Orders = orderRows.filter((order) => {
+  const saleRows = orderRows.filter((order) => isRecognisedSale(order.paymentStatus));
+  const last30Orders = saleRows.filter((order) => {
     return order.createdAt !== null && order.createdAt >= last30Start && order.createdAt < tomorrowStart;
   });
 
   const revenue = money(last30Orders.reduce((sum, order) => sum + money(order.total), 0));
   const orderCount = last30Orders.length;
   const avgOrder = orderCount > 0 ? money(revenue / orderCount) : 0;
-  const awaitingPickup = orderRows.filter((order) => {
+  const awaitingPickup = saleRows.filter((order) => {
     return (
-      order.paymentStatus !== "pending" &&
-      (order.fulfilmentStatus === "to_prepare" ||
-        order.fulfilmentStatus === "needs_attention")
+      order.fulfilmentStatus === "to_prepare" ||
+      order.fulfilmentStatus === "needs_attention"
     );
   }).length;
-  const readyOverSevenDays = orderRows.filter((order) => {
+  const readyOverSevenDays = saleRows.filter((order) => {
     return (
       order.fulfilmentStatus === "ready" &&
       order.readyAt !== null &&
       order.readyAt < sevenDaysAgo
     );
   }).length;
+  const needsAttention = saleRows.filter((order) => order.fulfilmentStatus === "needs_attention").length;
 
   const sparkBuckets = new Map<string, number>();
   for (let i = 0; i < 12; i += 1) {
     const day = addSydneyDays(sparkStart, i);
     sparkBuckets.set(dayKey(day), 0);
   }
-  for (const order of orderRows) {
+  for (const order of saleRows) {
     if (!order.createdAt || order.createdAt < sparkStart || order.createdAt >= tomorrowStart) continue;
     const key = dayKey(order.createdAt);
     if (!sparkBuckets.has(key)) continue;
@@ -333,6 +341,7 @@ export async function getLiveDashboardData(tenantId: string): Promise<LiveDashbo
     avgOrder,
     awaitingPickup,
     readyOverSevenDays,
+    needsAttention,
     spark: Array.from(sparkBuckets.values()),
     topItems: Array.from(topItemsByName.values())
       .sort((a, b) => b.revenue - a.revenue)
@@ -351,11 +360,12 @@ export async function getLiveReportsData(tenantId: string): Promise<LiveReportsD
     return addSydneyMonths(firstMonth, index);
   });
 
-  const orderRows = await db
+  const fetchedRows = await db
     .select()
     .from(orders)
     .where(and(eq(orders.tenantId, tenantId), gte(orders.createdAt, firstMonth), lt(orders.createdAt, nextMonthStart)))
     .orderBy(desc(orders.createdAt));
+  const orderRows = fetchedRows.filter((order) => isRecognisedSale(order.paymentStatus));
 
   const monthlyTotals = new Map(months.map((month) => [monthKey(month), 0]));
   const gstTotals = new Map(months.map((month) => [monthKey(month), 0]));

--- a/apps/web/src/db/queries.ts
+++ b/apps/web/src/db/queries.ts
@@ -113,6 +113,33 @@ export function isRecognisedSale(paymentStatus: PaymentStatus) {
   return paymentStatus === "paid" || paymentStatus === "partially_refunded";
 }
 
+type SaleMoneyOrder = {
+  total: string | number | null | undefined;
+  gst?: string | number | null | undefined;
+  refundedAmountCents?: number | null | undefined;
+};
+
+/** Net recognised-sale dollars after subtracting refundedAmountCents. */
+export function netSaleAmount(order: SaleMoneyOrder) {
+  const gross = money(order.total);
+  const refunded = money((order.refundedAmountCents ?? 0) / 100);
+  return money(Math.max(0, gross - refunded));
+}
+
+/** Remittable GST scaled by the retained (post-refund) share of the order total. */
+export function netGstAmount(order: SaleMoneyOrder) {
+  const gross = money(order.total);
+  if (gross <= 0) return 0;
+  return money(money(order.gst) * (netSaleAmount(order) / gross));
+}
+
+/** Multiply line/category dollars by this to allocate partial refunds across lines. */
+export function saleRetainRatio(order: SaleMoneyOrder) {
+  const gross = money(order.total);
+  if (gross <= 0) return 0;
+  return netSaleAmount(order) / gross;
+}
+
 const REPORTING_TIME_ZONE = "Australia/Sydney";
 const sydneyDatePartsFormatter = new Intl.DateTimeFormat("en-AU", {
   timeZone: REPORTING_TIME_ZONE,
@@ -266,7 +293,7 @@ export async function getLiveDashboardData(tenantId: string): Promise<LiveDashbo
     return order.createdAt !== null && order.createdAt >= last30Start && order.createdAt < tomorrowStart;
   });
 
-  const revenue = money(last30Orders.reduce((sum, order) => sum + money(order.total), 0));
+  const revenue = money(last30Orders.reduce((sum, order) => sum + netSaleAmount(order), 0));
   const orderCount = last30Orders.length;
   const avgOrder = orderCount > 0 ? money(revenue / orderCount) : 0;
   const awaitingPickup = saleRows.filter((order) => {
@@ -293,13 +320,14 @@ export async function getLiveDashboardData(tenantId: string): Promise<LiveDashbo
     if (!order.createdAt || order.createdAt < sparkStart || order.createdAt >= tomorrowStart) continue;
     const key = dayKey(order.createdAt);
     if (!sparkBuckets.has(key)) continue;
-    sparkBuckets.set(key, money((sparkBuckets.get(key) ?? 0) + money(order.total)));
+    sparkBuckets.set(key, money((sparkBuckets.get(key) ?? 0) + netSaleAmount(order)));
   }
 
-  const datedRecentRows = orderRows
+  // Same recognised-sale filter as Paid-order KPIs — pending / fully refunded stay off this list.
+  const datedRecentRows = saleRows
     .filter((order) => order.createdAt !== null)
     .sort((a, b) => b.createdAt!.getTime() - a.createdAt!.getTime());
-  const nullDatedRows = orderRows.filter((order) => order.createdAt === null);
+  const nullDatedRows = saleRows.filter((order) => order.createdAt === null);
   const recentOrders: LiveRecentOrder[] = [...datedRecentRows, ...nullDatedRows].slice(0, 5).map((order) => ({
     id: order.id,
     tenantId: order.tenantId,
@@ -311,11 +339,12 @@ export async function getLiveDashboardData(tenantId: string): Promise<LiveDashbo
     rollClass: order.studentRoll,
     parent: order.parentName,
     email: order.parentEmail,
-    total: money(order.total),
+    total: netSaleAmount(order),
     createdAt: order.createdAt,
   }));
 
   const last30OrderIds = last30Orders.map((order) => order.id);
+  const retainByOrderId = new Map(last30Orders.map((order) => [order.id, saleRetainRatio(order)]));
   const topItemsByName = new Map<string, LiveTopItem>();
   if (last30OrderIds.length > 0) {
     const lineRows = await db
@@ -324,13 +353,14 @@ export async function getLiveDashboardData(tenantId: string): Promise<LiveDashbo
       .where(inArray(orderLines.orderId, last30OrderIds));
 
     for (const line of lineRows) {
+      const retain = retainByOrderId.get(line.orderId) ?? 1;
       const current = topItemsByName.get(line.itemName) ?? {
         name: line.itemName,
         qty: 0,
         revenue: 0,
       };
       current.qty += line.qty;
-      current.revenue = money(current.revenue + money(line.lineTotal));
+      current.revenue = money(current.revenue + money(line.lineTotal) * retain);
       topItemsByName.set(line.itemName, current);
     }
   }
@@ -373,14 +403,14 @@ export async function getLiveReportsData(tenantId: string): Promise<LiveReportsD
   for (const order of orderRows) {
     if (!order.createdAt) continue;
     const key = monthKey(order.createdAt);
-    monthlyTotals.set(key, money((monthlyTotals.get(key) ?? 0) + money(order.total)));
-    gstTotals.set(key, money((gstTotals.get(key) ?? 0) + money(order.gst)));
+    monthlyTotals.set(key, money((monthlyTotals.get(key) ?? 0) + netSaleAmount(order)));
+    gstTotals.set(key, money((gstTotals.get(key) ?? 0) + netGstAmount(order)));
   }
 
-  const revenue = money(orderRows.reduce((sum, order) => sum + money(order.total), 0));
+  const revenue = money(orderRows.reduce((sum, order) => sum + netSaleAmount(order), 0));
   const orderCount = orderRows.length;
   const avgOrder = orderCount > 0 ? money(revenue / orderCount) : 0;
-  const gst = money(orderRows.reduce((sum, order) => sum + money(order.gst), 0));
+  const gst = money(orderRows.reduce((sum, order) => sum + netGstAmount(order), 0));
   const monthlyRevenue = months.map((month) => ({
     month: monthKey(month),
     label: monthLabel(month),
@@ -389,6 +419,7 @@ export async function getLiveReportsData(tenantId: string): Promise<LiveReportsD
 
   const orderIds = orderRows.map((order) => order.id);
   const orderMonthById = new Map<string, string>();
+  const retainByOrderId = new Map(orderRows.map((order) => [order.id, saleRetainRatio(order)]));
   for (const order of orderRows) {
     if (!order.createdAt) continue;
     orderMonthById.set(order.id, monthKey(order.createdAt));
@@ -412,12 +443,14 @@ export async function getLiveReportsData(tenantId: string): Promise<LiveReportsD
       .where(inArray(orderLines.orderId, orderIds));
 
     for (const line of lineRows) {
+      const retain = retainByOrderId.get(line.orderId) ?? 1;
+      const retainedLine = money(money(line.lineTotal) * retain);
       const category = line.category ?? "Uncategorised";
-      categoryTotals.set(category, money((categoryTotals.get(category) ?? 0) + money(line.lineTotal)));
+      categoryTotals.set(category, money((categoryTotals.get(category) ?? 0) + retainedLine));
       if (line.gstFree === true && line.prelovedSkuId != null) {
         const key = orderMonthById.get(line.orderId);
         if (!key) continue;
-        gstFreePrelovedTotals.set(key, money((gstFreePrelovedTotals.get(key) ?? 0) + money(line.lineTotal)));
+        gstFreePrelovedTotals.set(key, money((gstFreePrelovedTotals.get(key) ?? 0) + retainedLine));
       }
     }
   }

--- a/apps/web/src/lib/admin-data.ts
+++ b/apps/web/src/lib/admin-data.ts
@@ -250,6 +250,7 @@ export interface SalesData {
   topItems: { name: string; qty: number; revenue: number }[];
 }
 
+/** Legacy mock KPIs. Admin dashboard and reports read Neon via getLiveDashboardData / getLiveReportsData. */
 export const SALES_DATA: Record<TenantId, SalesData> = {
   imhs: {
     revenue: 18420,

--- a/apps/web/tests/admin/dashboard-live.spec.ts
+++ b/apps/web/tests/admin/dashboard-live.spec.ts
@@ -1,7 +1,30 @@
-import { expect, test } from "playwright/test";
-import { devLogin, TENANT } from "../preloved/helpers";
+import { expect, test, type Page } from "playwright/test";
 
+/**
+ * Live Neon dashboard / reports. Does not start the app.
+ * This worktree's shop rows are demo-academy / demo-blank / rgsh (imhs is not present).
+ *
+ *   pnpm dev:web
+ *   PLAYWRIGHT_BASE_URL=… ADMIN_TENANT=demo-academy pnpm test:admin-dashboard
+ */
+const TENANT = process.env.ADMIN_TENANT ?? "demo-academy";
+const EMPTY_TENANT = process.env.ADMIN_EMPTY_TENANT ?? "demo-blank";
+const OPERATOR_EMAIL =
+  process.env.OPERATOR_EMAIL ?? "operator@demo.uniformorder.online";
 const MOCK_SALES_REVENUE = "$18,420";
+const MOCK_ORDER_ID = "IMHS-04298";
+
+async function devLogin(page: Page, callbackPath: string) {
+  const callbackURL = encodeURIComponent(callbackPath);
+  const email = encodeURIComponent(OPERATOR_EMAIL);
+  await page.goto(`/api/dev/login?email=${email}&callbackURL=${callbackURL}`);
+  await page.waitForURL((url) => !url.pathname.startsWith("/api/dev/login"));
+  if (page.url().includes("/auth/") || page.url().includes("sign-in")) {
+    throw new Error(
+      "Dev login did not establish an admin session. Use pnpm dev:web (NODE_ENV=development) and an operator shop email.",
+    );
+  }
+}
 
 test.describe("Admin dashboard and reports use live Neon data", () => {
   test("dashboard KPIs and recent orders are live, not the leftover mock pack", async ({ page }) => {
@@ -10,6 +33,7 @@ test.describe("Admin dashboard and reports use live Neon data", () => {
     await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
 
     await expect(page.getByTestId("dashboard-kpi-revenue")).toContainText("Revenue · 30d");
+    await expect(page.getByTestId("dashboard-kpi-revenue")).toContainText("Paid orders");
     await expect(page.getByTestId("dashboard-kpi-orders")).toContainText("Orders · 30d");
     await expect(page.getByTestId("dashboard-kpi-avg")).toContainText("Avg order");
     await expect(page.getByTestId("dashboard-kpi-awaiting")).toContainText("Awaiting pickup");
@@ -17,11 +41,10 @@ test.describe("Admin dashboard and reports use live Neon data", () => {
     await expect(page.getByText(MOCK_SALES_REVENUE)).toHaveCount(0);
     await expect(page.getByText("Term 2 catalog")).toHaveCount(0);
     await expect(page.getByText("Stripe payout estimate")).toHaveCount(0);
+    await expect(page.getByText(MOCK_ORDER_ID)).toHaveCount(0);
 
     const recent = page.getByTestId("dashboard-recent-order");
-    const emptyRecent = page.getByTestId("dashboard-recent-empty");
-    await expect(recent.or(emptyRecent).first()).toBeVisible();
-
+    await expect(recent.first()).toBeVisible();
     await expect(page.getByTestId("dashboard-attention")).toBeVisible();
   });
 
@@ -38,5 +61,14 @@ test.describe("Admin dashboard and reports use live Neon data", () => {
     await expect(page.getByText(MOCK_SALES_REVENUE)).toHaveCount(0);
     await expect(page.getByRole("heading", { name: "GST summary (BAS-ready)" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Monthly revenue" })).toBeVisible();
+  });
+
+  test("empty tenant shows empty sales, top-item, and recent-order copy", async ({ page }) => {
+    await devLogin(page, `/admin/${EMPTY_TENANT}/dashboard`);
+    await expect(page.getByTestId("admin-dashboard")).toBeVisible();
+    await expect(page.getByTestId("dashboard-empty-sales")).toContainText("No paid orders in the last 30 days.");
+    await expect(page.getByTestId("dashboard-top-items-empty")).toContainText("No live order lines yet.");
+    await expect(page.getByTestId("dashboard-recent-empty")).toContainText("No live orders yet.");
+    await expect(page.getByText(MOCK_SALES_REVENUE)).toHaveCount(0);
   });
 });

--- a/apps/web/tests/admin/dashboard-live.spec.ts
+++ b/apps/web/tests/admin/dashboard-live.spec.ts
@@ -68,7 +68,15 @@ test.describe("Admin dashboard and reports use live Neon data", () => {
     await expect(page.getByTestId("admin-dashboard")).toBeVisible();
     await expect(page.getByTestId("dashboard-empty-sales")).toContainText("No paid orders in the last 30 days.");
     await expect(page.getByTestId("dashboard-top-items-empty")).toContainText("No live order lines yet.");
-    await expect(page.getByTestId("dashboard-recent-empty")).toContainText("No live orders yet.");
+    await expect(page.getByTestId("dashboard-recent-empty")).toContainText("No paid orders yet.");
+    await expect(page.getByText(MOCK_SALES_REVENUE)).toHaveCount(0);
+  });
+
+  test("empty tenant reports show empty sales and category copy", async ({ page }) => {
+    await devLogin(page, `/admin/${EMPTY_TENANT}/reports`);
+    await expect(page.getByTestId("admin-reports")).toBeVisible();
+    await expect(page.getByTestId("reports-empty-sales")).toContainText("No paid orders in the last 6 months.");
+    await expect(page.getByTestId("reports-category-empty")).toContainText("No live category sales yet.");
     await expect(page.getByText(MOCK_SALES_REVENUE)).toHaveCount(0);
   });
 });

--- a/apps/web/tests/admin/dashboard-live.spec.ts
+++ b/apps/web/tests/admin/dashboard-live.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "playwright/test";
+import { devLogin, TENANT } from "../preloved/helpers";
+
+const MOCK_SALES_REVENUE = "$18,420";
+
+test.describe("Admin dashboard and reports use live Neon data", () => {
+  test("dashboard KPIs and recent orders are live, not the leftover mock pack", async ({ page }) => {
+    await devLogin(page, `/admin/${TENANT}/dashboard`);
+    await expect(page.getByTestId("admin-dashboard")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+
+    await expect(page.getByTestId("dashboard-kpi-revenue")).toContainText("Revenue · 30d");
+    await expect(page.getByTestId("dashboard-kpi-orders")).toContainText("Orders · 30d");
+    await expect(page.getByTestId("dashboard-kpi-avg")).toContainText("Avg order");
+    await expect(page.getByTestId("dashboard-kpi-awaiting")).toContainText("Awaiting pickup");
+
+    await expect(page.getByText(MOCK_SALES_REVENUE)).toHaveCount(0);
+    await expect(page.getByText("Term 2 catalog")).toHaveCount(0);
+    await expect(page.getByText("Stripe payout estimate")).toHaveCount(0);
+
+    const recent = page.getByTestId("dashboard-recent-order");
+    const emptyRecent = page.getByTestId("dashboard-recent-empty");
+    await expect(recent.or(emptyRecent).first()).toBeVisible();
+
+    await expect(page.getByTestId("dashboard-attention")).toBeVisible();
+  });
+
+  test("reports KPIs and GST table read the same live shop totals", async ({ page }) => {
+    await devLogin(page, `/admin/${TENANT}/reports`);
+    await expect(page.getByTestId("admin-reports")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Reports" })).toBeVisible();
+
+    await expect(page.getByTestId("reports-kpi-revenue")).toContainText("Total revenue");
+    await expect(page.getByTestId("reports-kpi-orders")).toContainText("Total orders");
+    await expect(page.getByTestId("reports-kpi-avg")).toContainText("Avg order value");
+    await expect(page.getByTestId("reports-kpi-gst")).toContainText("GST collected");
+
+    await expect(page.getByText(MOCK_SALES_REVENUE)).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: "GST summary (BAS-ready)" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Monthly revenue" })).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:m03-intake-stock": "pnpm --filter web test:m03-intake-stock",
     "test:m04-donate-refund": "pnpm --filter web test:m04-donate-refund",
     "test:m05-parent-preloved-shop": "pnpm --filter web test:m05-parent-preloved-shop",
-    "test:m06-preloved-fulfilment": "pnpm --filter web test:m06-preloved-fulfilment"
+    "test:m06-preloved-fulfilment": "pnpm --filter web test:m06-preloved-fulfilment",
+    "test:admin-dashboard": "pnpm --filter web test:admin-dashboard"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary

Replaces leftover mock attention copy and unpaid/mock KPI totals on the school admin dashboard and reports screens with live Neon shop data.

- Dashboard (`/admin/[tenant]/dashboard`) and reports (`/admin/[tenant]/reports`) read paid orders via `getLiveDashboardData` / `getLiveReportsData`.
- Sales KPIs and recent orders exclude pending and fully refunded orders (`isRecognisedSale`).
- Partially refunded sales net out `refundedAmountCents` from revenue (and scale GST / line category totals by the retained share).
- Adds loading and error UI for both routes, empty-state copy when there are no paid orders, and Stripe Connect readiness in the attention panel.
- Playwright gate (`pnpm test:admin-dashboard`) asserts the mock pack (`$18,420`, `IMHS-04298`, etc.) is gone and empty-tenant copy shows for `demo-blank` (dashboard + reports).

## Review fixes (`d42d0cd`)

- Net partial refunds in dashboard/reports revenue paths.
- Recent orders filtered to recognised sales; empty copy says “No paid orders yet.”
- Added empty-tenant reports Playwright coverage; loading/error oracles left as follow-up.

## Test plan

- [x] `pnpm check-types:web`
- [x] `pnpm dev:web` then `PLAYWRIGHT_BASE_URL=… ADMIN_TENANT=demo-academy pnpm test:admin-dashboard` (4 passed)
- [ ] Spot-check `/admin/demo-academy/dashboard` and `/admin/demo-academy/reports` — KPIs match paid Neon rows after refunds
- [ ] Spot-check `/admin/demo-blank/dashboard` and `/admin/demo-blank/reports` — empty copy
- [ ] Confirm mock strings (`$18,420`, Term 2 catalog, Stripe payout estimate, `IMHS-04298`) do not appear