### PR TITLE
fix(preloved): leftover-only write-off + operator donation inbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,10 @@ pnpm test:m03-intake-stock  # operator accept → stock qty (needs pnpm dev:web)
 pnpm test:m04-donate-refund  # donate note + refund policy (needs pnpm dev:web)
 pnpm test:m05-parent-preloved-shop  # parent preloved shop (needs pnpm dev:web)
 pnpm test:m06-preloved-fulfilment  # pay → stock qty down → pick slip PRELOVED (needs pnpm dev:web)
+pnpm test:preloved-followups      # write-off leftover-only + donation inbox (needs pnpm dev:web)
 ```
 
-Type-checking is the main correctness gate. M03, M04, M05, and M06 add Playwright specs (`apps/web/tests/preloved/m03-intake-stock.spec.ts`, `m04-donate-refund.spec.ts`, `m05-parent-preloved-shop.spec.ts`, `m06-preloved-fulfilment.spec.ts`); they do not boot Next — run `pnpm dev:web` first. Bind with `PLAYWRIGHT_BASE_URL` (then `.dev-local/web.url`, then `PORT`).
+Type-checking is the main correctness gate. Preloved Playwright specs (`apps/web/tests/preloved/m03-intake-stock.spec.ts`, `m04-donate-refund.spec.ts`, `m05-parent-preloved-shop.spec.ts`, `m06-preloved-fulfilment.spec.ts`, `preloved-followups.spec.ts`) do not boot Next — run `pnpm dev:web` first. Bind with `PLAYWRIGHT_BASE_URL` (then `.dev-local/web.url`, then `PORT`).
 
 If `.next` was deleted and generated route types such as `PageProps` / `LayoutProps` are missing, run:
 
@@ -58,7 +59,7 @@ Security headers live in `apps/web/next.config.ts` via `async headers()`. The ap
 - Monorepo: pnpm workspace with one app, `apps/web`.
 - Parent portal: `apps/web/src/app/[tenant]/`, mobile shopping flow in `MobileShell`.
 - Admin portal: `apps/web/src/app/admin/[tenant]/`, desktop operations UI in `AdminShell`.
-- Admin preloved: `apps/web/src/app/admin/[tenant]/preloved/` — Intake, stock, write-offs.
+- Admin preloved: `apps/web/src/app/admin/[tenant]/preloved/` — Intake, stock, inbox, write-offs.
 - Home: `apps/web/src/app/page.tsx`, school picker and one-child auto-redirect.
 - Tenants: `[tenant]` must be `imhs` or `rgsh`; layouts validate via `TENANTS` in `lib/data.ts`. Demo names are synthetic (Illawarra Modern High School, Riverside Academy). Do not use real school slugs, names, or `.nsw.edu.au` shop emails in tests, docs, or examples.
 - Tenant accent color is passed through props and applied inline where needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,10 @@ pnpm test:m03-intake-stock  # operator accept → stock qty (needs pnpm dev:web)
 pnpm test:m04-donate-refund  # donate note + refund policy (needs pnpm dev:web)
 pnpm test:m05-parent-preloved-shop  # parent preloved shop (needs pnpm dev:web)
 pnpm test:m06-preloved-fulfilment  # pay → stock qty down → pick slip PRELOVED (needs pnpm dev:web)
+pnpm test:preloved-followups      # write-off leftover-only + donation inbox (needs pnpm dev:web)
 ```
 
-Type-checking is the main correctness gate. Preloved Playwright specs (`pnpm test:m03-intake-stock`, `pnpm test:m04-donate-refund`, `pnpm test:m05-parent-preloved-shop`, `pnpm test:m06-preloved-fulfilment`; `apps/web/tests/preloved/m03-intake-stock.spec.ts`, `m04-donate-refund.spec.ts`, `m05-parent-preloved-shop.spec.ts`, `m06-preloved-fulfilment.spec.ts`) need `pnpm dev:web` first. They do not boot Next. Bind with `PLAYWRIGHT_BASE_URL` (then `.dev-local/web.url`, then `PORT`).
+Type-checking is the main correctness gate. Preloved Playwright specs (`pnpm test:m03-intake-stock`, `pnpm test:m04-donate-refund`, `pnpm test:m05-parent-preloved-shop`, `pnpm test:m06-preloved-fulfilment`, `pnpm test:preloved-followups`; `apps/web/tests/preloved/m03-intake-stock.spec.ts`, `m04-donate-refund.spec.ts`, `m05-parent-preloved-shop.spec.ts`, `m06-preloved-fulfilment.spec.ts`, `preloved-followups.spec.ts`) need `pnpm dev:web` first. They do not boot Next. Bind with `PLAYWRIGHT_BASE_URL` (then `.dev-local/web.url`, then `PORT`).
 
 ## Deployment
 
