### PR TITLE
feat(phase2): consignment lots and school-fee credit marks

### DIFF
--- a/apps/web/drizzle/0022_consignment_lots.sql
+++ b/apps/web/drizzle/0022_consignment_lots.sql
@@ -1,0 +1,25 @@
+CREATE TYPE "public"."consignment_payout_preference" AS ENUM('eft', 'school_fee_credit', 'donate_proceeds');--> statement-breakpoint
+CREATE TYPE "public"."consignment_unsold_preference" AS ENUM('donate', 'collect');--> statement-breakpoint
+CREATE TYPE "public"."consignment_lot_payout_status" AS ENUM('pending', 'school_fee_credited', 'eft_paid', 'donated_proceeds');--> statement-breakpoint
+CREATE TABLE "consignment_lots" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" text NOT NULL REFERENCES "tenants"("id") ON DELETE cascade,
+	"ticket_code" text NOT NULL,
+	"family_name" text NOT NULL,
+	"student_name" text NOT NULL,
+	"email" text NOT NULL,
+	"mobile" text NOT NULL,
+	"payout_preference" "consignment_payout_preference" NOT NULL,
+	"bank_bsb" text,
+	"bank_account_name" text,
+	"bank_account_number" text,
+	"unsold_preference" "consignment_unsold_preference" NOT NULL,
+	"items" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"terms_accepted_at" timestamp with time zone NOT NULL,
+	"payout_status" "consignment_lot_payout_status" DEFAULT 'pending' NOT NULL,
+	"payout_marked_at" timestamp with time zone,
+	"payout_marked_by" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX "consignment_lots_tenant_ticket_unique" ON "consignment_lots" USING btree ("tenant_id","ticket_code");--> statement-breakpoint
+CREATE INDEX "idx_consignment_lots_tenant_time" ON "consignment_lots" USING btree ("tenant_id","created_at");

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1788900000000,
       "tag": "0021_preloved_paid_decrements",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1789000000000,
+      "tag": "0022_consignment_lots",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "test:m05-parent-hydration": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online PRELOVED_ITEM_ID=rvra-polo-ss PRELOVED_ITEM_NAME='Polo Shirt — Short Sleeve' playwright test -c playwright.config.ts tests/preloved/m05-parent-hydration.spec.ts",
     "test:m06-last-unit-race": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online PRELOVED_ITEM_ID=rvra-polo-ss PRELOVED_ITEM_NAME='Polo Shirt — Short Sleeve' playwright test -c playwright.config.ts tests/preloved/m06-last-unit-race.spec.ts",
     "test:preloved-test-gaps": "pnpm test:m05-parent-hydration && pnpm test:m06-last-unit-race",
+    "test:m07-consignment-school-fee": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online playwright test -c playwright.config.ts tests/preloved/m07-consignment-school-fee.spec.ts",
     "demo:seed:dry": "node ../../demo/demo_data/run.mjs seed --dry-run",
     "demo:seed": "node ../../demo/demo_data/run.mjs seed",
     "demo:cleanup": "node ../../demo/demo_data/run.mjs cleanup",

--- a/apps/web/src/app/[tenant]/preloved/consign/consign-screen.tsx
+++ b/apps/web/src/app/[tenant]/preloved/consign/consign-screen.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import {
+  Button,
+  Description,
+  FieldError,
+  Form,
+  Input,
+  Label,
+  TextField,
+} from "@heroui/react";
+import {
+  formatCommissionPercent,
+  type ConsignmentPayoutPreference,
+  type ConsignmentUnsoldPreference,
+} from "@/lib/preloved-consignment";
+
+async function readApiError(res: Response, fallback: string) {
+  try {
+    const data = (await res.json()) as { error?: unknown };
+    return typeof data.error === "string" ? data.error : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+type ItemRow = { garment: string; size: string };
+
+export function ConsignScreen({
+  tenantId,
+  accent,
+  commissionBps,
+}: {
+  tenantId: string;
+  accent: string;
+  commissionBps: number;
+}) {
+  const [familyName, setFamilyName] = useState("");
+  const [studentName, setStudentName] = useState("");
+  const [email, setEmail] = useState("");
+  const [mobile, setMobile] = useState("");
+  const [payoutPreference, setPayoutPreference] =
+    useState<ConsignmentPayoutPreference>("school_fee_credit");
+  const [bankBsb, setBankBsb] = useState("");
+  const [bankAccountName, setBankAccountName] = useState("");
+  const [bankAccountNumber, setBankAccountNumber] = useState("");
+  const [unsoldPreference, setUnsoldPreference] =
+    useState<ConsignmentUnsoldPreference>("donate");
+  const [items, setItems] = useState<ItemRow[]>([{ garment: "", size: "" }]);
+  const [termsAccepted, setTermsAccepted] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+  const [ticketCode, setTicketCode] = useState("");
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (pending) return;
+    setError("");
+    setTicketCode("");
+
+    if (!termsAccepted) {
+      setError("You must agree to the shop consignment terms.");
+      return;
+    }
+
+    setPending(true);
+    try {
+      const res = await fetch(`/api/tenant/${tenantId}/preloved/consign`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          familyName: familyName.trim(),
+          studentName: studentName.trim(),
+          email: email.trim(),
+          mobile: mobile.trim(),
+          payoutPreference,
+          bankBsb: payoutPreference === "eft" ? bankBsb.trim() : null,
+          bankAccountName:
+            payoutPreference === "eft" ? bankAccountName.trim() : null,
+          bankAccountNumber:
+            payoutPreference === "eft" ? bankAccountNumber.trim() : null,
+          unsoldPreference,
+          items: items.map((item) => ({
+            garment: item.garment.trim(),
+            size: item.size.trim(),
+          })),
+          termsAccepted: true,
+        }),
+      });
+      if (!res.ok) {
+        setError(await readApiError(res, "Could not submit the consignment form."));
+        return;
+      }
+      const data = (await res.json()) as { ticketCode?: string };
+      setTicketCode(data.ticketCode ?? "");
+      setFamilyName("");
+      setStudentName("");
+      setEmail("");
+      setMobile("");
+      setBankBsb("");
+      setBankAccountName("");
+      setBankAccountNumber("");
+      setItems([{ garment: "", size: "" }]);
+      setTermsAccepted(false);
+      setPayoutPreference("school_fee_credit");
+      setUnsoldPreference("donate");
+    } catch (err) {
+      console.error("Consign form failed:", err);
+      setError("Could not submit the consignment form.");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <>
+      {error ? (
+        <div
+          className="mb-3 text-[12.5px] px-3 py-2 rounded"
+          style={{ background: "#FEF2F2", color: "#B91C1C" }}
+          role="alert"
+          data-testid="consign-form-error"
+        >
+          {error}
+        </div>
+      ) : null}
+      {ticketCode ? (
+        <div
+          className="mb-3 text-[12.5px] px-3 py-2 rounded"
+          style={{ background: "#E5F0E7", color: "var(--color-success)" }}
+          role="status"
+          data-testid="consign-form-success"
+        >
+          Consignment lot received. Write ticket{" "}
+          <span className="font-semibold tnum" data-testid="consign-ticket-code">
+            {ticketCode}
+          </span>{" "}
+          on the bag tag and drop the washed bag at the shop. This is not a
+          listing — volunteers still inspect each garment.
+        </div>
+      ) : null}
+
+      <p className="text-sm text-ink-dim mb-4">
+        Shop commission is {formatCommissionPercent(commissionBps)} of the sale
+        price. Proceeds are paid by the school (EFT, school-fee credit, or
+        donated) — not through Stripe to parents.
+      </p>
+
+      <Form
+        className="flex flex-col gap-4"
+        onSubmit={handleSubmit}
+        aria-label="Consignment form"
+        data-testid="consign-form"
+      >
+        <TextField
+          fullWidth
+          isRequired
+          name="familyName"
+          value={familyName}
+          onChange={setFamilyName}
+          maxLength={80}
+          data-testid="consign-family"
+        >
+          <Label>Family name</Label>
+          <Input autoComplete="family-name" />
+          <FieldError />
+        </TextField>
+
+        <TextField
+          fullWidth
+          isRequired
+          name="studentName"
+          value={studentName}
+          onChange={setStudentName}
+          maxLength={80}
+          data-testid="consign-student"
+        >
+          <Label>Student name</Label>
+          <Input autoComplete="off" />
+          <FieldError />
+        </TextField>
+
+        <TextField
+          fullWidth
+          isRequired
+          name="email"
+          type="email"
+          value={email}
+          onChange={setEmail}
+          maxLength={120}
+          data-testid="consign-email"
+        >
+          <Label>Email</Label>
+          <Input autoComplete="email" />
+          <FieldError />
+        </TextField>
+
+        <TextField
+          fullWidth
+          isRequired
+          name="mobile"
+          value={mobile}
+          onChange={setMobile}
+          maxLength={40}
+          data-testid="consign-mobile"
+        >
+          <Label>Mobile</Label>
+          <Input autoComplete="tel" />
+          <FieldError />
+        </TextField>
+
+        <fieldset className="space-y-2" data-testid="consign-payout-preference">
+          <legend className="text-[13px] font-semibold text-ink mb-1">
+            Payout preference
+          </legend>
+          {(
+            [
+              ["school_fee_credit", "Credit school fees"],
+              ["eft", "EFT to bank account"],
+              ["donate_proceeds", "Donate proceeds to the P&C"],
+            ] as const
+          ).map(([value, label]) => (
+            <label key={value} className="flex items-center gap-2 text-sm text-ink">
+              <input
+                type="radio"
+                name="payoutPreference"
+                value={value}
+                checked={payoutPreference === value}
+                onChange={() => setPayoutPreference(value)}
+                data-testid={`consign-payout-${value}`}
+              />
+              {label}
+            </label>
+          ))}
+        </fieldset>
+
+        {payoutPreference === "eft" ? (
+          <div className="space-y-3 rounded-lg border border-rule p-3">
+            <TextField
+              fullWidth
+              isRequired
+              name="bankBsb"
+              value={bankBsb}
+              onChange={setBankBsb}
+              data-testid="consign-bank-bsb"
+            >
+              <Label>BSB</Label>
+              <Input className="tnum" inputMode="numeric" placeholder="000000" />
+              <Description>Operator-only. Not shown in the parent shop.</Description>
+              <FieldError />
+            </TextField>
+            <TextField
+              fullWidth
+              isRequired
+              name="bankAccountName"
+              value={bankAccountName}
+              onChange={setBankAccountName}
+              data-testid="consign-bank-name"
+            >
+              <Label>Account name</Label>
+              <Input />
+              <FieldError />
+            </TextField>
+            <TextField
+              fullWidth
+              isRequired
+              name="bankAccountNumber"
+              value={bankAccountNumber}
+              onChange={setBankAccountNumber}
+              data-testid="consign-bank-number"
+            >
+              <Label>Account number</Label>
+              <Input className="tnum" inputMode="numeric" />
+              <FieldError />
+            </TextField>
+          </div>
+        ) : null}
+
+        <fieldset className="space-y-2" data-testid="consign-unsold-preference">
+          <legend className="text-[13px] font-semibold text-ink mb-1">
+            If unsold at expiry
+          </legend>
+          {(
+            [
+              ["donate", "Donate to charity"],
+              ["collect", "Collect within 14 days, then donate"],
+            ] as const
+          ).map(([value, label]) => (
+            <label key={value} className="flex items-center gap-2 text-sm text-ink">
+              <input
+                type="radio"
+                name="unsoldPreference"
+                value={value}
+                checked={unsoldPreference === value}
+                onChange={() => setUnsoldPreference(value)}
+                data-testid={`consign-unsold-${value}`}
+              />
+              {label}
+            </label>
+          ))}
+        </fieldset>
+
+        <div className="space-y-3" data-testid="consign-items">
+          <div className="text-[13px] font-semibold text-ink">Items in the bag</div>
+          {items.map((item, index) => (
+            <div key={index} className="grid grid-cols-[1fr_5.5rem] gap-2">
+              <TextField
+                fullWidth
+                isRequired
+                name={`garment-${index}`}
+                value={item.garment}
+                onChange={(value) =>
+                  setItems((prev) =>
+                    prev.map((row, i) =>
+                      i === index ? { ...row, garment: value } : row,
+                    ),
+                  )
+                }
+                data-testid={`consign-item-garment-${index}`}
+              >
+                <Label>Garment</Label>
+                <Input placeholder="Sports polo" />
+                <FieldError />
+              </TextField>
+              <TextField
+                fullWidth
+                isRequired
+                name={`size-${index}`}
+                value={item.size}
+                onChange={(value) =>
+                  setItems((prev) =>
+                    prev.map((row, i) =>
+                      i === index ? { ...row, size: value } : row,
+                    ),
+                  )
+                }
+                data-testid={`consign-item-size-${index}`}
+              >
+                <Label>Size</Label>
+                <Input placeholder="10" />
+                <FieldError />
+              </TextField>
+            </div>
+          ))}
+          <Button
+            type="button"
+            variant="secondary"
+            className="self-start"
+            onPress={() =>
+              setItems((prev) =>
+                prev.length >= 30 ? prev : [...prev, { garment: "", size: "" }],
+              )
+            }
+            data-testid="consign-add-item"
+          >
+            Add another item
+          </Button>
+        </div>
+
+        <label className="flex items-start gap-2 text-sm text-ink">
+          <input
+            type="checkbox"
+            checked={termsAccepted}
+            onChange={(e) => setTermsAccepted(e.target.checked)}
+            className="mt-0.5"
+            data-testid="consign-terms"
+          />
+          <span>
+            I agree the shop sets the sale price, keeps the published commission,
+            and remits the balance by my payout preference. Unsold items follow
+            my unsold choice. Sold as worn — ACL still applies.
+          </span>
+        </label>
+
+        <Button
+          type="submit"
+          isPending={pending}
+          isDisabled={pending}
+          className="font-semibold text-white shadow-none self-start"
+          style={{ background: accent }}
+          data-testid="consign-submit"
+        >
+          {pending ? "Submitting…" : "Submit consignment form"}
+        </Button>
+      </Form>
+    </>
+  );
+}

--- a/apps/web/src/app/[tenant]/preloved/consign/page.tsx
+++ b/apps/web/src/app/[tenant]/preloved/consign/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getTenant } from "@/db/queries";
+import { getPrelovedSettings } from "@/db/preloved-queries";
+import { getSessionUser, isPlatformAdminEmail } from "@/lib/auth/authorization";
+import { isConsignmentIntakeMode } from "@/lib/preloved-consignment";
+import { MobileShell } from "@/components/mobile-shell";
+import { TenantFooter } from "@/components/tenant-footer";
+import { ConsignScreen } from "./consign-screen";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ tenant: string }>;
+}): Promise<Metadata> {
+  const { tenant: slug } = await params;
+  const tenant = await getTenant(slug);
+  if (!tenant) return { title: "Consign preloved" };
+  return { title: `Consign preloved — ${tenant.name}`, robots: { index: true } };
+}
+
+export default async function ConsignPage({
+  params,
+}: {
+  params: Promise<{ tenant: string }>;
+}) {
+  const { tenant: slug } = await params;
+  const tenant = await getTenant(slug);
+  if (!tenant) notFound();
+
+  const isVisibleToPublic =
+    tenant.isPubliclyListed && tenant.platformApprovalStatus === "approved";
+  if (!isVisibleToPublic) {
+    const user = await getSessionUser();
+    if (!user || !isPlatformAdminEmail(user.email)) notFound();
+  }
+
+  const settings = await getPrelovedSettings(tenant.id);
+  if (!settings.prelovedEnabled || !isConsignmentIntakeMode(settings.intakeMode)) {
+    notFound();
+  }
+
+  return (
+    <MobileShell bg="var(--color-paper)" logoUrl={tenant.logoUrl ?? undefined}>
+      <div className="px-5 py-6" data-testid="consign-page">
+        <h1
+          className="font-serif text-2xl font-semibold pb-2 mb-4 border-b-2"
+          style={{ borderColor: tenant.accent, color: "var(--color-navy-deep)" }}
+        >
+          Consign preloved
+        </h1>
+
+        <p className="text-sm leading-6 text-ink mb-5">
+          Fill this form, then drop the washed bag at the shop with the ticket
+          code on the tag. Volunteers inspect and price each garment — the form
+          replaces the paper consignment sheet, not intake.
+        </p>
+
+        <section className="rounded-lg border border-rule bg-paper p-4">
+          <ConsignScreen
+            tenantId={tenant.id}
+            accent={tenant.accent}
+            commissionBps={settings.commissionBps}
+          />
+        </section>
+      </div>
+      <TenantFooter tenant={tenant} />
+    </MobileShell>
+  );
+}