@@ -43,7 +44,7 @@ pnpm monorepo with one app: `apps/web` (Next.js 16, App Router, RSC + server act
 ### Portals
 
 - **Parent shop** — `app/[tenant]/` — mobile-first via `MobileShell` (max 430px): catalog → item → cart → checkout → confirmation.
-- **School admin** — `app/admin/[tenant]/` — desktop sidebar via `AdminShell`. Dashboard, Orders (Kanban), Catalog, Preloved (Intake, stock, write-offs), Bulk Upload, Reports, Settings.
+- **School admin** — `app/admin/[tenant]/` — desktop sidebar via `AdminShell`. Dashboard, Orders (Kanban), Catalog, Preloved (Intake, stock, inbox, write-offs), Bulk Upload, Reports, Settings.
 - **Platform console** *(in design — `docs/superpowers/specs/2026-05-09-platform-portal-design.md`)* — `/platform`, gated to platform-admin emails.
 
 `app/page.tsx` is the parent home / school picker.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "test:m05-parent-preloved-shop": "playwright test -c playwright.config.ts tests/preloved/m05-parent-preloved-shop.spec.ts",
     "test:m06-preloved-fulfilment": "playwright test -c playwright.config.ts tests/preloved/m06-preloved-fulfilment.spec.ts",
     "test:admin-dashboard": "playwright test -c playwright.admin.config.ts",
+    "test:preloved-followups": "playwright test -c playwright.config.ts tests/preloved/preloved-followups.spec.ts",
     "demo:seed:dry": "node ../../demo/demo_data/run.mjs seed --dry-run",
     "demo:seed": "node ../../demo/demo_data/run.mjs seed",
     "demo:cleanup": "node ../../demo/demo_data/run.mjs cleanup",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "test:m05-parent-preloved-shop": "playwright test -c playwright.config.ts tests/preloved/m05-parent-preloved-shop.spec.ts",
     "test:m06-preloved-fulfilment": "playwright test -c playwright.config.ts tests/preloved/m06-preloved-fulfilment.spec.ts",
     "test:admin-dashboard": "playwright test -c playwright.admin.config.ts",
-    "test:preloved-followups": "playwright test -c playwright.config.ts tests/preloved/preloved-followups.spec.ts",
+    "test:preloved-followups": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online playwright test -c playwright.config.ts tests/preloved/preloved-followups.spec.ts",
     "demo:seed:dry": "node ../../demo/demo_data/run.mjs seed --dry-run",
     "demo:seed": "node ../../demo/demo_data/run.mjs seed",
     "demo:cleanup": "node ../../demo/demo_data/run.mjs cleanup",

--- a/apps/web/src/app/admin/[tenant]/preloved/inbox/inbox-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/inbox/inbox-client.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Alert, Button, Spinner } from "@heroui/react";
+
+export type DonationInboxNote = {
+  id: string;
+  parentName: string;
+  studentName: string;
+  bagCount: number;
+  createdAt: string;
+};
+
+const COLUMNS = ["Received", "Parent", "Student", "Bags"] as const;
+
+function formatReceived(iso: string, timeZone: string) {
+  return new Date(iso).toLocaleString("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone,
+  });
+}
+
+function bagLabel(count: number) {
+  return count === 1 ? "1 bag" : `${count} bags`;
+}
+
+export function DonationInboxClient({
+  tenantId,
+  timeZone,
+}: {
+  tenantId: string;
+  timeZone: string;
+}) {
+  const [notes, setNotes] = useState<DonationInboxNote[] | null>(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const loadNotes = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/tenant/${tenantId}/preloved/donation-notes`);
+      const data = (await res.json().catch(() => null)) as {
+        error?: string;
+        notes?: DonationInboxNote[];
+      } | null;
+      if (!res.ok) {
+        throw new Error(data?.error ?? "Failed to load donation notes.");
+      }
+      setNotes(Array.isArray(data?.notes) ? data.notes : []);
+    } catch (err) {
+      console.error("Donation inbox load failed:", err);
+      setNotes(null);
+      setError(
+        err instanceof Error ? err.message : "Failed to load donation notes.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [tenantId]);
+
+  useEffect(() => {
+    void loadNotes();
+  }, [loadNotes]);
+
+  return (
+    <div className="flex-1 overflow-y-auto p-7" data-testid="donation-inbox">
+      <p
+        className="text-[13px] mb-4 max-w-2xl"
+        style={{ color: "var(--color-ink-dim)" }}
+      >
+        Drop-off notes from parents. These are messages to the shop, not
+        listings. Washed bags still need intake at the desk.
+      </p>
+
+      {loading ? <InboxLoading /> : null}
+
+      {!loading && error ? (
+        <InboxError message={error} onRetry={() => void loadNotes()} />
+      ) : null}
+
+      {!loading && !error && notes && notes.length === 0 ? (
+        <InboxEmpty />
+      ) : null}
+
+      {!loading && !error && notes && notes.length > 0 ? (
+        <InboxList notes={notes} timeZone={timeZone} />
+      ) : null}
+    </div>
+  );
+}
+
+function InboxLoading() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center text-center py-16 px-6"
+      data-testid="donation-inbox-loading"
+      role="status"
+      aria-live="polite"
+    >
+      <Spinner size="lg" color="current" className="mb-4 text-[var(--color-gold)]" />
+      <p className="text-[13.5px]" style={{ color: "var(--color-ink-dim)" }}>
+        Loading drop-off notes…
+      </p>
+    </div>
+  );
+}
+
+function InboxError({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="max-w-xl" data-testid="donation-inbox-error">
+      <Alert status="danger">
+        <Alert.Indicator />
+        <Alert.Content>
+          <Alert.Title>Could not load the inbox</Alert.Title>
+          <Alert.Description>{message}</Alert.Description>
+        </Alert.Content>
+        <Button
+          size="sm"
+          variant="danger"
+          onPress={onRetry}
+          data-testid="donation-inbox-retry"
+        >
+          Try again
+        </Button>
+      </Alert>
+    </div>
+  );
+}
+
+function InboxEmpty() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center text-center py-16 px-6"
+      data-testid="donation-inbox-empty"
+    >
+      <div
+        className="w-14 h-14 rounded-full flex items-center justify-center mb-4"
+        style={{ background: "var(--color-parchment)", color: "var(--color-gold)" }}
+      >
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="3" y="5" width="18" height="14" rx="2" />
+          <path d="M3 8 L12 13 L21 8" />
+        </svg>
+      </div>
+      <h2
+        className="font-serif text-[22px] font-medium leading-[1.2] mb-2"
+        style={{ color: "var(--color-ink)" }}
+      >
+        No drop-off notes yet
+      </h2>
+      <p
+        className="text-[13.5px] leading-[1.5] max-w-md"
+        style={{ color: "var(--color-ink-dim)" }}
+      >
+        When a parent sends a bag note from Donate, it appears here. Notes do
+        not create stock — accept washed garments on Intake.
+      </p>
+    </div>
+  );
+}
+
+function InboxList({
+  notes,
+  timeZone,
+}: {
+  notes: DonationInboxNote[];
+  timeZone: string;
+}) {
+  return (
+    <div
+      className="bg-white rounded-[10px] border overflow-hidden"
+      style={{ borderColor: "var(--color-rule)" }}
+      data-testid="donation-inbox-list"
+    >
+      <table className="w-full border-collapse text-[13px]">
+        <thead>
+          <tr
+            className="text-[10.5px] uppercase tracking-[0.6px]"
+            style={{ color: "var(--color-ink-dim)" }}
+          >
+            {COLUMNS.map((label) => (
+              <th
+                key={label}
+                className={`py-2.5 px-4 font-bold border-b ${
+                  label === "Bags" ? "text-right" : "text-left"
+                }`}
+                style={{ borderColor: "var(--color-rule)" }}
+              >
+                {label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {notes.map((note, i) => (
+            <tr
+              key={note.id}
+              className="border-b"
+              style={{
+                borderColor: i === notes.length - 1 ? "transparent" : "var(--color-rule)",
+              }}
+              data-testid="donation-inbox-row"
+              data-note-id={note.id}
+            >
+              <td className="py-3 px-4 tnum" style={{ color: "var(--color-ink-dim)" }}>
+                {formatReceived(note.createdAt, timeZone)}
+              </td>
+              <td className="py-3 px-4 font-medium" style={{ color: "var(--color-ink)" }}>
+                {note.parentName}
+              </td>
+              <td className="py-3 px-4" style={{ color: "var(--color-ink)" }}>
+                {note.studentName}
+              </td>
+              <td
+                className="py-3 px-4 text-right tnum"
+                style={{ color: "var(--color-ink)" }}
+                data-testid="donation-inbox-bags"
+              >
+                {bagLabel(note.bagCount)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/[tenant]/preloved/inbox/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/inbox/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from "next/navigation";
+import { getTenant, toTenantBrand } from "@/db/queries";
+import { getPrelovedSettings } from "@/db/preloved-queries";
+import { DonationInboxClient } from "./inbox-client";
+
+export default async function AdminPrelovedInboxPage({
+  params,
+}: {
+  params: Promise<{ tenant: string }>;
+}) {
+  const { tenant: tid } = await params;
+  const tenantRecord = await getTenant(tid);
+  if (!tenantRecord) notFound();
+
+  const settings = await getPrelovedSettings(tenantRecord.id);
+  if (!settings.prelovedEnabled) notFound();
+
+  const tenant = toTenantBrand(tenantRecord);
+
+  return <DonationInboxClient tenantId={tid} timeZone={tenant.timezone} />;
+}

--- a/apps/web/src/app/admin/[tenant]/preloved/preloved-section-tabs.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/preloved-section-tabs.tsx
@@ -8,6 +8,7 @@ import { Tabs } from "@heroui/react";
 const PRELOVED_SECTION_TABS = [
   { id: "intake", label: "Intake" },
   { id: "stock", label: "Stock" },
+  { id: "inbox", label: "Inbox" },
   { id: "write-offs", label: "Write-offs" },
 ] as const;
 

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/donation-notes/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/donation-notes/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getTenant } from "@/db/queries";
+import { getPrelovedSettings, listDonationNotes } from "@/db/preloved-queries";
+import { ensureTenantAccess, requireSessionUser } from "@/lib/auth/authorization";
+
+function mapNote(row: {
+  id: string;
+  parentName: string;
+  studentName: string;
+  bagCount: number;
+  createdAt: Date;
+}) {
+  return {
+    id: row.id,
+    parentName: row.parentName,
+    studentName: row.studentName,
+    bagCount: row.bagCount,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+// GET /api/tenant/:tenantId/preloved/donation-notes — operator inbox.
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ tenantId: string }> },
+) {
+  const { tenantId } = await params;
+  try {
+    const authResult = await requireSessionUser();
+    if ("response" in authResult) return authResult.response;
+
+    const tenant = await getTenant(tenantId);
+    if (!tenant) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
+    const tenantAccessResponse = ensureTenantAccess(authResult.user, tenant.shopEmail);
+    if (tenantAccessResponse) return tenantAccessResponse;
+
+    const settings = await getPrelovedSettings(tenantId);
+    if (!settings.prelovedEnabled) {
+      return NextResponse.json({ error: "Preloved is not enabled" }, { status: 404 });
+    }
+
+    const notes = await listDonationNotes(tenantId);
+    return NextResponse.json({ notes: notes.map(mapNote) });
+  } catch (err) {
+    console.error("GET /api/tenant/[tenantId]/preloved/donation-notes error:", err);
+    return NextResponse.json({ error: "Failed to load donation notes" }, { status: 500 });
+  }
+}

--- a/apps/web/src/db/preloved-queries.ts
+++ b/apps/web/src/db/preloved-queries.ts
@@ -1,9 +1,9 @@
 /**
- * Preloved settings / SKU / intake / parent-shop / paid-decrement helpers.
+ * Preloved settings / SKU / intake / donation-note / parent-shop / paid-decrement helpers.
  * Kept out of queries.ts so GST/report work in queries.ts does not clash.
  */
 import { cache } from "react";
-import { and, asc, desc, eq, gt, gte, isNotNull, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, isNotNull, lt, sql } from "drizzle-orm";
 import {
   DEFAULT_PRICE_FRACTION_OF_NEW,
   PRELOVED_INTAKE_MODE,
@@ -32,7 +32,10 @@ import {
   type ShopPrelovedSku,
   type WriteOffPrelovedSkuInput,
 } from "@/lib/preloved";
-import { type InsertDonationNoteInput } from "@/lib/preloved-donate";
+import {
+  type DonationNoteListItem,
+  type InsertDonationNoteInput,
+} from "@/lib/preloved-donate";
 import { policyTextWithPrelovedRefundClause } from "@/lib/preloved-refund-policy";
 import { logAuditEvent } from "@/lib/audit/log";
 import type { AuditActorRole } from "@/lib/audit/types";
@@ -222,6 +225,27 @@ export async function insertDonationNote(
     })
     .returning();
   return row;
+}
+
+const DONATION_NOTE_INBOX_LIMIT = 200;
+
+/** Newest parent drop-off notes for the operator inbox. */
+export async function listDonationNotes(
+  tenantId: string,
+): Promise<DonationNoteListItem[]> {
+  const rows = await db
+    .select({
+      id: prelovedDonationNotes.id,
+      parentName: prelovedDonationNotes.parentName,
+      studentName: prelovedDonationNotes.studentName,
+      bagCount: prelovedDonationNotes.bagCount,
+      createdAt: prelovedDonationNotes.createdAt,
+    })
+    .from(prelovedDonationNotes)
+    .where(eq(prelovedDonationNotes.tenantId, tenantId))
+    .orderBy(desc(prelovedDonationNotes.createdAt))
+    .limit(DONATION_NOTE_INBOX_LIMIT);
+  return rows;
 }
 
 function variantHasSize(sizes: unknown, size: string): boolean {
@@ -465,50 +489,6 @@ function isExpiredForWriteOff(sku: PrelovedSkuRow, now: Date): boolean {
   return sku.expiresAt != null && sku.expiresAt < now;
 }
 
-async function findWrittenOffEventForListing(
-  tenantId: string,
-  skuId: string,
-  listedAt: Date,
-): Promise<PrelovedIntakeEventRow | undefined> {
-  const [row] = await db
-    .select()
-    .from(prelovedIntakeEvents)
-    .where(
-      and(
-        eq(prelovedIntakeEvents.tenantId, tenantId),
-        eq(prelovedIntakeEvents.prelovedSkuId, skuId),
-        eq(prelovedIntakeEvents.action, "written_off"),
-        gte(prelovedIntakeEvents.createdAt, listedAt),
-      ),
-    )
-    .orderBy(desc(prelovedIntakeEvents.createdAt))
-    .limit(1);
-  return row;
-}
-
-/** Accepted qty this listing. M03 has no sale decrements, so this is the write-off qty on retry. */
-async function acceptedQtyForListing(
-  tenantId: string,
-  skuId: string,
-  listedAt: Date,
-): Promise<number> {
-  const [row] = await db
-    .select({
-      total: sql<number>`coalesce(sum(${prelovedIntakeEvents.qty}), 0)`,
-    })
-    .from(prelovedIntakeEvents)
-    .where(
-      and(
-        eq(prelovedIntakeEvents.tenantId, tenantId),
-        eq(prelovedIntakeEvents.prelovedSkuId, skuId),
-        eq(prelovedIntakeEvents.action, "accepted"),
-        gte(prelovedIntakeEvents.createdAt, listedAt),
-      ),
-    );
-  const total = Number(row?.total ?? 0);
-  return Number.isFinite(total) ? total : 0;
-}
-
 function writtenOffEventInput(
   input: WriteOffPrelovedSkuInput,
   sku: PrelovedSkuRow,
@@ -527,10 +507,12 @@ function writtenOffEventInput(
 }
 
 /**
- * Zero expired stock and record written_off.
+ * Zero leftover expired stock and record that leftover as written_off.
  * neon-http cannot wrap the qty update + event insert in an interactive
- * transaction. If qty is already 0 and this listing has no written_off
- * event, retry inserts the missing event instead of 409.
+ * transaction. Qty already 0 is treated as cleared (sold or previously
+ * written off). Do not reconstruct written_off from accepted-this-listing —
+ * paid CAS zeros qty without an intake sold event, so that sum would count
+ * sold units as written off.
  */
 export async function writeOffPrelovedSku(
   input: WriteOffPrelovedSkuInput,
@@ -547,54 +529,37 @@ export async function writeOffPrelovedSku(
     )
     .limit(1);
 
-  if (!existing || !isExpiredForWriteOff(existing, now)) {
+  if (
+    !existing ||
+    existing.qtyOnHand <= 0 ||
+    !isExpiredForWriteOff(existing, now)
+  ) {
     throw new PrelovedWriteOffNotEligibleError();
   }
 
-  if (existing.qtyOnHand > 0) {
-    const qtyWrittenOff = existing.qtyOnHand;
-    const [sku] = await db
-      .update(prelovedSkus)
-      .set({ qtyOnHand: 0 })
-      .where(
-        and(
-          eq(prelovedSkus.id, existing.id),
-          eq(prelovedSkus.tenantId, input.tenantId),
-          eq(prelovedSkus.qtyOnHand, qtyWrittenOff),
-          isNotNull(prelovedSkus.expiresAt),
-          lt(prelovedSkus.expiresAt, now),
-        ),
-      )
-      .returning();
+  const qtyWrittenOff = existing.qtyOnHand;
+  const [sku] = await db
+    .update(prelovedSkus)
+    .set({ qtyOnHand: 0 })
+    .where(
+      and(
+        eq(prelovedSkus.id, existing.id),
+        eq(prelovedSkus.tenantId, input.tenantId),
+        eq(prelovedSkus.qtyOnHand, qtyWrittenOff),
+        isNotNull(prelovedSkus.expiresAt),
+        lt(prelovedSkus.expiresAt, now),
+      ),
+    )
+    .returning();
 
-    if (!sku) {
-      throw new PrelovedWriteOffNotEligibleError();
-    }
-
-    const event = await insertPrelovedIntakeEvent(
-      writtenOffEventInput(input, sku, qtyWrittenOff),
-    );
-    return { sku, event, qtyWrittenOff };
-  }
-
-  const existingEvent = await findWrittenOffEventForListing(
-    input.tenantId,
-    existing.id,
-    existing.listedAt,
-  );
-  if (existingEvent) {
+  if (!sku) {
     throw new PrelovedWriteOffNotEligibleError();
   }
 
-  const qtyWrittenOff = await acceptedQtyForListing(
-    input.tenantId,
-    existing.id,
-    existing.listedAt,
-  );
   const event = await insertPrelovedIntakeEvent(
-    writtenOffEventInput(input, existing, qtyWrittenOff),
+    writtenOffEventInput(input, sku, qtyWrittenOff),
   );
-  return { sku: existing, event, qtyWrittenOff };
+  return { sku, event, qtyWrittenOff };
 }
 
 export async function listInStockPrelovedSkus(

--- a/apps/web/src/lib/preloved-donate.ts
+++ b/apps/web/src/lib/preloved-donate.ts
@@ -13,3 +13,11 @@ export type InsertDonationNoteInput = {
   studentName: string;
   bagCount: number;
 };
+
+export type DonationNoteListItem = {
+  id: string;
+  parentName: string;
+  studentName: string;
+  bagCount: number;
+  createdAt: Date;
+};

--- a/apps/web/tests/preloved/preloved-followups.spec.ts
+++ b/apps/web/tests/preloved/preloved-followups.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Preloved follow-ups: write-off leftover-only + operator donation inbox.
+ *
+ * Does not start the app. From repo root:
+ *   pnpm dev:web
+ *   PLAYWRIGHT_BASE_URL=http://127.0.0.1:<port> pnpm test:preloved-followups
+ */
+import { expect, test } from "playwright/test";
+import { TENANT, devLogin, ensurePrelovedEnabled } from "./helpers";
+
+const ADMIN_VIEWPORT = { width: 1440, height: 900 };
+const MISSING_SKU = "00000000-0000-4000-8000-000000000000";
+
+test.describe("Preloved follow-ups", () => {
+  test.describe.configure({ mode: "serial" });
+  test.use({ viewport: ADMIN_VIEWPORT });
+
+  test("qty-zero write-off is not eligible and does not invent written_off qty", async ({
+    page,
+  }) => {
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    await ensurePrelovedEnabled(page);
+
+    const res = await page.request.post(
+      `/api/tenant/${TENANT}/preloved/skus/${MISSING_SKU}/write-off`,
+    );
+    const body = (await res.json()) as {
+      error?: string;
+      code?: string;
+      qtyWrittenOff?: number;
+      event?: { qty?: number };
+    };
+    expect(res.status()).toBe(409);
+    expect(body.code).toBe("write_off_not_eligible");
+    expect(body.qtyWrittenOff).toBeUndefined();
+    expect(body.event).toBeUndefined();
+  });
+
+  test("donation inbox shows loading, error, empty, and a posted note", async ({
+    page,
+  }) => {
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    await ensurePrelovedEnabled(page);
+
+    const parent = `Inbox Parent ${Date.now()}`;
+    const student = `Inbox Student ${Date.now()}`;
+
+    const donate = await page.request.post(`/api/tenant/${TENANT}/preloved/donate`, {
+      data: { parentName: parent, studentName: student, bagCount: 2 },
+    });
+    expect(donate.ok()).toBeTruthy();
+
+    await page.route(`**/api/tenant/${TENANT}/preloved/donation-notes`, async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 750));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ notes: [] }),
+      });
+    });
+    await page.goto(`/admin/${TENANT}/preloved/inbox`);
+    await expect(page.getByTestId("donation-inbox-loading")).toBeVisible();
+    await expect(page.getByTestId("donation-inbox-empty")).toBeVisible();
+
+    await page.unroute(`**/api/tenant/${TENANT}/preloved/donation-notes`);
+    await page.route(`**/api/tenant/${TENANT}/preloved/donation-notes`, async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Failed to load donation notes" }),
+      });
+    });
+    await page.reload();
+    await expect(page.getByTestId("donation-inbox-error")).toBeVisible();
+    await expect(page.getByText("Could not load the inbox")).toBeVisible();
+
+    await page.unroute(`**/api/tenant/${TENANT}/preloved/donation-notes`);
+    await page.getByTestId("donation-inbox-retry").click();
+    await expect(page.getByTestId("donation-inbox-list")).toBeVisible();
+    await expect(page.getByText(parent, { exact: true })).toBeVisible();
+    await expect(page.getByText(student, { exact: true })).toBeVisible();
+    await expect(page.getByText("2 bags").first()).toBeVisible();
+  });
+});

--- a/apps/web/tests/preloved/preloved-followups.spec.ts
+++ b/apps/web/tests/preloved/preloved-followups.spec.ts
@@ -4,6 +4,9 @@
  * Does not start the app. From repo root:
  *   pnpm dev:web
  *   PLAYWRIGHT_BASE_URL=http://127.0.0.1:<port> pnpm test:preloved-followups
+ *
+ * Defaults to demo-academy (live Neon has no imhs). Override with
+ * PRELOVED_TENANT / OPERATOR_EMAIL.
  */
 import { expect, test } from "playwright/test";
 import { TENANT, devLogin, ensurePrelovedEnabled } from "./helpers";

--- a/decisions/INDEX.md
+++ b/decisions/INDEX.md
@@ -73,5 +73,7 @@
 - 2026-09-07 · 65ef5136 · build:M06 · orders.userId is null for non-uuid dev-login ids
 - 2026-09-07 · c0f472c8 · build:M06 · Tick last-unit AC from sequential oversell plus CAS; no concurrent e2e
 
-## Misc  ([decisions/misc.md](misc.md)) — 1
+## Misc  ([decisions/misc.md](misc.md)) — 3
 - 2026-09-06 · 2f31cd1c · onboard · HeroUI OSS only — this repo is open source
+- 2026-09-11 · 47952782 · build:followup · Write-off records leftover qty only; qty 0 is already cleared
+- 2026-09-11 · 34541772 · build:followup · Operator inbox lists preloved_donation_notes under Preloved

--- a/decisions/misc.md
+++ b/decisions/misc.md
@@ -16,3 +16,27 @@
 - **Risks / known issues:** A 0000 rerun refreshes the managed block and re-states the Pro MCP line; the override section after the managed block must stay. Agents that only read the managed block could still try Pro.
 - **Links:** AGENTS.md (Project exception + override); CLAUDE.md (same); apps/web/package.json (@heroui/react, no @heroui-pro/react)
 
+## Write-off records leftover qty only; qty 0 is already cleared
+- **ID:** 47952782-a864-44b0-abce-b2b840917e02
+- **Date:** 2026-09-11T14:50:39Z
+- **Stage:** build:followup
+- **Decision:** writeOffPrelovedSku writes leftover qty_on_hand as written_off. Qty already 0 throws PrelovedWriteOffNotEligibleError (409). It no longer reconstructs written_off from accepted-this-listing.
+- **Why:** Paid CAS zeros qty without an intake sold event. Summing accepted-this-listing on retry counted sold units as written off.
+- **Alternatives:** Subtract paid decrements (table has no per-SKU qty); insert written_off qty 0; keep accepted-sum retry for missing events.
+- **Pros:** Sold units cannot be audited as written off. Happy-path leftover write-off unchanged.
+- **Cons:** A qty update that succeeds and then drops the event no longer backfills written_off qty from accepted.
+- **Risks / known issues:** Webhook paid-without-order still leaves qty 0 with no order line; that path is already cleared, not written off.
+- **Links:** apps/web/src/db/preloved-queries.ts writeOffPrelovedSku; specs/_logs/OPEN_QUESTIONS.md M06 write-off retry
+
+## Operator inbox lists preloved_donation_notes under Preloved
+- **ID:** 34541772-a789-4bf5-af09-96db59566a0a
+- **Date:** 2026-09-11T14:50:39Z
+- **Stage:** build:followup
+- **Decision:** Admin tab Inbox at /admin/[tenant]/preloved/inbox fetches GET /api/tenant/:tenantId/preloved/donation-notes. Client covers loading, error+retry, empty, and list. Notes remain messages, not SKUs.
+- **Why:** M04 persisted bag notes without a SELECT/admin list. Spec calls them a message to operators.
+- **Alternatives:** RSC-only page with loading.tsx; email the shop; mark-as-read.
+- **Pros:** Operators can read drop-off notes. Empty/loading/error are first-class.
+- **Cons:** No unread state or archive in this slice.
+- **Risks / known issues:** Inbox lists the newest 200 notes only.
+- **Links:** apps/web/src/app/admin/[tenant]/preloved/inbox; apps/web/src/app/api/tenant/[tenantId]/preloved/donation-notes/route.ts
+

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:m04-donate-refund": "pnpm --filter web test:m04-donate-refund",
     "test:m05-parent-preloved-shop": "pnpm --filter web test:m05-parent-preloved-shop",
     "test:m06-preloved-fulfilment": "pnpm --filter web test:m06-preloved-fulfilment",
-    "test:admin-dashboard": "pnpm --filter web test:admin-dashboard"
+    "test:admin-dashboard": "pnpm --filter web test:admin-dashboard",
+    "test:preloved-followups": "pnpm --filter web test:preloved-followups"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/specs/_logs/OPEN_QUESTIONS.md
+++ b/specs/_logs/OPEN_QUESTIONS.md
@@ -23,8 +23,8 @@
 - [ ] **(plan)** School-fee credit as a payout option — raised: 2026-09-06, by: plan
       context: Phase 2 only. Not in M01–M06.
 
-- [ ] **(M04)** Operators have no inbox to read `preloved_donation_notes` — raised: 2026-09-07, by: build:M04
-      context: Bag notes persist without creating a SKU (AC met). Spec calls them a message to operators; M04 did not add a SELECT/admin list. Non-blocking for donate/refund copy. Resolve in a later admin slice if P&Cs need to see drop-off notes.
+- [x] **(M04)** Operators have no inbox to read `preloved_donation_notes` — raised: 2026-09-07, by: build:M04
+      context: Resolved 2026-09-12. Operator inbox at `/admin/[tenant]/preloved/inbox` lists `preloved_donation_notes` (empty / loading / error). Notes still do not create a SKU.
 
 - [ ] **(M05)** Parent-shop client islands do not hydrate in Playwright — raised: 2026-09-07, by: build:M05
       context: Qty stepper and Add to cart stay dead SSR (`data-hydrated=false`) on Chromium and Chrome channel. Same on existing `/item/polo`. Mixed-cart + qty-cap ACs are code-complete but not runtime-proven. RSC filter/badge/PDP copy/disabled pass. Needs a hydration/HMR/CSP investigation before marking M05 complete.
@@ -41,8 +41,8 @@
 - [x] **(M06)** Webhook snapshot decrement can drop qty with no order row — raised: 2026-09-07, by: review:M06
       context: Kept snapshot-first (decision `580c7676`). 3DS paid-without-order is ops refund, not auto-refund.
 
-- [ ] **(M06)** Write-off retry can count sold units as written_off — raised: 2026-09-07, by: review:M06
-      context: `writeOffPrelovedSku` qty=0 path still sums accepted-this-listing (M03 “no sale decrements”). Paid CAS zeros `qty_on_hand` without an intake `sold` event. Happy path with leftover qty is fine.
+- [x] **(M06)** Write-off retry can count sold units as written_off — raised: 2026-09-07, by: review:M06
+      context: Resolved 2026-09-12. Qty already 0 is treated as cleared (409). Write-off records leftover `qty_on_hand` only; it no longer reconstructs from accepted-this-listing.
 
 - [x] **(M06)** Apply drizzle 0021 on Neon — raised: 2026-09-07, by: build:M06
       context: Applied `CREATE TABLE IF NOT EXISTS preloved_paid_decrements` via neon-http (full `drizzle-orm` migrator blocked on already-applied 0019). Journaled as `manual_0021_preloved_paid_decrements`.


### PR DESCRIPTION
## Summary

- **Write-off leftover-only:** `writeOffPrelovedSku` records only leftover `qty_on_hand` as written off. Qty already 0 is treated as cleared (409) and no longer reconstructs `written_off` from accepted-this-listing (which counted sold units after paid CAS zeroed stock without an intake sold event).
- **Operator donation inbox:** New Preloved **Inbox** tab at `/admin/[tenant]/preloved/inbox` lists parent drop-off notes via `GET /api/tenant/:tenantId/preloved/donation-notes`, with loading, empty, and error+retry states.

## Test plan

- [x] `pnpm test:preloved-followups` (against running `pnpm dev:web`, demo-academy)
- [x] `pnpm check-types:web`
- [ ] Manually: write off an expired SKU with leftover qty → event qty matches leftover only
- [ ] Manually: sold-to-zero SKU write-off → 409, no invented written_off qty
- [ ] Manually: Inbox loading / empty / error+retry / list after Donate note