--- a/apps/web/src/app/admin/[tenant]/preloved/consignments/consignments-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/consignments/consignments-client.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Alert, Button, Spinner } from "@heroui/react";
+import {
+  formatCommissionPercent,
+  formatLotPayoutStatus,
+  formatPayoutPreference,
+  formatUnsoldPreference,
+  payoutStatusForPreference,
+  type ConsignmentLotPayoutStatus,
+  type ConsignmentLotItemDraft,
+  type ConsignmentPayoutPreference,
+  type ConsignmentUnsoldPreference,
+} from "@/lib/preloved-consignment";
+
+export type ConsignmentLotRow = {
+  id: string;
+  ticketCode: string;
+  familyName: string;
+  studentName: string;
+  email: string;
+  mobile: string;
+  payoutPreference: ConsignmentPayoutPreference;
+  bankBsb: string | null;
+  bankAccountName: string | null;
+  bankAccountNumber: string | null;
+  unsoldPreference: ConsignmentUnsoldPreference;
+  items: ConsignmentLotItemDraft[];
+  payoutStatus: ConsignmentLotPayoutStatus;
+  payoutMarkedAt: string | null;
+  createdAt: string;
+};
+
+function formatReceived(iso: string, timeZone: string) {
+  return new Date(iso).toLocaleString("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone,
+  });
+}
+
+export function ConsignmentsClient({
+  tenantId,
+  timeZone,
+}: {
+  tenantId: string;
+  timeZone: string;
+}) {
+  const [lots, setLots] = useState<ConsignmentLotRow[] | null>(null);
+  const [commissionBps, setCommissionBps] = useState<number | null>(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [markingId, setMarkingId] = useState<string | null>(null);
+  const [markError, setMarkError] = useState("");
+
+  const loadLots = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(
+        `/api/tenant/${tenantId}/preloved/consignment-lots`,
+      );
+      const data = (await res.json().catch(() => null)) as {
+        error?: string;
+        lots?: ConsignmentLotRow[];
+        commissionBps?: number;
+      } | null;
+      if (!res.ok) {
+        throw new Error(data?.error ?? "Failed to load consignment lots.");
+      }
+      setLots(Array.isArray(data?.lots) ? data.lots : []);
+      setCommissionBps(
+        typeof data?.commissionBps === "number" ? data.commissionBps : null,
+      );
+    } catch (err) {
+      console.error("Consignments load failed:", err);
+      setLots(null);
+      setError(
+        err instanceof Error ? err.message : "Failed to load consignment lots.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [tenantId]);
+
+  useEffect(() => {
+    void loadLots();
+  }, [loadLots]);
+
+  const markPayout = async (lot: ConsignmentLotRow) => {
+    setMarkingId(lot.id);
+    setMarkError("");
+    const payoutStatus = payoutStatusForPreference(lot.payoutPreference);
+    try {
+      const res = await fetch(
+        `/api/tenant/${tenantId}/preloved/consignment-lots/${lot.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ payoutStatus }),
+        },
+      );
+      const data = (await res.json().catch(() => null)) as {
+        error?: string;
+        lot?: ConsignmentLotRow;
+      } | null;
+      if (!res.ok) {
+        throw new Error(data?.error ?? "Failed to mark payout.");
+      }
+      if (data?.lot) {
+        setLots((prev) =>
+          prev
+            ? prev.map((row) => (row.id === data.lot!.id ? data.lot! : row))
+            : prev,
+        );
+      }
+    } catch (err) {
+      console.error("Mark payout failed:", err);
+      setMarkError(
+        err instanceof Error ? err.message : "Failed to mark payout.",
+      );
+    } finally {
+      setMarkingId(null);
+    }
+  };
+
+  return (
+    <div className="flex-1 overflow-y-auto p-7" data-testid="consignments-panel">
+      <p
+        className="text-[13px] mb-4 max-w-2xl"
+        style={{ color: "var(--color-ink-dim)" }}
+      >
+        Parent consignment lots. Bank details are operator-only. Mark school-fee
+        credit, EFT, or donated proceeds by hand — there is no school-finance
+        integration.
+        {commissionBps != null
+          ? ` Shop commission: ${formatCommissionPercent(commissionBps)}.`
+          : null}
+      </p>
+
+      {markError ? (
+        <div className="mb-4 max-w-xl" data-testid="consignments-mark-error">
+          <Alert status="danger">
+            <Alert.Indicator />
+            <Alert.Content>
+              <Alert.Title>Could not mark payout</Alert.Title>
+              <Alert.Description>{markError}</Alert.Description>
+            </Alert.Content>
+          </Alert>
+        </div>
+      ) : null}
+
+      {loading ? <LotsLoading /> : null}
+
+      {!loading && error ? (
+        <LotsError message={error} onRetry={() => void loadLots()} />
+      ) : null}
+
+      {!loading && !error && lots && lots.length === 0 ? <LotsEmpty /> : null}
+
+      {!loading && !error && lots && lots.length > 0 ? (
+        <LotsList
+          lots={lots}
+          timeZone={timeZone}
+          markingId={markingId}
+          onMark={(lot) => void markPayout(lot)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function LotsLoading() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center text-center py-16 px-6"
+      data-testid="consignments-loading"
+      role="status"
+      aria-live="polite"
+    >
+      <Spinner size="lg" color="current" className="mb-4 text-[var(--color-gold)]" />
+      <p className="text-[13.5px]" style={{ color: "var(--color-ink-dim)" }}>
+        Loading consignment lots…
+      </p>
+    </div>
+  );
+}
+
+function LotsError({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="max-w-xl" data-testid="consignments-error">
+      <Alert status="danger">
+        <Alert.Indicator />
+        <Alert.Content>
+          <Alert.Title>Could not load consignments</Alert.Title>
+          <Alert.Description>{message}</Alert.Description>
+        </Alert.Content>
+        <Button
+          size="sm"
+          variant="danger"
+          onPress={onRetry}
+          data-testid="consignments-retry"
+        >
+          Try again
+        </Button>
+      </Alert>
+    </div>
+  );
+}
+
+function LotsEmpty() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center text-center py-16 px-6"
+      data-testid="consignments-empty"
+    >
+      <h2
+        className="font-serif text-[22px] font-medium leading-[1.2] mb-2"
+        style={{ color: "var(--color-ink)" }}
+      >
+        No consignment lots yet
+      </h2>
+      <p
+        className="text-[13.5px] leading-[1.5] max-w-md"
+        style={{ color: "var(--color-ink-dim)" }}
+      >
+        When a parent submits the consign form, the lot and ticket code appear
+        here. Accept garments on Intake after inspection.
+      </p>
+    </div>
+  );
+}
+
+function LotsList({
+  lots,
+  timeZone,
+  markingId,
+  onMark,
+}: {
+  lots: ConsignmentLotRow[];
+  timeZone: string;
+  markingId: string | null;
+  onMark: (lot: ConsignmentLotRow) => void;
+}) {
+  return (
+    <div className="space-y-4" data-testid="consignments-list">
+      {lots.map((lot) => {
+        const markLabel =
+          lot.payoutPreference === "school_fee_credit"
+            ? "Mark school-fee credited"
+            : lot.payoutPreference === "eft"
+              ? "Mark EFT paid"
+              : "Mark proceeds donated";
+        return (
+          <article
+            key={lot.id}
+            className="bg-white rounded-[10px] border p-4"
+            style={{ borderColor: "var(--color-rule)" }}
+            data-testid="consignments-row"
+            data-lot-id={lot.id}
+            data-ticket={lot.ticketCode}
+            data-payout-status={lot.payoutStatus}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div
+                  className="font-semibold text-[14px] tnum"
+                  style={{ color: "var(--color-ink)" }}
+                  data-testid="consignments-ticket"
+                >
+                  {lot.ticketCode}
+                </div>
+                <div className="text-[12.5px]" style={{ color: "var(--color-ink-dim)" }}>
+                  {formatReceived(lot.createdAt, timeZone)}
+                </div>
+              </div>
+              <div
+                className="text-[12px] font-semibold uppercase tracking-wide"
+                style={{ color: "var(--color-ink-dim)" }}
+                data-testid="consignments-status"
+              >
+                {formatLotPayoutStatus(lot.payoutStatus)}
+              </div>
+            </div>
+
+            <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[13px]">
+              <dt style={{ color: "var(--color-ink-dim)" }}>Family</dt>
+              <dd style={{ color: "var(--color-ink)" }}>
+                {lot.familyName} / {lot.studentName}
+              </dd>
+              <dt style={{ color: "var(--color-ink-dim)" }}>Contact</dt>
+              <dd style={{ color: "var(--color-ink)" }}>
+                {lot.email} · {lot.mobile}
+              </dd>
+              <dt style={{ color: "var(--color-ink-dim)" }}>Payout</dt>
+              <dd style={{ color: "var(--color-ink)" }}>
+                {formatPayoutPreference(lot.payoutPreference)}
+              </dd>
+              <dt style={{ color: "var(--color-ink-dim)" }}>Unsold</dt>
+              <dd style={{ color: "var(--color-ink)" }}>
+                {formatUnsoldPreference(lot.unsoldPreference)}
+              </dd>
+              {lot.payoutPreference === "eft" ? (
+                <>
+                  <dt style={{ color: "var(--color-ink-dim)" }}>Bank</dt>
+                  <dd className="tnum" style={{ color: "var(--color-ink)" }}>
+                    {lot.bankAccountName} · BSB {lot.bankBsb} · {lot.bankAccountNumber}
+                  </dd>
+                </>
+              ) : null}
+              <dt style={{ color: "var(--color-ink-dim)" }}>Items</dt>
+              <dd style={{ color: "var(--color-ink)" }}>
+                {lot.items
+                  .map((item) => `${item.garment} (${item.size})`)
+                  .join(", ")}
+              </dd>
+            </dl>
+
+            {lot.payoutStatus === "pending" ? (
+              <div className="mt-3">
+                <Button
+                  size="sm"
+                  onPress={() => onMark(lot)}
+                  isPending={markingId === lot.id}
+                  isDisabled={markingId === lot.id}
+                  data-testid="consignments-mark-payout"
+                >
+                  {markLabel}
+                </Button>
+              </div>
+            ) : null}
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/[tenant]/preloved/consignments/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/consignments/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from "next/navigation";
+import { getTenant, toTenantBrand } from "@/db/queries";
+import { getPrelovedSettings } from "@/db/preloved-queries";
+import { isConsignmentIntakeMode } from "@/lib/preloved-consignment";
+import { ConsignmentsClient } from "./consignments-client";
+
+export default async function AdminPrelovedConsignmentsPage({
+  params,
+}: {
+  params: Promise<{ tenant: string }>;
+}) {
+  const { tenant: tid } = await params;
+  const tenantRecord = await getTenant(tid);
+  if (!tenantRecord) notFound();
+
+  const settings = await getPrelovedSettings(tenantRecord.id);
+  if (!settings.prelovedEnabled || !isConsignmentIntakeMode(settings.intakeMode)) {
+    notFound();
+  }
+
+  const tenant = toTenantBrand(tenantRecord);
+
+  return <ConsignmentsClient tenantId={tid} timeZone={tenant.timezone} />;
+}

--- a/apps/web/src/app/admin/[tenant]/preloved/intake/intake-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/intake/intake-client.tsx
@@ -22,7 +22,9 @@ import {
   isPrelovedPriceAboveCap,
   roundPrelovedPrice,
   type PrelovedCondition,
+  type PrelovedIntakeMode,
 } from "@/lib/preloved";
+import { isConsignmentIntakeMode } from "@/lib/preloved-consignment";
 
 export type IntakeCatalogItem = {
   id: string;
@@ -90,12 +92,14 @@ export function IntakeClient({
   catalog,
   priceFractionOfNew,
   refuseList,
+  intakeMode,
 }: {
   tenantId: string;
   tenant: Tenant;
   catalog: IntakeCatalogItem[];
   priceFractionOfNew: number;
   refuseList: string[];
+  intakeMode: PrelovedIntakeMode;
 }) {
   const [itemId, setItemId] = useState("");
   const [size, setSize] = useState("");
@@ -351,7 +355,11 @@ export function IntakeClient({
             <TextField isReadOnly name="source" value="Donation">
               <Label>Source</Label>
               <Input />
-              <Description>Donation only. Consignment is not available.</Description>
+              <Description>
+                {isConsignmentIntakeMode(intakeMode)
+                  ? "This desk still accepts donations into the pooled rack. Link garments to a consignment lot ticket in a later slice."
+                  : "Donation only. Turn on donation + consignment in Settings to open the consign form."}
+              </Description>
             </TextField>
 
             <TextField

--- a/apps/web/src/app/admin/[tenant]/preloved/intake/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/intake/page.tsx
@@ -56,6 +56,7 @@ export default async function AdminPrelovedIntakePage({
       catalog={catalog}
       priceFractionOfNew={settings.priceFractionOfNew}
       refuseList={settings.refuseList}
+      intakeMode={settings.intakeMode}
     />
   );
 }

--- a/apps/web/src/app/admin/[tenant]/preloved/layout.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/layout.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { AdminTopbar } from "@/components/admin-shell";
 import { getTenant } from "@/db/queries";
 import { getPrelovedSettings } from "@/db/preloved-queries";
+import { isConsignmentIntakeMode } from "@/lib/preloved-consignment";
 import { PrelovedSectionTabs } from "./preloved-section-tabs";
 
 export default async function AdminPrelovedLayout({
@@ -28,7 +29,10 @@ export default async function AdminPrelovedLayout({
         className="px-7 bg-white"
         style={{ borderBottom: "1px solid var(--color-rule)" }}
       >
-        <PrelovedSectionTabs tenantId={tenant} />
+        <PrelovedSectionTabs
+          tenantId={tenant}
+          showConsignments={isConsignmentIntakeMode(settings.intakeMode)}
+        />
       </div>
       <div className="flex-1 min-h-0 overflow-auto">{children}</div>
     </div>

--- a/apps/web/src/app/admin/[tenant]/preloved/preloved-section-tabs.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/preloved-section-tabs.tsx
@@ -5,17 +5,24 @@ import { usePathname } from "next/navigation";
 import type { ComponentProps } from "react";
 import { Tabs } from "@heroui/react";
 
-const PRELOVED_SECTION_TABS = [
+const BASE_TABS = [
   { id: "intake", label: "Intake" },
   { id: "stock", label: "Stock" },
   { id: "inbox", label: "Inbox" },
   { id: "write-offs", label: "Write-offs" },
 ] as const;
 
-type PrelovedSectionTabId = (typeof PRELOVED_SECTION_TABS)[number]["id"];
+const CONSIGNMENTS_TAB = { id: "consignments", label: "Consignments" } as const;
 
-function selectedPrelovedSection(pathname: string): PrelovedSectionTabId {
-  const match = PRELOVED_SECTION_TABS.find(
+type PrelovedSectionTabId =
+  | (typeof BASE_TABS)[number]["id"]
+  | typeof CONSIGNMENTS_TAB.id;
+
+function selectedPrelovedSection(
+  pathname: string,
+  tabs: readonly { id: PrelovedSectionTabId; label: string }[],
+): PrelovedSectionTabId {
+  const match = tabs.find(
     (tab) =>
       pathname.endsWith(`/preloved/${tab.id}`) ||
       pathname.includes(`/preloved/${tab.id}/`),
@@ -23,15 +30,24 @@ function selectedPrelovedSection(pathname: string): PrelovedSectionTabId {
   return match?.id ?? "intake";
 }
 
-export function PrelovedSectionTabs({ tenantId }: { tenantId: string }) {
+export function PrelovedSectionTabs({
+  tenantId,
+  showConsignments = false,
+}: {
+  tenantId: string;
+  showConsignments?: boolean;
+}) {
   const pathname = usePathname();
-  const selectedKey = selectedPrelovedSection(pathname);
+  const tabs = showConsignments
+    ? ([...BASE_TABS, CONSIGNMENTS_TAB] as const)
+    : BASE_TABS;
+  const selectedKey = selectedPrelovedSection(pathname, tabs);
 
   return (
     <Tabs variant="secondary" selectedKey={selectedKey} className="w-full">
       <Tabs.ListContainer>
         <Tabs.List aria-label="Preloved sections">
-          {PRELOVED_SECTION_TABS.map((tab) => {
+          {tabs.map((tab) => {
             const href = `/admin/${tenantId}/preloved/${tab.id}`;
             return (
               <Tabs.Tab

--- a/apps/web/src/app/admin/[tenant]/settings/preloved-settings-section.tsx
+++ b/apps/web/src/app/admin/[tenant]/settings/preloved-settings-section.tsx
@@ -5,9 +5,18 @@ import { useRouter } from "next/navigation";
 import {
   DEFAULT_PRICE_FRACTION_OF_NEW,
   isPersistablePriceFractionOfNew,
+  PRELOVED_INTAKE_MODES,
   roundPriceFractionOfNew,
+  type PrelovedIntakeMode,
   type PrelovedSettings,
 } from "@/lib/preloved";
+import {
+  COMMISSION_BPS_PRESETS,
+  DEFAULT_COMMISSION_BPS,
+  formatCommissionPercent,
+  isConsignmentIntakeMode,
+  isValidCommissionBps,
+} from "@/lib/preloved-consignment";
 
 const GST_FREE_COPY =
   "Confirm with your accountant that your P&C / school is an endorsed charity, gift-deductible entity, or government school before treating donated preloved as GST-free (GST Act s 38-255).";
@@ -33,6 +42,8 @@ export function PrelovedSettingsSection({
   settings: PrelovedSettings;
 }) {
   const [enabled, setEnabled] = useState(settings.prelovedEnabled);
+  const [intakeMode, setIntakeMode] = useState<PrelovedIntakeMode>(settings.intakeMode);
+  const [commissionBps, setCommissionBps] = useState(String(settings.commissionBps));
   const [priceFraction, setPriceFraction] = useState(String(settings.priceFractionOfNew));
   const [holdDays, setHoldDays] = useState(String(settings.holdDays));
   const [refuseList, setRefuseList] = useState(formatRefuseList(settings.refuseList));
@@ -45,6 +56,7 @@ export function PrelovedSettingsSection({
   const parsedFraction = Number(priceFraction);
   const showFractionWarning =
     Number.isFinite(parsedFraction) && parsedFraction > DEFAULT_PRICE_FRACTION_OF_NEW;
+  const consignOn = isConsignmentIntakeMode(intakeMode);
 
   const handleSave = async () => {
     setSaving(true);
@@ -53,6 +65,7 @@ export function PrelovedSettingsSection({
 
     const parsedFractionValue = Number(priceFraction);
     const days = Number(holdDays);
+    const commission = Number(commissionBps);
     if (!isPersistablePriceFractionOfNew(parsedFractionValue)) {
       setSaveError("Price fraction must be at least 0.01 and at most 2.");
       setSaving(false);
@@ -64,6 +77,11 @@ export function PrelovedSettingsSection({
       setSaving(false);
       return;
     }
+    if (!isValidCommissionBps(commission)) {
+      setSaveError("Commission must be an integer between 0 and 10000 basis points.");
+      setSaving(false);
+      return;
+    }
 
     try {
       const res = await fetch(`/api/tenant/${tenantId}/preloved`, {
@@ -71,6 +89,8 @@ export function PrelovedSettingsSection({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           prelovedEnabled: enabled,
+          intakeMode,
+          commissionBps: commission,
           priceFractionOfNew: fraction,
           holdDays: days,
           donatedGstFree,
@@ -98,8 +118,8 @@ export function PrelovedSettingsSection({
         Preloved
       </h2>
       <p className="text-[12.5px] mb-4" style={{ color: "var(--color-ink-dim)" }}>
-        Donation-only rack. Parents donate washed current-uniform items; the shop inspects, prices,
-        and sells them. Consignment is not available in this phase.
+        Donation rack by default. Enable donation + consignment to open the parent
+        consign form, lot tickets, and school-fee credit marks.
       </p>
 
       <div className="flex flex-col gap-4">
@@ -128,6 +148,73 @@ export function PrelovedSettingsSection({
             />
           </button>
         </div>
+
+        <fieldset data-testid="preloved-intake-mode">
+          <legend
+            className="block text-[11px] font-bold uppercase tracking-[0.6px] mb-1.5"
+            style={{ color: "var(--color-ink-dim)" }}
+          >
+            Intake mode
+          </legend>
+          <div className="flex flex-col gap-2">
+            {PRELOVED_INTAKE_MODES.map((mode) => (
+              <label
+                key={mode}
+                className="flex items-start gap-2 text-[12.5px]"
+                style={{ color: "var(--color-ink)" }}
+              >
+                <input
+                  type="radio"
+                  name="intakeMode"
+                  value={mode}
+                  checked={intakeMode === mode}
+                  onChange={() => setIntakeMode(mode)}
+                  data-testid={`preloved-intake-mode-${mode}`}
+                  className="mt-0.5"
+                />
+                <span>
+                  {mode === "donation_only"
+                    ? "Donation only"
+                    : "Donation + consignment"}
+                </span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        {consignOn ? (
+          <div>
+            <label
+              className="block text-[11px] font-bold uppercase tracking-[0.6px] mb-1.5"
+              style={{ color: "var(--color-ink-dim)" }}
+              htmlFor="preloved-commission-bps"
+            >
+              Shop commission (basis points)
+            </label>
+            <input
+              id="preloved-commission-bps"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={10000}
+              step={100}
+              value={commissionBps}
+              onChange={(e) => setCommissionBps(e.target.value)}
+              className="w-full h-10 border rounded-md px-3 text-[13px] outline-none tnum"
+              style={{
+                borderColor: "var(--color-rule)",
+                color: "var(--color-ink)",
+                fontFamily: "var(--font-sans)",
+              }}
+              data-testid="preloved-commission-bps"
+            />
+            <p className="text-[11px] mt-1" style={{ color: "var(--color-ink-dim)" }}>
+              Default {DEFAULT_COMMISSION_BPS} ({formatCommissionPercent(DEFAULT_COMMISSION_BPS)}
+              to the shop). Common presets:{" "}
+              {COMMISSION_BPS_PRESETS.map((bps) => formatCommissionPercent(bps)).join(", ")}.
+            </p>
+          </div>
+        ) : null}
 
         <div className="grid grid-cols-2 gap-4">
           <div>
@@ -230,7 +317,7 @@ export function PrelovedSettingsSection({
           <span>
             <span className="font-semibold block mb-0.5">Treat donated preloved as GST-free</span>
             <span id="preloved-gst-copy" style={{ color: "var(--color-ink-dim)" }}>
-              {GST_FREE_COPY}
+              {GST_FREE_COPY} Consignment sales stay taxable by default.
             </span>
           </span>
         </label>

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/consign/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/consign/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getTenant } from "@/db/queries";
+import {
+  getPrelovedSettings,
+  insertConsignmentLot,
+} from "@/db/preloved-queries";
+import { getSessionUser, isPlatformAdminEmail } from "@/lib/auth/authorization";
+import {
+  CONSIGNMENT_PAYOUT_PREFERENCES,
+  CONSIGNMENT_UNSOLD_PREFERENCES,
+  isConsignmentIntakeMode,
+  isValidBsb,
+  MAX_CONSIGNMENT_ITEMS,
+  MIN_CONSIGNMENT_ITEMS,
+  normalizeBsb,
+} from "@/lib/preloved-consignment";
+import { applyRateLimit } from "@/lib/rate-limit";
+
+const ItemSchema = z
+  .object({
+    garment: z.string().trim().min(1).max(120),
+    size: z.string().trim().min(1).max(40),
+  })
+  .strict();
+
+const ConsignSchema = z
+  .object({
+    familyName: z.string().trim().min(1).max(80),
+    studentName: z.string().trim().min(1).max(80),
+    email: z.string().trim().email().max(120),
+    mobile: z.string().trim().min(8).max(40),
+    payoutPreference: z.enum(CONSIGNMENT_PAYOUT_PREFERENCES),
+    bankBsb: z.string().trim().max(20).optional().nullable(),
+    bankAccountName: z.string().trim().max(80).optional().nullable(),
+    bankAccountNumber: z.string().trim().max(40).optional().nullable(),
+    unsoldPreference: z.enum(CONSIGNMENT_UNSOLD_PREFERENCES),
+    items: z.array(ItemSchema).min(MIN_CONSIGNMENT_ITEMS).max(MAX_CONSIGNMENT_ITEMS),
+    termsAccepted: z.literal(true),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.payoutPreference !== "eft") return;
+    const bsb = value.bankBsb ? normalizeBsb(value.bankBsb) : "";
+    if (!isValidBsb(bsb)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["bankBsb"],
+        message: "BSB must be 6 digits for EFT payout",
+      });
+    }
+    if (!value.bankAccountName?.trim()) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["bankAccountName"],
+        message: "Account name is required for EFT payout",
+      });
+    }
+    if (!value.bankAccountNumber?.trim()) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["bankAccountNumber"],
+        message: "Account number is required for EFT payout",
+      });
+    }
+  });
+
+// POST /api/tenant/:tenantId/preloved/consign — public lot form. No SKU yet.
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ tenantId: string }> },
+) {
+  const { tenantId } = await params;
+  try {
+    const rateLimitResponse = applyRateLimit(
+      req,
+      `preloved-consign:${tenantId}:anon`,
+      { limit: 10, windowMs: 60_000 },
+    );
+    if (rateLimitResponse) return rateLimitResponse;
+
+    const tenant = await getTenant(tenantId);
+    if (!tenant) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
+
+    const isVisibleToPublic =
+      tenant.isPubliclyListed && tenant.platformApprovalStatus === "approved";
+    if (!isVisibleToPublic) {
+      const user = await getSessionUser();
+      if (!user || !isPlatformAdminEmail(user.email)) {
+        return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+      }
+    }
+
+    const settings = await getPrelovedSettings(tenantId);
+    if (!settings.prelovedEnabled || !isConsignmentIntakeMode(settings.intakeMode)) {
+      return NextResponse.json(
+        { error: "Consignment is not enabled" },
+        { status: 404 },
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const parsed = ConsignSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid consignment form", issues: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const data = parsed.data;
+    const lot = await insertConsignmentLot({
+      tenantId,
+      familyName: data.familyName,
+      studentName: data.studentName,
+      email: data.email,
+      mobile: data.mobile,
+      payoutPreference: data.payoutPreference,
+      bankBsb:
+        data.payoutPreference === "eft" && data.bankBsb
+          ? normalizeBsb(data.bankBsb)
+          : null,
+      bankAccountName:
+        data.payoutPreference === "eft" ? data.bankAccountName?.trim() ?? null : null,
+      bankAccountNumber:
+        data.payoutPreference === "eft"
+          ? data.bankAccountNumber?.trim() ?? null
+          : null,
+      unsoldPreference: data.unsoldPreference,
+      items: data.items,
+    });
+
+    return NextResponse.json(
+      { ok: true, ticketCode: lot.ticketCode, id: lot.id },
+      { status: 201 },
+    );
+  } catch (err) {
+    console.error("POST /api/tenant/[tenantId]/preloved/consign error:", err);
+    return NextResponse.json(
+      { error: "Failed to record consignment lot" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/[lotId]/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/[lotId]/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 import { getTenant } from "@/db/queries";
 import {
   getPrelovedSettings,
@@ -10,25 +9,22 @@ import {
   requireSessionUser,
 } from "@/lib/auth/authorization";
 import {
-  CONSIGNMENT_LOT_PAYOUT_STATUSES,
   isConsignmentIntakeMode,
+  type ConsignmentLotListItem,
 } from "@/lib/preloved-consignment";
 
-const MarkSchema = z
-  .object({
-    payoutStatus: z.enum(
-      CONSIGNMENT_LOT_PAYOUT_STATUSES.filter((s) => s !== "pending") as [
-        "school_fee_credited",
-        "eft_paid",
-        "donated_proceeds",
-      ],
-    ),
-  })
-  .strict();
+function serializeLot(lot: ConsignmentLotListItem) {
+  return {
+    ...lot,
+    createdAt: lot.createdAt.toISOString(),
+    payoutMarkedAt: lot.payoutMarkedAt?.toISOString() ?? null,
+  };
+}
 
 // PATCH /api/tenant/:tenantId/preloved/consignment-lots/:lotId — manual payout mark.
+// Status is derived from the lot payout preference. Client body is ignored.
 export async function PATCH(
-  req: NextRequest,
+  _req: NextRequest,
   { params }: { params: Promise<{ tenantId: string; lotId: string }> },
 ) {
   const { tenantId, lotId } = await params;
@@ -51,38 +47,28 @@ export async function PATCH(
       );
     }
 
-    let body: unknown;
-    try {
-      body = await req.json();
-    } catch {
-      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-    }
-
-    const parsed = MarkSchema.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: "Invalid payout mark", issues: parsed.error.flatten() },
-        { status: 400 },
-      );
-    }
-
-    const lot = await markConsignmentLotPayout({
+    const result = await markConsignmentLotPayout({
       tenantId,
       lotId,
-      payoutStatus: parsed.data.payoutStatus,
       actorId: authResult.user.id,
     });
-    if (!lot) {
+    if (!result.ok && result.reason === "not_found") {
       return NextResponse.json({ error: "Lot not found" }, { status: 404 });
+    }
+    if (!result.ok) {
+      return NextResponse.json(
+        {
+          error: "Lot payout already marked",
+          code: "already_marked",
+          lot: serializeLot(result.lot),
+        },
+        { status: 409 },
+      );
     }
 
     return NextResponse.json({
       ok: true,
-      lot: {
-        ...lot,
-        createdAt: lot.createdAt.toISOString(),
-        payoutMarkedAt: lot.payoutMarkedAt?.toISOString() ?? null,
-      },
+      lot: serializeLot(result.lot),
     });
   } catch (err) {
     console.error(

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/[lotId]/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/[lotId]/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getTenant } from "@/db/queries";
+import {
+  getPrelovedSettings,
+  markConsignmentLotPayout,
+} from "@/db/preloved-queries";
+import {
+  ensureTenantAccess,
+  requireSessionUser,
+} from "@/lib/auth/authorization";
+import {
+  CONSIGNMENT_LOT_PAYOUT_STATUSES,
+  isConsignmentIntakeMode,
+} from "@/lib/preloved-consignment";
+
+const MarkSchema = z
+  .object({
+    payoutStatus: z.enum(
+      CONSIGNMENT_LOT_PAYOUT_STATUSES.filter((s) => s !== "pending") as [
+        "school_fee_credited",
+        "eft_paid",
+        "donated_proceeds",
+      ],
+    ),
+  })
+  .strict();
+
+// PATCH /api/tenant/:tenantId/preloved/consignment-lots/:lotId — manual payout mark.
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ tenantId: string; lotId: string }> },
+) {
+  const { tenantId, lotId } = await params;
+  try {
+    const authResult = await requireSessionUser();
+    if ("response" in authResult) return authResult.response;
+
+    const tenant = await getTenant(tenantId);
+    if (!tenant) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
+    const tenantAccessResponse = ensureTenantAccess(authResult.user, tenant.shopEmail);
+    if (tenantAccessResponse) return tenantAccessResponse;
+
+    const settings = await getPrelovedSettings(tenantId);
+    if (!settings.prelovedEnabled || !isConsignmentIntakeMode(settings.intakeMode)) {
+      return NextResponse.json(
+        { error: "Consignment is not enabled" },
+        { status: 404 },
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const parsed = MarkSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid payout mark", issues: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const lot = await markConsignmentLotPayout({
+      tenantId,
+      lotId,
+      payoutStatus: parsed.data.payoutStatus,
+      actorId: authResult.user.id,
+    });
+    if (!lot) {
+      return NextResponse.json({ error: "Lot not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      lot: {
+        ...lot,
+        createdAt: lot.createdAt.toISOString(),
+        payoutMarkedAt: lot.payoutMarkedAt?.toISOString() ?? null,
+      },
+    });
+  } catch (err) {
+    console.error(
+      "PATCH /api/tenant/[tenantId]/preloved/consignment-lots/[lotId] error:",
+      err,
+    );
+    return NextResponse.json(
+      { error: "Failed to mark consignment payout" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getTenant } from "@/db/queries";
+import { getPrelovedSettings, listConsignmentLots } from "@/db/preloved-queries";
+import {
+  ensureTenantAccess,
+  requireSessionUser,
+} from "@/lib/auth/authorization";
+import { isConsignmentIntakeMode } from "@/lib/preloved-consignment";
+
+// GET /api/tenant/:tenantId/preloved/consignment-lots — operator list.
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ tenantId: string }> },
+) {
+  const { tenantId } = await params;
+  try {
+    const authResult = await requireSessionUser();
+    if ("response" in authResult) return authResult.response;
+
+    const tenant = await getTenant(tenantId);
+    if (!tenant) {
+      return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
+    }
+    const tenantAccessResponse = ensureTenantAccess(authResult.user, tenant.shopEmail);
+    if (tenantAccessResponse) return tenantAccessResponse;
+
+    const settings = await getPrelovedSettings(tenantId);
+    if (!settings.prelovedEnabled) {
+      return NextResponse.json({ error: "Preloved is not enabled" }, { status: 404 });
+    }
+    if (!isConsignmentIntakeMode(settings.intakeMode)) {
+      return NextResponse.json(
+        { error: "Consignment is not enabled" },
+        { status: 404 },
+      );
+    }
+
+    const lots = await listConsignmentLots(tenantId);
+    return NextResponse.json({
+      ok: true,
+      commissionBps: settings.commissionBps,
+      lots: lots.map((lot) => ({
+        ...lot,
+        createdAt: lot.createdAt.toISOString(),
+        payoutMarkedAt: lot.payoutMarkedAt?.toISOString() ?? null,
+      })),
+    });
+  } catch (err) {
+    console.error(
+      "GET /api/tenant/[tenantId]/preloved/consignment-lots error:",
+      err,
+    );
+    return NextResponse.json(
+      { error: "Failed to load consignment lots" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/route.ts
@@ -13,15 +13,20 @@ import {
 } from "@/lib/auth/authorization";
 import {
   isPersistablePriceFractionOfNew,
+  PRELOVED_INTAKE_MODES,
   roundPriceFractionOfNew,
   type PrelovedSettingsPatch,
 } from "@/lib/preloved";
+import {
+  isValidCommissionBps,
+  MAX_COMMISSION_BPS,
+  MIN_COMMISSION_BPS,
+} from "@/lib/preloved-consignment";
 
-// Operator-writable fields only. intakeMode and commissionBps are not accepted
-// (Phase 1 is donation-only; commission is unused until Phase 2).
 const PatchSchema = z
   .object({
     prelovedEnabled: z.boolean().optional(),
+    intakeMode: z.enum(PRELOVED_INTAKE_MODES).optional(),
     priceFractionOfNew: z
       .number()
       .finite()
@@ -33,10 +38,17 @@ const PatchSchema = z
     holdDays: z.number().int().min(1).max(3650).optional(),
     donatedGstFree: z.boolean().optional(),
     refuseList: z.array(z.string().trim().min(1).max(80)).max(50).optional(),
+    commissionBps: z
+      .number()
+      .int()
+      .min(MIN_COMMISSION_BPS)
+      .max(MAX_COMMISSION_BPS)
+      .refine(isValidCommissionBps)
+      .optional(),
   })
   .strict();
 
-// PATCH /api/tenant/:tenantId/preloved — operator-only. Values above 0.50 are allowed.
+// PATCH /api/tenant/:tenantId/preloved — operator-only.
 export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ tenantId: string }> },
@@ -70,10 +82,12 @@ export async function PATCH(
     const patch = parsed.data as PrelovedSettingsPatch;
     if (
       patch.prelovedEnabled === undefined &&
+      patch.intakeMode === undefined &&
       patch.priceFractionOfNew === undefined &&
       patch.holdDays === undefined &&
       patch.donatedGstFree === undefined &&
-      patch.refuseList === undefined
+      patch.refuseList === undefined &&
+      patch.commissionBps === undefined
     ) {
       return NextResponse.json({ error: "No preloved settings to update" }, { status: 400 });
     }

--- a/apps/web/src/components/tenant-footer.tsx
+++ b/apps/web/src/components/tenant-footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { TenantRow } from "@/db/schema";
 import { getPrelovedSettings } from "@/db/preloved-queries";
+import { isConsignmentIntakeMode } from "@/lib/preloved-consignment";
 
 export async function TenantFooter({
   tenant,
@@ -9,7 +10,9 @@ export async function TenantFooter({
   tenant: TenantRow;
   hideContact?: boolean;
 }) {
-  const { prelovedEnabled } = await getPrelovedSettings(tenant.id);
+  const settings = await getPrelovedSettings(tenant.id);
+  const { prelovedEnabled, intakeMode } = settings;
+  const showConsign = prelovedEnabled && isConsignmentIntakeMode(intakeMode);
   const showRefund = tenant.currentLegalVersionId !== null;
   return (
     <footer className="border-t border-rule bg-parchment px-5 py-4 text-[12px] leading-relaxed text-ink-dim">
@@ -21,6 +24,15 @@ export async function TenantFooter({
             data-testid="footer-donate-link"
           >
             Donate
+          </Link>
+        )}
+        {showConsign && (
+          <Link
+            className="underline hover:text-ink"
+            href={`/${tenant.id}/preloved/consign`}
+            data-testid="footer-consign-link"
+          >
+            Consign
           </Link>
         )}
         {showRefund && (

--- a/apps/web/src/db/preloved-queries.ts
+++ b/apps/web/src/db/preloved-queries.ts
@@ -40,9 +40,9 @@ import {
 import {
   generateConsignmentTicketCode,
   isValidCommissionBps,
+  payoutStatusForPreference,
   type ConsignmentLotItemDraft,
   type ConsignmentLotListItem,
-  type ConsignmentLotPayoutStatus,
   type InsertConsignmentLotInput,
 } from "@/lib/preloved-consignment";
 import { policyTextWithPrelovedRefundClause } from "@/lib/preloved-refund-policy";
@@ -359,28 +359,70 @@ export async function listConsignmentLots(
   return rows.map(mapConsignmentLotRow);
 }
 
+export type MarkConsignmentLotPayoutResult =
+  | { ok: true; lot: ConsignmentLotListItem }
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "already_marked"; lot: ConsignmentLotListItem };
+
+/**
+ * Mark a pending lot. Status is derived from payoutPreference.
+ * Completed marks are not overwritten (409 already_marked).
+ */
 export async function markConsignmentLotPayout(opts: {
   tenantId: string;
   lotId: string;
-  payoutStatus: ConsignmentLotPayoutStatus;
   actorId?: string | null;
-}): Promise<ConsignmentLotListItem | null> {
+}): Promise<MarkConsignmentLotPayoutResult> {
   const actorId = parseActorId(opts.actorId);
+  const lotWhere = and(
+    eq(consignmentLots.id, opts.lotId),
+    eq(consignmentLots.tenantId, opts.tenantId),
+  );
+
+  const [existing] = await db
+    .select()
+    .from(consignmentLots)
+    .where(lotWhere)
+    .limit(1);
+
+  if (!existing) {
+    return { ok: false, reason: "not_found" };
+  }
+  if (existing.payoutStatus !== "pending") {
+    return {
+      ok: false,
+      reason: "already_marked",
+      lot: mapConsignmentLotRow(existing),
+    };
+  }
+
   const [row] = await db
     .update(consignmentLots)
     .set({
-      payoutStatus: opts.payoutStatus,
+      payoutStatus: payoutStatusForPreference(existing.payoutPreference),
       payoutMarkedAt: new Date(),
       payoutMarkedBy: actorId,
     })
-    .where(
-      and(
-        eq(consignmentLots.id, opts.lotId),
-        eq(consignmentLots.tenantId, opts.tenantId),
-      ),
-    )
+    .where(and(lotWhere, eq(consignmentLots.payoutStatus, "pending")))
     .returning();
-  return row ? mapConsignmentLotRow(row) : null;
+
+  if (!row) {
+    const [current] = await db
+      .select()
+      .from(consignmentLots)
+      .where(lotWhere)
+      .limit(1);
+    if (!current) {
+      return { ok: false, reason: "not_found" };
+    }
+    return {
+      ok: false,
+      reason: "already_marked",
+      lot: mapConsignmentLotRow(current),
+    };
+  }
+
+  return { ok: true, lot: mapConsignmentLotRow(row) };
 }
 
 function variantHasSize(sizes: unknown, size: string): boolean {

--- a/apps/web/src/db/preloved-queries.ts
+++ b/apps/web/src/db/preloved-queries.ts
@@ -6,7 +6,6 @@ import { cache } from "react";
 import { and, asc, desc, eq, gt, isNotNull, lt, sql } from "drizzle-orm";
 import {
   DEFAULT_PRICE_FRACTION_OF_NEW,
-  PRELOVED_INTAKE_MODE,
   PRELOVED_INTAKE_SOURCE,
   PrelovedCatalogMatchError,
   PrelovedExpiredStockError,
@@ -18,6 +17,8 @@ import {
   isPersistablePriceFractionOfNew,
   isPrelovedPriceAboveCap,
   parseActorId,
+  parseCommissionBps,
+  parseIntakeMode,
   parsePriceFraction,
   parseRefuseList,
   prelovedExpiresAt,
@@ -36,6 +37,14 @@ import {
   type DonationNoteListItem,
   type InsertDonationNoteInput,
 } from "@/lib/preloved-donate";
+import {
+  generateConsignmentTicketCode,
+  isValidCommissionBps,
+  type ConsignmentLotItemDraft,
+  type ConsignmentLotListItem,
+  type ConsignmentLotPayoutStatus,
+  type InsertConsignmentLotInput,
+} from "@/lib/preloved-consignment";
 import { policyTextWithPrelovedRefundClause } from "@/lib/preloved-refund-policy";
 import { logAuditEvent } from "@/lib/audit/log";
 import type { AuditActorRole } from "@/lib/audit/types";
@@ -44,10 +53,12 @@ import { db } from "./index";
 import {
   catalogItems,
   catalogVariants,
+  consignmentLots,
   prelovedDonationNotes,
   prelovedIntakeEvents,
   prelovedSkus,
   tenantPrelovedSettings,
+  type ConsignmentLotRow,
   type PrelovedDonationNoteRow,
   type PrelovedIntakeEventRow,
   type PrelovedSkuRow,
@@ -66,11 +77,12 @@ function mapSettingsRow(
   return {
     tenantId: row.tenantId,
     prelovedEnabled: row.prelovedEnabled,
-    intakeMode: PRELOVED_INTAKE_MODE,
+    intakeMode: parseIntakeMode(row.intakeMode),
     priceFractionOfNew: parsePriceFraction(row.priceFractionOfNew),
     holdDays: row.holdDays,
     donatedGstFree: row.donatedGstFree,
     refuseList: parseRefuseList(row.refuseList),
+    commissionBps: parseCommissionBps(row.commissionBps),
   };
 }
 
@@ -90,7 +102,7 @@ export const getPrelovedSettings = cache(async (tenantId: string): Promise<Prelo
 /**
  * Insert or update tenant preloved settings.
  * Only provided patch columns are written; omitted columns use DB defaults
- * on insert and stay unchanged on conflict. Commission is never written.
+ * on insert and stay unchanged on conflict.
  */
 export async function upsertPrelovedSettings(
   tenantId: string,
@@ -98,12 +110,15 @@ export async function upsertPrelovedSettings(
 ): Promise<PrelovedSettings> {
   const columns: {
     prelovedEnabled?: boolean;
+    intakeMode?: PrelovedSettings["intakeMode"];
     priceFractionOfNew?: string;
     holdDays?: number;
     donatedGstFree?: boolean;
     refuseList?: string[];
+    commissionBps?: number;
   } = {};
   if (patch.prelovedEnabled !== undefined) columns.prelovedEnabled = patch.prelovedEnabled;
+  if (patch.intakeMode !== undefined) columns.intakeMode = patch.intakeMode;
   if (patch.priceFractionOfNew !== undefined) {
     if (!isPersistablePriceFractionOfNew(patch.priceFractionOfNew)) {
       throw new RangeError(
@@ -117,6 +132,12 @@ export async function upsertPrelovedSettings(
   if (patch.holdDays !== undefined) columns.holdDays = patch.holdDays;
   if (patch.donatedGstFree !== undefined) columns.donatedGstFree = patch.donatedGstFree;
   if (patch.refuseList !== undefined) columns.refuseList = [...patch.refuseList];
+  if (patch.commissionBps !== undefined) {
+    if (!isValidCommissionBps(patch.commissionBps)) {
+      throw new RangeError("commissionBps must be an integer between 0 and 10000");
+    }
+    columns.commissionBps = patch.commissionBps;
+  }
 
   const [row] = await db
     .insert(tenantPrelovedSettings)
@@ -246,6 +267,120 @@ export async function listDonationNotes(
     .orderBy(desc(prelovedDonationNotes.createdAt))
     .limit(DONATION_NOTE_INBOX_LIMIT);
   return rows;
+}
+
+const CONSIGNMENT_LOT_LIST_LIMIT = 200;
+
+function parseLotItems(value: unknown): ConsignmentLotItemDraft[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(
+      (entry): entry is ConsignmentLotItemDraft =>
+        !!entry &&
+        typeof entry === "object" &&
+        typeof (entry as ConsignmentLotItemDraft).garment === "string" &&
+        typeof (entry as ConsignmentLotItemDraft).size === "string",
+    )
+    .map((entry) => ({
+      garment: entry.garment.trim(),
+      size: entry.size.trim(),
+    }));
+}
+
+function mapConsignmentLotRow(row: ConsignmentLotRow): ConsignmentLotListItem {
+  return {
+    id: row.id,
+    ticketCode: row.ticketCode,
+    familyName: row.familyName,
+    studentName: row.studentName,
+    email: row.email,
+    mobile: row.mobile,
+    payoutPreference: row.payoutPreference,
+    bankBsb: row.bankBsb,
+    bankAccountName: row.bankAccountName,
+    bankAccountNumber: row.bankAccountNumber,
+    unsoldPreference: row.unsoldPreference,
+    items: parseLotItems(row.items),
+    payoutStatus: row.payoutStatus,
+    payoutMarkedAt: row.payoutMarkedAt,
+    createdAt: row.createdAt,
+  };
+}
+
+/** Create a consignment lot with a unique ticket code (retry on collision). */
+export async function insertConsignmentLot(
+  input: InsertConsignmentLotInput,
+): Promise<ConsignmentLotRow> {
+  const items = input.items.map((item) => ({
+    garment: item.garment.trim(),
+    size: item.size.trim(),
+  }));
+  const termsAcceptedAt = new Date();
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const ticketCode = generateConsignmentTicketCode();
+    try {
+      const [row] = await db
+        .insert(consignmentLots)
+        .values({
+          tenantId: input.tenantId,
+          ticketCode,
+          familyName: input.familyName,
+          studentName: input.studentName,
+          email: input.email,
+          mobile: input.mobile,
+          payoutPreference: input.payoutPreference,
+          bankBsb: input.bankBsb ?? null,
+          bankAccountName: input.bankAccountName ?? null,
+          bankAccountNumber: input.bankAccountNumber ?? null,
+          unsoldPreference: input.unsoldPreference,
+          items,
+          termsAcceptedAt,
+        })
+        .returning();
+      return row;
+    } catch (err) {
+      if (isUniqueConstraintError(err) && attempt < 4) continue;
+      throw err;
+    }
+  }
+  throw new Error("Failed to allocate a consignment ticket code");
+}
+
+/** Newest consignment lots for the operator consignments tab. */
+export async function listConsignmentLots(
+  tenantId: string,
+): Promise<ConsignmentLotListItem[]> {
+  const rows = await db
+    .select()
+    .from(consignmentLots)
+    .where(eq(consignmentLots.tenantId, tenantId))
+    .orderBy(desc(consignmentLots.createdAt))
+    .limit(CONSIGNMENT_LOT_LIST_LIMIT);
+  return rows.map(mapConsignmentLotRow);
+}
+
+export async function markConsignmentLotPayout(opts: {
+  tenantId: string;
+  lotId: string;
+  payoutStatus: ConsignmentLotPayoutStatus;
+  actorId?: string | null;
+}): Promise<ConsignmentLotListItem | null> {
+  const actorId = parseActorId(opts.actorId);
+  const [row] = await db
+    .update(consignmentLots)
+    .set({
+      payoutStatus: opts.payoutStatus,
+      payoutMarkedAt: new Date(),
+      payoutMarkedBy: actorId,
+    })
+    .where(
+      and(
+        eq(consignmentLots.id, opts.lotId),
+        eq(consignmentLots.tenantId, opts.tenantId),
+      ),
+    )
+    .returning();
+  return row ? mapConsignmentLotRow(row) : null;
 }
 
 function variantHasSize(sizes: unknown, size: string): boolean {

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -93,6 +93,21 @@ export const prelovedIntakeActionEnum = pgEnum("preloved_intake_action", [
   "written_off",
 ]);
 
+export const consignmentPayoutPreferenceEnum = pgEnum(
+  "consignment_payout_preference",
+  ["eft", "school_fee_credit", "donate_proceeds"],
+);
+
+export const consignmentUnsoldPreferenceEnum = pgEnum(
+  "consignment_unsold_preference",
+  ["donate", "collect"],
+);
+
+export const consignmentLotPayoutStatusEnum = pgEnum(
+  "consignment_lot_payout_status",
+  ["pending", "school_fee_credited", "eft_paid", "donated_proceeds"],
+);
+
 // ─── Tenant legal versions ───────────────────────────────────────────────────
 // IMPORTANT: defined before `tenants` because `tenants.current_legal_version_id`
 // needs the FK target in scope. The opposite-direction FK (tenantId → tenants.id)
@@ -336,6 +351,53 @@ export const prelovedPaidDecrements = pgTable("preloved_paid_decrements", {
     .notNull()
     .defaultNow(),
 });
+
+// Phase 2 consignment lot (paper-form digital twin). Operator still inspects
+// each garment; items JSON is the parent's declared list, not stock.
+export const consignmentLots = pgTable(
+  "consignment_lots",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    ticketCode: text("ticket_code").notNull(),
+    familyName: text("family_name").notNull(),
+    studentName: text("student_name").notNull(),
+    email: text("email").notNull(),
+    mobile: text("mobile").notNull(),
+    payoutPreference: consignmentPayoutPreferenceEnum("payout_preference").notNull(),
+    bankBsb: text("bank_bsb"),
+    bankAccountName: text("bank_account_name"),
+    bankAccountNumber: text("bank_account_number"),
+    unsoldPreference: consignmentUnsoldPreferenceEnum("unsold_preference").notNull(),
+    items: jsonb("items")
+      .$type<{ garment: string; size: string }[]>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    termsAcceptedAt: timestamp("terms_accepted_at", { withTimezone: true }).notNull(),
+    payoutStatus: consignmentLotPayoutStatusEnum("payout_status")
+      .notNull()
+      .default("pending"),
+    payoutMarkedAt: timestamp("payout_marked_at", { withTimezone: true }),
+    payoutMarkedBy: uuid("payout_marked_by").references(() => neonAuthUsers.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    tenantTicketUnique: uniqueIndex("consignment_lots_tenant_ticket_unique").on(
+      t.tenantId,
+      t.ticketCode,
+    ),
+    tenantTimeIdx: index("idx_consignment_lots_tenant_time").on(
+      t.tenantId,
+      t.createdAt,
+    ),
+  }),
+);
 
 // ─── Pending order snapshots ─────────────────────────────────────────────────
 /**
@@ -662,3 +724,4 @@ export type TenantPrelovedSettingsRow = typeof tenantPrelovedSettings.$inferSele
 export type PrelovedSkuRow = typeof prelovedSkus.$inferSelect;
 export type PrelovedIntakeEventRow = typeof prelovedIntakeEvents.$inferSelect;
 export type PrelovedDonationNoteRow = typeof prelovedDonationNotes.$inferSelect;
+export type ConsignmentLotRow = typeof consignmentLots.$inferSelect;

--- a/apps/web/src/lib/preloved-consignment.ts
+++ b/apps/web/src/lib/preloved-consignment.ts
@@ -1,0 +1,146 @@
+/**
+ * Phase 2 consignment lots — parent form + operator payout marks.
+ * School-fee credit is a manual operator mark (no school-finance integration).
+ * This module must not import the DB client.
+ */
+
+export const CONSIGNMENT_PAYOUT_PREFERENCES = [
+  "eft",
+  "school_fee_credit",
+  "donate_proceeds",
+] as const;
+export type ConsignmentPayoutPreference =
+  (typeof CONSIGNMENT_PAYOUT_PREFERENCES)[number];
+
+export const CONSIGNMENT_UNSOLD_PREFERENCES = ["donate", "collect"] as const;
+export type ConsignmentUnsoldPreference =
+  (typeof CONSIGNMENT_UNSOLD_PREFERENCES)[number];
+
+export const CONSIGNMENT_LOT_PAYOUT_STATUSES = [
+  "pending",
+  "school_fee_credited",
+  "eft_paid",
+  "donated_proceeds",
+] as const;
+export type ConsignmentLotPayoutStatus =
+  (typeof CONSIGNMENT_LOT_PAYOUT_STATUSES)[number];
+
+export const MIN_CONSIGNMENT_ITEMS = 1;
+export const MAX_CONSIGNMENT_ITEMS = 30;
+export const DEFAULT_COMMISSION_BPS = 5000;
+export const MIN_COMMISSION_BPS = 0;
+export const MAX_COMMISSION_BPS = 10_000;
+
+/** Common shop commission presets (basis points). */
+export const COMMISSION_BPS_PRESETS = [2500, 3000, 4000, 5000] as const;
+
+export type ConsignmentLotItemDraft = {
+  garment: string;
+  size: string;
+};
+
+export type InsertConsignmentLotInput = {
+  tenantId: string;
+  familyName: string;
+  studentName: string;
+  email: string;
+  mobile: string;
+  payoutPreference: ConsignmentPayoutPreference;
+  bankBsb?: string | null;
+  bankAccountName?: string | null;
+  bankAccountNumber?: string | null;
+  unsoldPreference: ConsignmentUnsoldPreference;
+  items: ConsignmentLotItemDraft[];
+};
+
+export type ConsignmentLotListItem = {
+  id: string;
+  ticketCode: string;
+  familyName: string;
+  studentName: string;
+  email: string;
+  mobile: string;
+  payoutPreference: ConsignmentPayoutPreference;
+  bankBsb: string | null;
+  bankAccountName: string | null;
+  bankAccountNumber: string | null;
+  unsoldPreference: ConsignmentUnsoldPreference;
+  items: ConsignmentLotItemDraft[];
+  payoutStatus: ConsignmentLotPayoutStatus;
+  payoutMarkedAt: Date | null;
+  createdAt: Date;
+};
+
+export function isConsignmentIntakeMode(mode: string): boolean {
+  return mode === "donation_and_consignment";
+}
+
+export function formatPayoutPreference(
+  value: ConsignmentPayoutPreference,
+): string {
+  if (value === "eft") return "EFT";
+  if (value === "school_fee_credit") return "School-fee credit";
+  if (value === "donate_proceeds") return "Donate proceeds";
+  return value;
+}
+
+export function formatUnsoldPreference(
+  value: ConsignmentUnsoldPreference,
+): string {
+  if (value === "donate") return "Donate unsold to charity";
+  if (value === "collect") return "Collect within 14 days of expiry";
+  return value;
+}
+
+export function formatLotPayoutStatus(value: ConsignmentLotPayoutStatus): string {
+  if (value === "pending") return "Pending";
+  if (value === "school_fee_credited") return "School-fee credited";
+  if (value === "eft_paid") return "EFT paid";
+  if (value === "donated_proceeds") return "Proceeds donated";
+  return value;
+}
+
+export function formatCommissionPercent(bps: number): string {
+  return `${(bps / 100).toFixed(bps % 100 === 0 ? 0 : 1)}%`;
+}
+
+export function isValidCommissionBps(value: number): boolean {
+  return (
+    Number.isInteger(value) &&
+    value >= MIN_COMMISSION_BPS &&
+    value <= MAX_COMMISSION_BPS
+  );
+}
+
+/** Compact ticket for bag tags — e.g. CL-A3F9K2. */
+export function generateConsignmentTicketCode(now = new Date()): string {
+  const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  let suffix = "";
+  const seed =
+    now.getTime().toString(36).toUpperCase().replace(/[^A-Z0-9]/g, "") +
+    Math.random().toString(36).toUpperCase().replace(/[^A-Z0-9]/g, "");
+  for (let i = 0; i < seed.length && suffix.length < 6; i++) {
+    const ch = seed[i]!;
+    if (alphabet.includes(ch)) suffix += ch;
+  }
+  while (suffix.length < 6) {
+    suffix += alphabet[Math.floor(Math.random() * alphabet.length)]!;
+  }
+  return `CL-${suffix.slice(0, 6)}`;
+}
+
+export function normalizeBsb(value: string): string {
+  return value.replace(/\s|-/g, "");
+}
+
+export function isValidBsb(value: string): boolean {
+  return /^\d{6}$/.test(normalizeBsb(value));
+}
+
+export function payoutStatusForPreference(
+  preference: ConsignmentPayoutPreference,
+): ConsignmentLotPayoutStatus {
+  if (preference === "school_fee_credit") return "school_fee_credited";
+  if (preference === "eft") return "eft_paid";
+  return "donated_proceeds";
+}

--- a/apps/web/src/lib/preloved.ts
+++ b/apps/web/src/lib/preloved.ts
@@ -1,12 +1,21 @@
 /**
- * Phase 1 preloved domain types and in-code defaults.
- * Donation-only: no consignment or commission fields on the public settings type.
+ * Preloved domain types and in-code defaults.
+ * Phase 2 exposes intake mode + commission; donation-only remains the default.
  * This module must not import the DB client.
  */
 import { round2 } from "./order-totals";
+import {
+  DEFAULT_COMMISSION_BPS,
+  isValidCommissionBps,
+} from "./preloved-consignment";
 
+export const PRELOVED_INTAKE_MODES = [
+  "donation_only",
+  "donation_and_consignment",
+] as const;
+export type PrelovedIntakeMode = (typeof PRELOVED_INTAKE_MODES)[number];
+/** @deprecated Prefer PRELOVED_INTAKE_MODES[0]; kept for donation-default call sites. */
 export const PRELOVED_INTAKE_MODE = "donation_only" as const;
-export type PrelovedIntakeMode = typeof PRELOVED_INTAKE_MODE;
 
 export const PRELOVED_CONDITIONS = ["good", "fair"] as const;
 export type PrelovedCondition = (typeof PRELOVED_CONDITIONS)[number];
@@ -38,15 +47,18 @@ export type PrelovedSettings = {
   holdDays: number;
   donatedGstFree: boolean;
   refuseList: string[];
+  commissionBps: number;
 };
 
-/** Operator-writable settings. Intake mode and commission are not accepted. */
+/** Operator-writable settings including Phase 2 intake mode + commission. */
 export type PrelovedSettingsPatch = {
   prelovedEnabled?: boolean;
+  intakeMode?: PrelovedIntakeMode;
   priceFractionOfNew?: number;
   holdDays?: number;
   donatedGstFree?: boolean;
   refuseList?: string[];
+  commissionBps?: number;
 };
 
 export type AcceptAndPoolInput = {
@@ -128,7 +140,21 @@ export function defaultPrelovedSettings(tenantId: string): PrelovedSettings {
     holdDays: DEFAULT_HOLD_DAYS,
     donatedGstFree: false,
     refuseList: [...DEFAULT_REFUSE_LIST],
+    commissionBps: DEFAULT_COMMISSION_BPS,
   };
+}
+
+export function parseIntakeMode(value: unknown): PrelovedIntakeMode {
+  if (value === "donation_and_consignment" || value === "donation_only") {
+    return value;
+  }
+  return PRELOVED_INTAKE_MODE;
+}
+
+export function parseCommissionBps(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value ?? NaN);
+  if (!isValidCommissionBps(parsed)) return DEFAULT_COMMISSION_BPS;
+  return parsed;
 }
 
 export function parsePriceFraction(value: string | number | null | undefined): number {

--- a/apps/web/tests/preloved/m07-consignment-school-fee.spec.ts
+++ b/apps/web/tests/preloved/m07-consignment-school-fee.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Phase 2 first vertical: enable consignment, parent form with school-fee
+ * credit preference, operator lot list + manual credit mark.
+ *
+ * Needs pnpm dev:web. Prefer demo-academy like other Phase 1 follow-up gates.
+ */
+import { expect, test } from "playwright/test";
+import {
+  TENANT,
+  devLogin,
+  ensurePrelovedEnabled,
+} from "./helpers";
+
+test.describe("Phase 2 consignment / school-fee credit", () => {
+  test("parent submits lot; operator marks school-fee credited", async ({
+    page,
+  }) => {
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    await ensurePrelovedEnabled(page);
+
+    const enableRes = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+      data: {
+        prelovedEnabled: true,
+        intakeMode: "donation_and_consignment",
+        commissionBps: 5000,
+      },
+    });
+    expect(enableRes.ok()).toBeTruthy();
+
+    await page.goto(`/${TENANT}/preloved/consign`);
+    await expect(page.getByTestId("consign-page")).toBeVisible();
+    await expect(page.getByTestId("footer-consign-link")).toBeVisible();
+
+    await page.getByTestId("consign-family").locator("input").fill("Nguyen");
+    await page.getByTestId("consign-student").locator("input").fill("Minh");
+    await page.getByTestId("consign-email").locator("input").fill("parent@example.com");
+    await page.getByTestId("consign-mobile").locator("input").fill("0400000000");
+    await page.getByTestId("consign-payout-school_fee_credit").check();
+    await page.getByTestId("consign-unsold-donate").check();
+    await page.getByTestId("consign-item-garment-0").locator("input").fill("Sports polo");
+    await page.getByTestId("consign-item-size-0").locator("input").fill("10");
+    await page.getByTestId("consign-terms").check();
+    await page.getByTestId("consign-submit").click();
+
+    await expect(page.getByTestId("consign-form-success")).toBeVisible();
+    const ticket = (await page.getByTestId("consign-ticket-code").innerText()).trim();
+    expect(ticket).toMatch(/^CL-[A-Z0-9]{6}$/);
+
+    await page.goto(`/admin/${TENANT}/preloved/consignments`);
+    await expect(page.getByTestId("consignments-panel")).toBeVisible();
+    await expect(page.getByTestId("consignments-list")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const row = page.locator(`[data-testid="consignments-row"][data-ticket="${ticket}"]`);
+    await expect(row).toBeVisible();
+    await expect(row).toHaveAttribute("data-payout-status", "pending");
+    await row.getByTestId("consignments-mark-payout").click();
+    await expect(row).toHaveAttribute("data-payout-status", "school_fee_credited", {
+      timeout: 10_000,
+    });
+    await expect(row.getByTestId("consignments-status")).toContainText(
+      /School-fee credited/i,
+    );
+  });
+});

--- a/apps/web/tests/preloved/m07-consignment-school-fee.spec.ts
+++ b/apps/web/tests/preloved/m07-consignment-school-fee.spec.ts
@@ -62,5 +62,67 @@ test.describe("Phase 2 consignment / school-fee credit", () => {
     await expect(row.getByTestId("consignments-status")).toContainText(
       /School-fee credited/i,
     );
+
+    const lotId = await row.getAttribute("data-lot-id");
+    expect(lotId).toBeTruthy();
+
+    const remakeRes = await page.request.patch(
+      `/api/tenant/${TENANT}/preloved/consignment-lots/${lotId}`,
+      { data: { payoutStatus: "eft_paid" } },
+    );
+    expect(remakeRes.status()).toBe(409);
+    const remakeBody = (await remakeRes.json()) as {
+      code?: string;
+      lot?: { payoutStatus?: string; payoutMarkedAt?: string | null };
+    };
+    expect(remakeBody.code).toBe("already_marked");
+    expect(remakeBody.lot?.payoutStatus).toBe("school_fee_credited");
+    const markedAt = remakeBody.lot?.payoutMarkedAt;
+    expect(markedAt).toBeTruthy();
+
+    const remakeAgain = await page.request.patch(
+      `/api/tenant/${TENANT}/preloved/consignment-lots/${lotId}`,
+      { data: { payoutStatus: "donated_proceeds" } },
+    );
+    expect(remakeAgain.status()).toBe(409);
+    const remakeAgainBody = (await remakeAgain.json()) as {
+      lot?: { payoutStatus?: string; payoutMarkedAt?: string | null };
+    };
+    expect(remakeAgainBody.lot?.payoutStatus).toBe("school_fee_credited");
+    expect(remakeAgainBody.lot?.payoutMarkedAt).toBe(markedAt);
+    await expect(row).toHaveAttribute("data-payout-status", "school_fee_credited");
+
+    const createRes = await page.request.post(
+      `/api/tenant/${TENANT}/preloved/consign`,
+      {
+        data: {
+          familyName: "Derived",
+          studentName: "Status",
+          email: "derived@example.com",
+          mobile: "0400000001",
+          payoutPreference: "school_fee_credit",
+          unsoldPreference: "donate",
+          items: [{ garment: "Sports shorts", size: "12" }],
+          termsAccepted: true,
+        },
+      },
+    );
+    expect(createRes.ok()).toBeTruthy();
+    const created = (await createRes.json()) as {
+      ticketCode?: string;
+      id?: string;
+    };
+    expect(created.ticketCode).toMatch(/^CL-[A-Z0-9]{6}$/);
+    expect(created.id).toBeTruthy();
+
+    const deriveRes = await page.request.patch(
+      `/api/tenant/${TENANT}/preloved/consignment-lots/${created.id}`,
+      { data: { payoutStatus: "eft_paid" } },
+    );
+    expect(deriveRes.ok()).toBeTruthy();
+    const deriveBody = (await deriveRes.json()) as {
+      lot?: { payoutStatus?: string };
+    };
+    expect(deriveBody.lot?.payoutStatus).toBe("school_fee_credited");
   });
 });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:preloved-followups": "pnpm --filter web test:preloved-followups",
     "test:m05-parent-hydration": "pnpm --filter web test:m05-parent-hydration",
     "test:m06-last-unit-race": "pnpm --filter web test:m06-last-unit-race",
-    "test:preloved-test-gaps": "pnpm --filter web test:preloved-test-gaps"
+    "test:preloved-test-gaps": "pnpm --filter web test:preloved-test-gaps",
+    "test:m07-consignment-school-fee": "pnpm --filter web test:m07-consignment-school-fee"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/specs/_logs/OPEN_QUESTIONS.md
+++ b/specs/_logs/OPEN_QUESTIONS.md
@@ -20,8 +20,8 @@
 - [ ] **(plan)** Hats on the default refuse list not separately confirmed — raised: 2026-09-06, by: plan
       context: Spec default refuse list includes hats (Tara/CCGS). Some primary shops sell hats. Non-blocking; tenant can edit the list. Confirm only if hats should be allowed by default.
 
-- [ ] **(plan)** School-fee credit as a payout option — raised: 2026-09-06, by: plan
-      context: Phase 2 only. Not in M01–M06.
+- [x] **(plan)** School-fee credit as a payout option — raised: 2026-09-06, by: plan
+      context: Phase 2 first vertical (2026-09-12): parent consign form offers school-fee credit; operators mark lots manually. No school-finance integration. Payout CSV / sold-item linking still open.
 
 - [x] **(M04)** Operators have no inbox to read `preloved_donation_notes` — raised: 2026-09-07, by: build:M04
       context: Resolved 2026-09-12. Operator inbox at `/admin/[tenant]/preloved/inbox` lists `preloved_donation_notes` (empty / loading / error). Notes still do not create a SKU.


### PR DESCRIPTION
## Summary
First Phase 2 vertical for consignment / school-fee credit (does not rebuild Phase 1 or the platform portal).

- Settings: `intakeMode` donation + consignment, configurable `commissionBps`
- Parent consign form (`/[tenant]/preloved/consign`) with ticket code, payout preference (EFT / school-fee credit / donate proceeds), unsold preference, item list
- Operator Consignments tab: list lots (empty/loading/error), bank details for EFT, manual payout marks including school-fee credited
- Migration `0022_consignment_lots`

## Out of this PR
- Linking accepted garments to lot tickets on Intake
- Payout CSV / sold-item commission ledger
- School finance system integration (intentionally out of scope)

## Verify
- `pnpm check-types:web` — pass
- `pnpm test:m07-consignment-school-fee` against `pnpm dev:web` (demo-academy) — pass