### PR TITLE
feat(phase2): link consignment lots to intake and stock

### DIFF
--- a/apps/web/drizzle/0023_consignment_lot_intake.sql
+++ b/apps/web/drizzle/0023_consignment_lot_intake.sql
@@ -1,0 +1,32 @@
+ALTER TYPE "public"."preloved_intake_source" ADD VALUE IF NOT EXISTS 'consignment';--> statement-breakpoint
+ALTER TABLE "preloved_intake_events" ADD COLUMN IF NOT EXISTS "consignment_lot_id" uuid;--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "preloved_intake_events"
+    ADD CONSTRAINT "preloved_intake_events_consignment_lot_id_consignment_lots_id_fk"
+    FOREIGN KEY ("consignment_lot_id") REFERENCES "consignment_lots"("id")
+    ON DELETE set null ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_preloved_intake_events_lot_time"
+  ON "preloved_intake_events" ("consignment_lot_id", "created_at");--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "consignment_items" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" text NOT NULL REFERENCES "tenants"("id") ON DELETE cascade,
+	"lot_id" uuid NOT NULL REFERENCES "consignment_lots"("id") ON DELETE cascade,
+	"preloved_sku_id" uuid NOT NULL REFERENCES "preloved_skus"("id") ON DELETE restrict,
+	"intake_event_id" uuid NOT NULL REFERENCES "preloved_intake_events"("id") ON DELETE restrict,
+	"source_item_id" text NOT NULL REFERENCES "catalog_items"("id") ON DELETE restrict,
+	"size" text NOT NULL,
+	"condition" "preloved_condition" NOT NULL,
+	"qty" integer DEFAULT 1 NOT NULL,
+	"sold_order_line_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "consignment_items_qty_positive" CHECK ("qty" >= 1)
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "consignment_items_intake_event_unique"
+  ON "consignment_items" ("intake_event_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_consignment_items_lot_time"
+  ON "consignment_items" ("lot_id", "created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_consignment_items_sku_time"
+  ON "consignment_items" ("preloved_sku_id", "created_at");

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1789000000000,
       "tag": "0022_consignment_lots",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1789100000000,
+      "tag": "0023_consignment_lot_intake",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "test:m06-last-unit-race": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online PRELOVED_ITEM_ID=rvra-polo-ss PRELOVED_ITEM_NAME='Polo Shirt — Short Sleeve' playwright test -c playwright.config.ts tests/preloved/m06-last-unit-race.spec.ts",
     "test:preloved-test-gaps": "pnpm test:m05-parent-hydration && pnpm test:m06-last-unit-race",
     "test:m07-consignment-school-fee": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online playwright test -c playwright.config.ts tests/preloved/m07-consignment-school-fee.spec.ts",
+    "test:m08-lot-intake": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online PRELOVED_ITEM_ID=rvra-polo-ss PRELOVED_ITEM_NAME='Polo Shirt — Short Sleeve' playwright test -c playwright.config.ts tests/preloved/m08-lot-intake.spec.ts",
     "demo:seed:dry": "node ../../demo/demo_data/run.mjs seed --dry-run",
     "demo:seed": "node ../../demo/demo_data/run.mjs seed",
     "demo:cleanup": "node ../../demo/demo_data/run.mjs cleanup",

--- a/apps/web/src/app/admin/[tenant]/preloved/consignments/consignments-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/consignments/consignments-client.tsx
@@ -30,6 +30,16 @@ export type ConsignmentLotRow = {
   payoutStatus: ConsignmentLotPayoutStatus;
   payoutMarkedAt: string | null;
   createdAt: string;
+  acceptedUnits: {
+    id: string;
+    skuId: string;
+    itemName: string;
+    size: string;
+    condition: "good" | "fair";
+    qty: number;
+    createdAt: string;
+  }[];
+  acceptedQty: number;
 };
 
 function formatReceived(iso: string, timeZone: string) {
@@ -134,9 +144,10 @@ export function ConsignmentsClient({
         className="text-[13px] mb-4 max-w-2xl"
         style={{ color: "var(--color-ink-dim)" }}
       >
-        Parent consignment lots. Bank details are operator-only. Mark school-fee
-        credit, EFT, or donated proceeds by hand — there is no school-finance
-        integration.
+        Parent consignment lots. Accept garments on Intake against a ticket so
+        sold units can be attributed later. Bank details are operator-only. Mark
+        school-fee credit, EFT, or donated proceeds by hand — there is no
+        school-finance integration.
         {commissionBps != null
           ? ` Shop commission: ${formatCommissionPercent(commissionBps)}.`
           : null}
@@ -235,7 +246,7 @@ function LotsEmpty() {
         style={{ color: "var(--color-ink-dim)" }}
       >
         When a parent submits the consign form, the lot and ticket code appear
-        here. Accept garments on Intake after inspection.
+        here. Accept garments on Intake against that ticket after inspection.
       </p>
     </div>
   );
@@ -270,6 +281,7 @@ function LotsList({
             data-lot-id={lot.id}
             data-ticket={lot.ticketCode}
             data-payout-status={lot.payoutStatus}
+            data-accepted-qty={String(lot.acceptedQty ?? 0)}
           >
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
@@ -318,11 +330,35 @@ function LotsList({
                   </dd>
                 </>
               ) : null}
-              <dt style={{ color: "var(--color-ink-dim)" }}>Items</dt>
+              <dt style={{ color: "var(--color-ink-dim)" }}>Declared</dt>
               <dd style={{ color: "var(--color-ink)" }}>
                 {lot.items
                   .map((item) => `${item.garment} (${item.size})`)
                   .join(", ")}
+              </dd>
+              <dt style={{ color: "var(--color-ink-dim)" }}>On rack</dt>
+              <dd
+                style={{ color: "var(--color-ink)" }}
+                data-testid="consignments-accepted"
+              >
+                {(lot.acceptedUnits ?? []).length === 0 ? (
+                  <span data-testid="consignments-accepted-empty">
+                    None accepted yet. Link this ticket on Intake.
+                  </span>
+                ) : (
+                  <ul className="space-y-0.5">
+                    {(lot.acceptedUnits ?? []).map((unit) => (
+                      <li
+                        key={unit.id}
+                        data-testid="consignments-accepted-row"
+                        data-sku-id={unit.skuId}
+                      >
+                        {unit.itemName} · {unit.size} · {unit.condition} · qty{" "}
+                        {unit.qty}
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </dd>
             </dl>
 

--- a/apps/web/src/app/admin/[tenant]/preloved/intake/intake-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/intake/intake-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Button,
   Description,
@@ -10,6 +10,7 @@ import {
   Radio,
   RadioGroup,
   Select,
+  Spinner,
   TextArea,
   TextField,
 } from "@heroui/react";
@@ -42,6 +43,15 @@ type IntakeSuccess = {
   kind: "accepted" | "rejected";
   message: string;
 };
+
+type IntakeLotOption = {
+  id: string;
+  ticketCode: string;
+  familyName: string;
+  studentName: string;
+};
+
+const DONATION_SOURCE = "donation";
 
 function asKey(value: Key | Key[] | null): string {
   if (typeof value === "string" || typeof value === "number") return String(value);
@@ -110,6 +120,55 @@ export function IntakeClient({
   const [pending, setPending] = useState<"accepted" | "rejected" | null>(null);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState<IntakeSuccess | null>(null);
+  const [sourceKey, setSourceKey] = useState(DONATION_SOURCE);
+  const [lots, setLots] = useState<IntakeLotOption[] | null>(null);
+  const [lotsLoading, setLotsLoading] = useState(false);
+  const [lotsError, setLotsError] = useState("");
+
+  const consignmentDesk = isConsignmentIntakeMode(intakeMode);
+
+  const loadLots = useCallback(async () => {
+    if (!isConsignmentIntakeMode(intakeMode)) {
+      setLots([]);
+      setLotsError("");
+      setLotsLoading(false);
+      return;
+    }
+    setLotsLoading(true);
+    setLotsError("");
+    try {
+      const res = await fetch(`/api/tenant/${tenantId}/preloved/consignment-lots`);
+      const data = (await res.json().catch(() => null)) as {
+        error?: string;
+        lots?: IntakeLotOption[];
+      } | null;
+      if (!res.ok) {
+        throw new Error(data?.error ?? "Failed to load consignment lots.");
+      }
+      setLots(
+        Array.isArray(data?.lots)
+          ? data.lots.map((lot) => ({
+              id: lot.id,
+              ticketCode: lot.ticketCode,
+              familyName: lot.familyName,
+              studentName: lot.studentName,
+            }))
+          : [],
+      );
+    } catch (err) {
+      console.error("Intake lots load failed:", err);
+      setLots(null);
+      setLotsError(
+        err instanceof Error ? err.message : "Failed to load consignment lots.",
+      );
+    } finally {
+      setLotsLoading(false);
+    }
+  }, [intakeMode, tenantId]);
+
+  useEffect(() => {
+    void loadLots();
+  }, [loadLots]);
 
   const selectedItem = catalog.find((item) => item.id === itemId);
   const sizeOptions = sizesForItem(selectedItem);
@@ -189,6 +248,10 @@ export function IntakeClient({
     setSuccess(null);
     try {
       const note = defectNote.trim();
+      const selectedLot =
+        sourceKey !== DONATION_SOURCE
+          ? lots?.find((lot) => lot.id === sourceKey)
+          : undefined;
       const data = await postIntake({
         action: "accepted",
         sourceItemId: itemId,
@@ -196,12 +259,16 @@ export function IntakeClient({
         condition,
         price: appliedPrice,
         ...(note.length > 0 ? { defectNote: note } : {}),
+        ...(selectedLot ? { consignmentLotId: selectedLot.id } : {}),
       });
       const qty = data?.sku?.qtyOnHand;
       const qtyBit = typeof qty === "number" ? ` Qty on hand is now ${qty}.` : "";
+      const sourceBit = selectedLot
+        ? ` Linked to ${selectedLot.ticketCode}.`
+        : " Donation pooled on the rack.";
       setSuccess({
         kind: "accepted",
-        message: `Accepted ${selectedItem?.name ?? "item"} size ${size} (${formatPrelovedCondition(condition)}). Donation pooled on the rack.${qtyBit}`,
+        message: `Accepted ${selectedItem?.name ?? "item"} size ${size} (${formatPrelovedCondition(condition)}).${sourceBit}${qtyBit}`,
       });
       setDefectNote("");
     } catch (err) {
@@ -246,9 +313,11 @@ export function IntakeClient({
   return (
     <div className="flex-1 overflow-y-auto p-7" data-testid="intake-desk">
       <p className="text-[13px] mb-4 max-w-2xl" style={{ color: "var(--color-ink-dim)" }}>
-        Inspect a washed current-uniform donation. Match the new catalogue item
-        and size, set Good or Fair, then accept onto the pooled rack. Source is
-        donation only.
+        Inspect a washed current-uniform garment. Match the new catalogue item
+        and size, set Good or Fair, then accept onto the pooled rack.
+        {consignmentDesk
+          ? " Link a consignment ticket so sold units can be attributed to that lot."
+          : " Source is donation only."}
       </p>
 
       {error ? (
@@ -352,15 +421,25 @@ export function IntakeClient({
               ))}
             </RadioGroup>
 
-            <TextField isReadOnly name="source" value="Donation">
-              <Label>Source</Label>
-              <Input />
-              <Description>
-                {isConsignmentIntakeMode(intakeMode)
-                  ? "This desk still accepts donations into the pooled rack. Link garments to a consignment lot ticket in a later slice."
-                  : "Donation only. Turn on donation + consignment in Settings to open the consign form."}
-              </Description>
-            </TextField>
+            {consignmentDesk ? (
+              <IntakeLotField
+                sourceKey={sourceKey}
+                lots={lots}
+                loading={lotsLoading}
+                error={lotsError}
+                onChange={setSourceKey}
+                onRetry={() => void loadLots()}
+              />
+            ) : (
+              <TextField isReadOnly name="source" value="Donation">
+                <Label>Source</Label>
+                <Input />
+                <Description>
+                  Donation only. Turn on donation + consignment in Settings to
+                  open the consign form and link tickets here.
+                </Description>
+              </TextField>
+            )}
 
             <TextField
               name="price"
@@ -458,6 +537,112 @@ export function IntakeClient({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function IntakeLotField({
+  sourceKey,
+  lots,
+  loading,
+  error,
+  onChange,
+  onRetry,
+}: {
+  sourceKey: string;
+  lots: IntakeLotOption[] | null;
+  loading: boolean;
+  error: string;
+  onChange: (value: string) => void;
+  onRetry: () => void;
+}) {
+  const options = lots ?? [];
+
+  return (
+    <div className="md:col-span-2" data-testid="intake-lot-field">
+      {loading ? (
+        <div
+          className="flex items-center gap-2 mb-2 text-[12.5px]"
+          style={{ color: "var(--color-ink-dim)" }}
+          data-testid="intake-lot-loading"
+          role="status"
+          aria-live="polite"
+        >
+          <Spinner size="sm" color="current" className="text-[var(--color-gold)]" />
+          Loading consignment lots…
+        </div>
+      ) : null}
+
+      {error ? (
+        <div
+          className="mb-2 text-[12.5px] px-3 py-2 rounded"
+          style={{ background: "#FEF2F2", color: "#B91C1C" }}
+          role="alert"
+          data-testid="intake-lot-error"
+        >
+          <p>{error}</p>
+          <button
+            type="button"
+            className="mt-1 underline font-semibold"
+            onClick={onRetry}
+            data-testid="intake-lot-retry"
+          >
+            Try again
+          </button>
+        </div>
+      ) : null}
+
+      {!loading && !error && options.length === 0 ? (
+        <p
+          className="mb-2 text-[12.5px]"
+          style={{ color: "var(--color-ink-dim)" }}
+          data-testid="intake-lot-empty"
+        >
+          No consignment lots yet. Parents submit the consign form first. You
+          can still accept this garment as a donation.
+        </p>
+      ) : null}
+
+      <Select
+        fullWidth
+        name="consignmentLotId"
+        placeholder="Donation (pooled rack)"
+        value={sourceKey}
+        onChange={(value) => onChange(asKey(value) || DONATION_SOURCE)}
+        data-testid="intake-lot"
+      >
+        <Label>Source lot</Label>
+        <Select.Trigger>
+          <Select.Value />
+          <Select.Indicator />
+        </Select.Trigger>
+        <Select.Popover>
+          <ListBox>
+            <ListBox.Item
+              id={DONATION_SOURCE}
+              textValue="Donation (pooled rack)"
+            >
+              Donation (pooled rack)
+              <ListBox.ItemIndicator />
+            </ListBox.Item>
+            {options.map((lot) => (
+              <ListBox.Item
+                key={lot.id}
+                id={lot.id}
+                textValue={`${lot.ticketCode} ${lot.familyName} ${lot.studentName}`}
+              >
+                {lot.ticketCode} — {lot.familyName} / {lot.studentName}
+                <ListBox.ItemIndicator />
+              </ListBox.Item>
+            ))}
+          </ListBox>
+        </Select.Popover>
+        <Description>
+          Consigned garments still pool on the rack by item, size, and
+          condition. The ticket is stored so a later payout CSV can attribute
+          sold units.
+        </Description>
+      </Select>
     </div>
   );
 }

--- a/apps/web/src/app/admin/[tenant]/preloved/intake/intake-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/intake/intake-client.tsx
@@ -233,6 +233,12 @@ export function IntakeClient({
     return data;
   };
 
+  const selectedLot =
+    sourceKey !== DONATION_SOURCE
+      ? lots?.find((lot) => lot.id === sourceKey)
+      : undefined;
+  const unresolvedTicket = sourceKey !== DONATION_SOURCE && !selectedLot;
+
   const handleAccept = async () => {
     if (!itemId || !size || !matchedVariant) {
       setError("Match an existing catalogue item and size before accepting.");
@@ -242,16 +248,22 @@ export function IntakeClient({
       setError("Enter a price greater than 0.");
       return;
     }
+    if (unresolvedTicket) {
+      setError(
+        lotsLoading
+          ? "Wait for consignment lots to load before accepting against a ticket."
+          : lotsError
+            ? "Reload consignment lots before accepting against a ticket."
+            : "That ticket is no longer in the list. Pick donation or a current ticket.",
+      );
+      return;
+    }
 
     setPending("accepted");
     setError("");
     setSuccess(null);
     try {
       const note = defectNote.trim();
-      const selectedLot =
-        sourceKey !== DONATION_SOURCE
-          ? lots?.find((lot) => lot.id === sourceKey)
-          : undefined;
       const data = await postIntake({
         action: "accepted",
         sourceItemId: itemId,
@@ -517,7 +529,7 @@ export function IntakeClient({
           <div className="flex flex-wrap items-center gap-3 pt-5">
             <Button
               isPending={pending === "accepted"}
-              isDisabled={pending !== null}
+              isDisabled={pending !== null || unresolvedTicket}
               onPress={handleAccept}
               className="font-semibold text-white shadow-none"
               style={{ background: tenant.accent }}
@@ -590,7 +602,17 @@ function IntakeLotField({
             Try again
           </button>
         </div>
-      ) : null}
+      ) : (
+        <button
+          type="button"
+          className="mb-2 text-[12.5px] underline font-semibold"
+          style={{ color: "var(--color-ink-dim)" }}
+          onClick={onRetry}
+          data-testid="intake-lot-retry"
+        >
+          Refresh tickets
+        </button>
+      )}
 
       {!loading && !error && options.length === 0 ? (
         <p

--- a/apps/web/src/app/admin/[tenant]/preloved/stock/page.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/stock/page.tsx
@@ -3,7 +3,7 @@ import { getTenant, toTenantBrand } from "@/db/queries";
 import { listInStockPrelovedSkus } from "@/db/preloved-queries";
 import { formatPrelovedCondition, type PrelovedStockListItem } from "@/lib/preloved";
 
-const COLUMNS = ["Item", "Size", "Condition", "Qty", "Price", "Expiry"] as const;
+const COLUMNS = ["Item", "Lot", "Size", "Condition", "Qty", "Price", "Expiry"] as const;
 
 export default async function AdminPrelovedStockPage({
   params,
@@ -89,6 +89,14 @@ function StockRow({
       <td className="py-3 px-4 font-medium" style={{ color: "var(--color-ink)" }}>
         {row.itemName}
       </td>
+      <td
+        className="py-3 px-4 tnum"
+        style={{ color: "var(--color-ink)" }}
+        data-testid="stock-lot-tickets"
+        data-lot-tickets={row.lotTickets.join(",")}
+      >
+        {row.lotTickets.length > 0 ? row.lotTickets.join(", ") : "—"}
+      </td>
       <td className="py-3 px-4" style={{ color: "var(--color-ink)" }}>
         {row.size}
       </td>
@@ -137,9 +145,9 @@ function EmptyStockState() {
         No preloved stock on the rack
       </h2>
       <p className="text-[13.5px] leading-[1.5] max-w-md" style={{ color: "var(--color-ink-dim)" }}>
-        Accepted donations pool here by item, size, and condition. Written-off
-        garments with quantity 0 are omitted. Use Intake to accept a washed
-        garment onto the rack.
+        Accepted donations and consigned garments pool here by item, size, and
+        condition. Linked tickets show in the Lot column. Written-off garments
+        with quantity 0 are omitted. Use Intake to accept a washed garment.
       </p>
     </div>
   );

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/[lotId]/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/[lotId]/route.ts
@@ -18,6 +18,10 @@ function serializeLot(lot: ConsignmentLotListItem) {
     ...lot,
     createdAt: lot.createdAt.toISOString(),
     payoutMarkedAt: lot.payoutMarkedAt?.toISOString() ?? null,
+    acceptedUnits: lot.acceptedUnits.map((unit) => ({
+      ...unit,
+      createdAt: unit.createdAt.toISOString(),
+    })),
   };
 }
 

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/route.ts
@@ -43,6 +43,10 @@ export async function GET(
         ...lot,
         createdAt: lot.createdAt.toISOString(),
         payoutMarkedAt: lot.payoutMarkedAt?.toISOString() ?? null,
+        acceptedUnits: lot.acceptedUnits.map((unit) => ({
+          ...unit,
+          createdAt: unit.createdAt.toISOString(),
+        })),
       })),
     });
   } catch (err) {

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/intake/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/intake/route.ts
@@ -10,6 +10,8 @@ import { ensureTenantAccess, requireSessionUser } from "@/lib/auth/authorization
 import {
   PRELOVED_CONDITIONS,
   PrelovedCatalogMatchError,
+  PrelovedConsignmentLotNotFoundError,
+  PrelovedConsignmentNotEnabledError,
   PrelovedExpiredStockError,
 } from "@/lib/preloved";
 
@@ -21,6 +23,7 @@ const AcceptedSchema = z
     condition: z.enum(PRELOVED_CONDITIONS),
     price: z.number().finite().positive().max(10000).optional(),
     defectNote: z.string().trim().max(500).nullable().optional(),
+    consignmentLotId: z.string().uuid().optional(),
   })
   .strict();
 
@@ -62,7 +65,8 @@ function mapSku(row: {
   };
 }
 
-// POST /api/tenant/:tenantId/preloved/intake — operator accept/reject. Donation only.
+// POST /api/tenant/:tenantId/preloved/intake — operator accept/reject.
+// Donation by default; optional consignmentLotId attributes the unit to a lot.
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ tenantId: string }> },
@@ -128,6 +132,7 @@ export async function POST(
       price: parsed.data.price,
       defectNote: parsed.data.defectNote,
       actorId: authResult.user.id,
+      consignmentLotId: parsed.data.consignmentLotId ?? null,
     });
 
     return NextResponse.json({
@@ -135,16 +140,31 @@ export async function POST(
       sku: mapSku(result.sku),
       defaultPrice: result.defaultPrice,
       priceAboveCap: result.priceAboveCap,
+      lot: result.lot,
       event: {
         id: result.event.id,
         action: result.event.action,
         qty: result.event.qty,
         prelovedSkuId: result.event.prelovedSkuId,
+        source: result.event.source,
+        consignmentLotId: result.event.consignmentLotId,
       },
     });
   } catch (err) {
     if (err instanceof PrelovedCatalogMatchError) {
       return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    if (err instanceof PrelovedConsignmentNotEnabledError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: 400 },
+      );
+    }
+    if (err instanceof PrelovedConsignmentLotNotFoundError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: 404 },
+      );
     }
     if (err instanceof PrelovedExpiredStockError) {
       return NextResponse.json(

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/intake/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/intake/route.ts
@@ -13,6 +13,7 @@ import {
   PrelovedConsignmentLotNotFoundError,
   PrelovedConsignmentNotEnabledError,
   PrelovedExpiredStockError,
+  PrelovedGstPoolConflictError,
 } from "@/lib/preloved";
 
 const AcceptedSchema = z
@@ -167,6 +168,12 @@ export async function POST(
       );
     }
     if (err instanceof PrelovedExpiredStockError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: 409 },
+      );
+    }
+    if (err instanceof PrelovedGstPoolConflictError) {
       return NextResponse.json(
         { error: err.message, code: err.code },
         { status: 409 },

--- a/apps/web/src/db/preloved-queries.ts
+++ b/apps/web/src/db/preloved-queries.ts
@@ -3,11 +3,14 @@
  * Kept out of queries.ts so GST/report work in queries.ts does not clash.
  */
 import { cache } from "react";
-import { and, asc, desc, eq, gt, isNotNull, lt, sql } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import { and, asc, desc, eq, gt, inArray, isNotNull, lt, sql } from "drizzle-orm";
 import {
   DEFAULT_PRICE_FRACTION_OF_NEW,
   PRELOVED_INTAKE_SOURCE,
   PrelovedCatalogMatchError,
+  PrelovedConsignmentLotNotFoundError,
+  PrelovedConsignmentNotEnabledError,
   PrelovedExpiredStockError,
   PrelovedInsufficientQtyError,
   PrelovedWriteOffNotEligibleError,
@@ -39,8 +42,10 @@ import {
 } from "@/lib/preloved-donate";
 import {
   generateConsignmentTicketCode,
+  isConsignmentIntakeMode,
   isValidCommissionBps,
   payoutStatusForPreference,
+  type ConsignmentAcceptedUnit,
   type ConsignmentLotItemDraft,
   type ConsignmentLotListItem,
   type InsertConsignmentLotInput,
@@ -53,6 +58,7 @@ import { db } from "./index";
 import {
   catalogItems,
   catalogVariants,
+  consignmentItems,
   consignmentLots,
   prelovedDonationNotes,
   prelovedIntakeEvents,
@@ -304,7 +310,110 @@ function mapConsignmentLotRow(row: ConsignmentLotRow): ConsignmentLotListItem {
     payoutStatus: row.payoutStatus,
     payoutMarkedAt: row.payoutMarkedAt,
     createdAt: row.createdAt,
+    acceptedUnits: [],
+    acceptedQty: 0,
   };
+}
+
+export async function getConsignmentLot(
+  tenantId: string,
+  lotId: string,
+): Promise<ConsignmentLotRow | null> {
+  const [row] = await db
+    .select()
+    .from(consignmentLots)
+    .where(
+      and(eq(consignmentLots.id, lotId), eq(consignmentLots.tenantId, tenantId)),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+async function attachAcceptedUnits(
+  tenantId: string,
+  lots: ConsignmentLotListItem[],
+): Promise<ConsignmentLotListItem[]> {
+  if (lots.length === 0) return lots;
+  const lotIds = lots.map((lot) => lot.id);
+  const rows = await db
+    .select({
+      id: consignmentItems.id,
+      lotId: consignmentItems.lotId,
+      skuId: consignmentItems.prelovedSkuId,
+      itemName: catalogItems.name,
+      size: consignmentItems.size,
+      condition: consignmentItems.condition,
+      qty: consignmentItems.qty,
+      createdAt: consignmentItems.createdAt,
+    })
+    .from(consignmentItems)
+    .innerJoin(catalogItems, eq(catalogItems.id, consignmentItems.sourceItemId))
+    .where(
+      and(
+        eq(consignmentItems.tenantId, tenantId),
+        inArray(consignmentItems.lotId, lotIds),
+      ),
+    )
+    .orderBy(desc(consignmentItems.createdAt));
+
+  const byLot = new Map<string, ConsignmentAcceptedUnit[]>();
+  for (const row of rows) {
+    const unit: ConsignmentAcceptedUnit = {
+      id: row.id,
+      skuId: row.skuId,
+      itemName: row.itemName,
+      size: row.size,
+      condition: row.condition,
+      qty: row.qty,
+      createdAt: row.createdAt,
+    };
+    const list = byLot.get(row.lotId) ?? [];
+    list.push(unit);
+    byLot.set(row.lotId, list);
+  }
+
+  return lots.map((lot) => {
+    const acceptedUnits = byLot.get(lot.id) ?? [];
+    return {
+      ...lot,
+      acceptedUnits,
+      acceptedQty: acceptedUnits.reduce((sum, unit) => sum + unit.qty, 0),
+    };
+  });
+}
+
+async function attachLotTickets(
+  tenantId: string,
+  items: PrelovedStockListItem[],
+): Promise<PrelovedStockListItem[]> {
+  if (items.length === 0) return items;
+  const skuIds = items.map((item) => item.id);
+  const rows = await db
+    .select({
+      skuId: consignmentItems.prelovedSkuId,
+      ticketCode: consignmentLots.ticketCode,
+    })
+    .from(consignmentItems)
+    .innerJoin(consignmentLots, eq(consignmentLots.id, consignmentItems.lotId))
+    .where(
+      and(
+        eq(consignmentItems.tenantId, tenantId),
+        inArray(consignmentItems.prelovedSkuId, skuIds),
+      ),
+    )
+    .orderBy(asc(consignmentLots.ticketCode));
+
+  const bySku = new Map<string, string[]>();
+  for (const row of rows) {
+    const list = bySku.get(row.skuId) ?? [];
+    if (!list.includes(row.ticketCode)) list.push(row.ticketCode);
+    bySku.set(row.skuId, list);
+  }
+
+  return items.map((item) => ({
+    ...item,
+    lotTickets: bySku.get(item.id) ?? [],
+  }));
 }
 
 /** Create a consignment lot with a unique ticket code (retry on collision). */
@@ -356,7 +465,7 @@ export async function listConsignmentLots(
     .where(eq(consignmentLots.tenantId, tenantId))
     .orderBy(desc(consignmentLots.createdAt))
     .limit(CONSIGNMENT_LOT_LIST_LIMIT);
-  return rows.map(mapConsignmentLotRow);
+  return attachAcceptedUnits(tenantId, rows.map(mapConsignmentLotRow));
 }
 
 export type MarkConsignmentLotPayoutResult =
@@ -389,10 +498,13 @@ export async function markConsignmentLotPayout(opts: {
     return { ok: false, reason: "not_found" };
   }
   if (existing.payoutStatus !== "pending") {
+    const [lot] = await attachAcceptedUnits(opts.tenantId, [
+      mapConsignmentLotRow(existing),
+    ]);
     return {
       ok: false,
       reason: "already_marked",
-      lot: mapConsignmentLotRow(existing),
+      lot,
     };
   }
 
@@ -415,14 +527,20 @@ export async function markConsignmentLotPayout(opts: {
     if (!current) {
       return { ok: false, reason: "not_found" };
     }
+    const [lot] = await attachAcceptedUnits(opts.tenantId, [
+      mapConsignmentLotRow(current),
+    ]);
     return {
       ok: false,
       reason: "already_marked",
-      lot: mapConsignmentLotRow(current),
+      lot,
     };
   }
 
-  return { ok: true, lot: mapConsignmentLotRow(row) };
+  const [lot] = await attachAcceptedUnits(opts.tenantId, [
+    mapConsignmentLotRow(row),
+  ]);
+  return { ok: true, lot };
 }
 
 function variantHasSize(sizes: unknown, size: string): boolean {
@@ -471,6 +589,7 @@ function mapStockListItem(row: {
     listedAt: row.listedAt,
     expiresAt: row.expiresAt,
     defectNote: row.defectNote,
+    lotTickets: [],
   };
 }
 
@@ -480,6 +599,7 @@ export type AcceptAndPoolResult = {
   defaultPrice: number;
   appliedPrice: number;
   priceAboveCap: boolean;
+  lot: { id: string; ticketCode: string } | null;
 };
 
 /** True when ON CONFLICT may increment (restock qty 0, or not yet expired). */
@@ -488,14 +608,15 @@ function canAcceptOntoSku(listedAt: Date) {
 }
 
 /**
- * Pool one donated garment onto the (tenant, item, size, condition) SKU.
+ * Pool one garment onto the (tenant, item, size, condition) SKU.
  * ON CONFLICT increments qty_on_hand on the existing row (same id).
- * Restock after qty 0 restarts listedAt/expiresAt, recopies donatedGstFree,
- * and applies the new price (and defectNote when sent). Pooling onto in-stock
- * qty only increments qty_on_hand.
+ * Restock after qty 0 restarts listedAt/expiresAt, recopies donatedGstFree
+ * (or taxable when the unit is consigned), and applies the new price (and
+ * defectNote when sent). Pooling onto in-stock qty only increments qty_on_hand.
  * Accept onto expired in-stock qty is refused until write-off (qty 0).
- * SKU upsert and accepted event insert run in one db.batch so a failed event
- * cannot leave a qty increment that a client retry would apply again.
+ * A consignment lot writes source=consignment plus a consignment_items row so
+ * later sold-line remittance can attribute the unit. SKU upsert, accepted
+ * event, and optional item insert run in one db.batch.
  * The event is INSERT … SELECT of the eligible unique-key row because batch
  * queries are composed before INSERT … RETURNING is available, and a VALUES
  * insert would still write an event when the conflict WHERE no-ops.
@@ -504,6 +625,17 @@ export async function acceptAndPool(
   input: AcceptAndPoolInput,
 ): Promise<AcceptAndPoolResult> {
   const settings = await getPrelovedSettings(input.tenantId);
+  const lotId = input.consignmentLotId?.trim() || null;
+  let lot: ConsignmentLotRow | null = null;
+  if (lotId) {
+    if (!isConsignmentIntakeMode(settings.intakeMode)) {
+      throw new PrelovedConsignmentNotEnabledError();
+    }
+    lot = await getConsignmentLot(input.tenantId, lotId);
+    if (!lot) {
+      throw new PrelovedConsignmentLotNotFoundError();
+    }
+  }
 
   const catalogRows = await db
     .select({
@@ -553,7 +685,7 @@ export async function acceptAndPool(
   } = {
     qtyOnHand: sql`${prelovedSkus.qtyOnHand} + 1`,
     price: sql`CASE WHEN ${prelovedSkus.qtyOnHand} = 0 THEN ${priceSql}::numeric ELSE ${prelovedSkus.price} END`,
-    gstFree: sql`CASE WHEN ${prelovedSkus.qtyOnHand} = 0 THEN ${settings.donatedGstFree} ELSE ${prelovedSkus.gstFree} END`,
+    gstFree: sql`CASE WHEN ${prelovedSkus.qtyOnHand} = 0 THEN ${lot ? false : settings.donatedGstFree} ELSE ${prelovedSkus.gstFree} END`,
     listedAt: sql`CASE WHEN ${prelovedSkus.qtyOnHand} = 0 THEN ${listedAt} ELSE ${prelovedSkus.listedAt} END`,
     expiresAt: sql`CASE WHEN ${prelovedSkus.qtyOnHand} = 0 THEN ${expiresAt} ELSE ${prelovedSkus.expiresAt} END`,
   };
@@ -570,7 +702,7 @@ export async function acceptAndPool(
       condition: input.condition,
       price: priceSql,
       qtyOnHand: 1,
-      gstFree: settings.donatedGstFree,
+      gstFree: lot ? false : settings.donatedGstFree,
       active: true,
       defectNote: input.defectNote ?? null,
       listedAt,
@@ -590,20 +722,32 @@ export async function acceptAndPool(
     })
     .returning();
 
+  const eventId = randomUUID();
+  const sourceSql = lot
+    ? sql`'consignment'::preloved_intake_source`
+    : sql`${PRELOVED_INTAKE_SOURCE}::preloved_intake_source`;
+  const lotIdSql = lot ? sql`${lot.id}::uuid` : sql`null::uuid`;
+  const eligibleSku = and(
+    eq(prelovedSkus.tenantId, input.tenantId),
+    eq(prelovedSkus.sourceItemId, input.sourceItemId),
+    eq(prelovedSkus.size, input.size),
+    eq(prelovedSkus.condition, input.condition),
+    canAcceptOntoSku(listedAt),
+  );
+
   const eventInsert = db
     .insert(prelovedIntakeEvents)
     .select(
       db
         .select({
-          id: sql`gen_random_uuid()`.as("id"),
+          id: sql`${eventId}::uuid`.as("id"),
           tenantId: prelovedSkus.tenantId,
           prelovedSkuId: prelovedSkus.id,
           sourceItemId: prelovedSkus.sourceItemId,
           size: prelovedSkus.size,
           condition: prelovedSkus.condition,
-          source: sql<typeof PRELOVED_INTAKE_SOURCE>`${PRELOVED_INTAKE_SOURCE}::preloved_intake_source`.as(
-            "source",
-          ),
+          source: sourceSql.as("source"),
+          consignmentLotId: lotIdSql.as("consignmentLotId"),
           action: sql<"accepted">`'accepted'::preloved_intake_action`.as(
             "action",
           ),
@@ -615,19 +759,37 @@ export async function acceptAndPool(
           createdAt: sql`now()`.as("createdAt"),
         })
         .from(prelovedSkus)
-        .where(
-          and(
-            eq(prelovedSkus.tenantId, input.tenantId),
-            eq(prelovedSkus.sourceItemId, input.sourceItemId),
-            eq(prelovedSkus.size, input.size),
-            eq(prelovedSkus.condition, input.condition),
-            canAcceptOntoSku(listedAt),
-          ),
-        ),
+        .where(eligibleSku),
     )
     .returning();
 
-  const [skuRows, eventRows] = await db.batch([skuUpsert, eventInsert]);
+  const itemInsert = lot
+    ? db
+        .insert(consignmentItems)
+        .select(
+          db
+            .select({
+              id: sql`${randomUUID()}::uuid`.as("id"),
+              tenantId: prelovedSkus.tenantId,
+              lotId: sql`${lot.id}::uuid`.as("lotId"),
+              prelovedSkuId: prelovedSkus.id,
+              intakeEventId: sql`${eventId}::uuid`.as("intakeEventId"),
+              sourceItemId: prelovedSkus.sourceItemId,
+              size: prelovedSkus.size,
+              condition: prelovedSkus.condition,
+              qty: sql<number>`1::int`.as("qty"),
+              soldOrderLineId: sql`null::uuid`.as("soldOrderLineId"),
+              createdAt: sql`now()`.as("createdAt"),
+            })
+            .from(prelovedSkus)
+            .where(eligibleSku),
+        )
+        .returning()
+    : null;
+
+  const [skuRows, eventRows, itemRows] = itemInsert
+    ? await db.batch([skuUpsert, eventInsert, itemInsert])
+    : [...(await db.batch([skuUpsert, eventInsert])), undefined];
   const sku = skuRows[0];
   const event = eventRows[0];
 
@@ -637,8 +799,18 @@ export async function acceptAndPool(
   if (!event) {
     throw new Error("Failed to record preloved intake event");
   }
+  if (lot && (!itemRows || !itemRows[0])) {
+    throw new Error("Failed to attribute consignment intake to the lot");
+  }
 
-  return { sku, event, defaultPrice, appliedPrice, priceAboveCap };
+  return {
+    sku,
+    event,
+    defaultPrice,
+    appliedPrice,
+    priceAboveCap,
+    lot: lot ? { id: lot.id, ticketCode: lot.ticketCode } : null,
+  };
 }
 
 export async function rejectPrelovedIntake(
@@ -750,7 +922,7 @@ export async function listInStockPrelovedSkus(
       and(eq(prelovedSkus.tenantId, tenantId), gt(prelovedSkus.qtyOnHand, 0)),
     )
     .orderBy(desc(prelovedSkus.listedAt));
-  return rows.map(mapStockListItem);
+  return attachLotTickets(tenantId, rows.map(mapStockListItem));
 }
 
 const shopSkuSelect = {
@@ -853,7 +1025,7 @@ export async function listExpiredPrelovedSkus(
       ),
     )
     .orderBy(asc(prelovedSkus.expiresAt));
-  return rows.map(mapStockListItem);
+  return attachLotTickets(tenantId, rows.map(mapStockListItem));
 }
 
 export type DecrementPrelovedLine = {

--- a/apps/web/src/db/preloved-queries.ts
+++ b/apps/web/src/db/preloved-queries.ts
@@ -12,6 +12,7 @@ import {
   PrelovedConsignmentLotNotFoundError,
   PrelovedConsignmentNotEnabledError,
   PrelovedExpiredStockError,
+  PrelovedGstPoolConflictError,
   PrelovedInsufficientQtyError,
   PrelovedWriteOffNotEligibleError,
   defaultPrelovedPrice,
@@ -607,6 +608,21 @@ function canAcceptOntoSku(listedAt: Date) {
   return sql`(${prelovedSkus.qtyOnHand} = 0 OR ${prelovedSkus.expiresAt} IS NULL OR ${prelovedSkus.expiresAt} >= ${listedAt})`;
 }
 
+/** Restock (qty 0) may change GST; in-stock pools must match incoming treatment. */
+function canAcceptMatchingGstOntoSku(listedAt: Date, incomingGstFree: boolean) {
+  return sql`(${canAcceptOntoSku(listedAt)} AND (${prelovedSkus.qtyOnHand} = 0 OR ${prelovedSkus.gstFree} = ${incomingGstFree}))`;
+}
+
+function gstPoolConflictOnHand(sku: {
+  qtyOnHand: number;
+  expiresAt: Date | null;
+  gstFree: boolean;
+}, listedAt: Date, incomingGstFree: boolean): boolean {
+  if (sku.qtyOnHand <= 0) return false;
+  if (sku.expiresAt != null && sku.expiresAt < listedAt) return false;
+  return sku.gstFree !== incomingGstFree;
+}
+
 /**
  * Pool one garment onto the (tenant, item, size, condition) SKU.
  * ON CONFLICT increments qty_on_hand on the existing row (same id).
@@ -614,9 +630,12 @@ function canAcceptOntoSku(listedAt: Date) {
  * (or taxable when the unit is consigned), and applies the new price (and
  * defectNote when sent). Pooling onto in-stock qty only increments qty_on_hand.
  * Accept onto expired in-stock qty is refused until write-off (qty 0).
- * A consignment lot writes source=consignment plus a consignment_items row so
- * later sold-line remittance can attribute the unit. SKU upsert, accepted
- * event, and optional item insert run in one db.batch.
+ * In-stock pools refuse a unit whose GST treatment differs from the row
+ * (consigned units are taxable; donations copy donatedGstFree). Qty 0 may
+ * restock with the incoming treatment. A consignment lot writes
+ * source=consignment plus a consignment_items row so later sold-line
+ * remittance can attribute the unit. SKU upsert, accepted event, and
+ * optional item insert run in one db.batch.
  * The event is INSERT … SELECT of the eligible unique-key row because batch
  * queries are composed before INSERT … RETURNING is available, and a VALUES
  * insert would still write an event when the conflict WHERE no-ops.
@@ -674,6 +693,27 @@ export async function acceptAndPool(
 
   const listedAt = new Date();
   const expiresAt = prelovedExpiresAt(listedAt, settings.holdDays);
+  const incomingGstFree = lot ? false : settings.donatedGstFree;
+  const [existingSku] = await db
+    .select({
+      qtyOnHand: prelovedSkus.qtyOnHand,
+      expiresAt: prelovedSkus.expiresAt,
+      gstFree: prelovedSkus.gstFree,
+    })
+    .from(prelovedSkus)
+    .where(
+      and(
+        eq(prelovedSkus.tenantId, input.tenantId),
+        eq(prelovedSkus.sourceItemId, input.sourceItemId),
+        eq(prelovedSkus.size, input.size),
+        eq(prelovedSkus.condition, input.condition),
+      ),
+    )
+    .limit(1);
+  if (existingSku && gstPoolConflictOnHand(existingSku, listedAt, incomingGstFree)) {
+    throw new PrelovedGstPoolConflictError();
+  }
+
   const priceSql = toNumeric2(appliedPrice, 0);
   const conflictSet: {
     qtyOnHand: ReturnType<typeof sql>;
@@ -685,7 +725,7 @@ export async function acceptAndPool(
   } = {
     qtyOnHand: sql`${prelovedSkus.qtyOnHand} + 1`,
     price: sql`CASE WHEN ${prelovedSkus.qtyOnHand} = 0 THEN ${priceSql}::numeric ELSE ${prelovedSkus.price} END`,
-    gstFree: sql`CASE WHEN ${prelovedSkus.qtyOnHand} = 0 THEN ${lot ? false : settings.donatedGstFree} ELSE ${prelovedSkus.gstFree} END`,
+    gstFree: sql`CASE WHEN ${prelovedSkus.qtyOnHand} = 0 THEN ${incomingGstFree} ELSE ${prelovedSkus.gstFree} END`,
     listedAt: sql`CASE WHEN ${prelovedSkus.qtyOnHand} = 0 THEN ${listedAt} ELSE ${prelovedSkus.listedAt} END`,
     expiresAt: sql`CASE WHEN ${prelovedSkus.qtyOnHand} = 0 THEN ${expiresAt} ELSE ${prelovedSkus.expiresAt} END`,
   };
@@ -702,7 +742,7 @@ export async function acceptAndPool(
       condition: input.condition,
       price: priceSql,
       qtyOnHand: 1,
-      gstFree: lot ? false : settings.donatedGstFree,
+      gstFree: incomingGstFree,
       active: true,
       defectNote: input.defectNote ?? null,
       listedAt,
@@ -717,8 +757,9 @@ export async function acceptAndPool(
       ],
       set: conflictSet,
       // Keep expired in-stock rows unchanged so a new unit is not mixed
-      // onto a hold that is already past and write-off eligible.
-      setWhere: canAcceptOntoSku(listedAt),
+      // onto a hold that is already past and write-off eligible. Also
+      // refuse an in-stock GST mismatch so a race cannot mix treatments.
+      setWhere: canAcceptMatchingGstOntoSku(listedAt, incomingGstFree),
     })
     .returning();
 
@@ -732,7 +773,7 @@ export async function acceptAndPool(
     eq(prelovedSkus.sourceItemId, input.sourceItemId),
     eq(prelovedSkus.size, input.size),
     eq(prelovedSkus.condition, input.condition),
-    canAcceptOntoSku(listedAt),
+    canAcceptMatchingGstOntoSku(listedAt, incomingGstFree),
   );
 
   const eventInsert = db
@@ -794,6 +835,25 @@ export async function acceptAndPool(
   const event = eventRows[0];
 
   if (!sku) {
+    const [current] = await db
+      .select({
+        qtyOnHand: prelovedSkus.qtyOnHand,
+        expiresAt: prelovedSkus.expiresAt,
+        gstFree: prelovedSkus.gstFree,
+      })
+      .from(prelovedSkus)
+      .where(
+        and(
+          eq(prelovedSkus.tenantId, input.tenantId),
+          eq(prelovedSkus.sourceItemId, input.sourceItemId),
+          eq(prelovedSkus.size, input.size),
+          eq(prelovedSkus.condition, input.condition),
+        ),
+      )
+      .limit(1);
+    if (current && gstPoolConflictOnHand(current, listedAt, incomingGstFree)) {
+      throw new PrelovedGstPoolConflictError();
+    }
     throw new PrelovedExpiredStockError();
   }
   if (!event) {

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -85,6 +85,7 @@ export const prelovedConditionEnum = pgEnum("preloved_condition", [
 
 export const prelovedIntakeSourceEnum = pgEnum("preloved_intake_source", [
   "donation",
+  "consignment",
 ]);
 
 export const prelovedIntakeActionEnum = pgEnum("preloved_intake_action", [
@@ -294,6 +295,10 @@ export const prelovedIntakeEvents = pgTable(
     size: text("size"),
     condition: prelovedConditionEnum("condition"),
     source: prelovedIntakeSourceEnum("source").notNull().default("donation"),
+    consignmentLotId: uuid("consignment_lot_id").references(
+      () => consignmentLots.id,
+      { onDelete: "set null" },
+    ),
     action: prelovedIntakeActionEnum("action").notNull(),
     qty: integer("qty").notNull(),
     rejectReason: text("reject_reason"),
@@ -311,6 +316,10 @@ export const prelovedIntakeEvents = pgTable(
     ),
     skuTimeIdx: index("idx_preloved_intake_events_sku_time").on(
       t.prelovedSkuId,
+      t.createdAt,
+    ),
+    lotTimeIdx: index("idx_preloved_intake_events_lot_time").on(
+      t.consignmentLotId,
       t.createdAt,
     ),
   }),
@@ -396,6 +405,50 @@ export const consignmentLots = pgTable(
       t.tenantId,
       t.createdAt,
     ),
+  }),
+);
+
+// One accepted consigned garment. Pooled SKU qty still lives on preloved_skus;
+// this row attributes the unit to a lot so later sold-line remittance can join.
+export const consignmentItems = pgTable(
+  "consignment_items",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    lotId: uuid("lot_id")
+      .notNull()
+      .references(() => consignmentLots.id, { onDelete: "cascade" }),
+    prelovedSkuId: uuid("preloved_sku_id")
+      .notNull()
+      .references(() => prelovedSkus.id, { onDelete: "restrict" }),
+    intakeEventId: uuid("intake_event_id")
+      .notNull()
+      .references(() => prelovedIntakeEvents.id, { onDelete: "restrict" }),
+    sourceItemId: text("source_item_id")
+      .notNull()
+      .references(() => catalogItems.id, { onDelete: "restrict" }),
+    size: text("size").notNull(),
+    condition: prelovedConditionEnum("condition").notNull(),
+    qty: integer("qty").notNull().default(1),
+    // Later payout CSV / sold-line ledger fills this. No FK yet — order_lines
+    // is declared later and remittance is a separate slice.
+    soldOrderLineId: uuid("sold_order_line_id"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    intakeEventUnique: uniqueIndex("consignment_items_intake_event_unique").on(
+      t.intakeEventId,
+    ),
+    lotTimeIdx: index("idx_consignment_items_lot_time").on(t.lotId, t.createdAt),
+    skuTimeIdx: index("idx_consignment_items_sku_time").on(
+      t.prelovedSkuId,
+      t.createdAt,
+    ),
+    qtyPositive: check("consignment_items_qty_positive", sql`${t.qty} >= 1`),
   }),
 );
 
@@ -725,3 +778,4 @@ export type PrelovedSkuRow = typeof prelovedSkus.$inferSelect;
 export type PrelovedIntakeEventRow = typeof prelovedIntakeEvents.$inferSelect;
 export type PrelovedDonationNoteRow = typeof prelovedDonationNotes.$inferSelect;
 export type ConsignmentLotRow = typeof consignmentLots.$inferSelect;
+export type ConsignmentItemRow = typeof consignmentItems.$inferSelect;

--- a/apps/web/src/lib/preloved-consignment.ts
+++ b/apps/web/src/lib/preloved-consignment.ts
@@ -53,6 +53,16 @@ export type InsertConsignmentLotInput = {
   items: ConsignmentLotItemDraft[];
 };
 
+export type ConsignmentAcceptedUnit = {
+  id: string;
+  skuId: string;
+  itemName: string;
+  size: string;
+  condition: "good" | "fair";
+  qty: number;
+  createdAt: Date;
+};
+
 export type ConsignmentLotListItem = {
   id: string;
   ticketCode: string;
@@ -69,6 +79,8 @@ export type ConsignmentLotListItem = {
   payoutStatus: ConsignmentLotPayoutStatus;
   payoutMarkedAt: Date | null;
   createdAt: Date;
+  acceptedUnits: ConsignmentAcceptedUnit[];
+  acceptedQty: number;
 };
 
 export function isConsignmentIntakeMode(mode: string): boolean {

--- a/apps/web/src/lib/preloved.ts
+++ b/apps/web/src/lib/preloved.ts
@@ -240,6 +240,17 @@ export class PrelovedExpiredStockError extends Error {
   }
 }
 
+export class PrelovedGstPoolConflictError extends Error {
+  readonly code = "gst_pool_conflict";
+
+  constructor(
+    message = "This size and condition already has stock with a different GST treatment. GST-free donated units and taxable consigned units cannot share one pooled SKU.",
+  ) {
+    super(message);
+    this.name = "PrelovedGstPoolConflictError";
+  }
+}
+
 export class PrelovedInsufficientQtyError extends Error {
   readonly code = "insufficient_qty";
 

--- a/apps/web/src/lib/preloved.ts
+++ b/apps/web/src/lib/preloved.ts
@@ -29,8 +29,10 @@ export function formatPrelovedCondition(condition: PrelovedCondition): string {
 export const PRELOVED_INTAKE_KINDS = ["accepted", "rejected", "written_off"] as const;
 export type PrelovedIntakeKind = (typeof PRELOVED_INTAKE_KINDS)[number];
 
+export const PRELOVED_INTAKE_SOURCES = ["donation", "consignment"] as const;
+export type PrelovedIntakeSource = (typeof PRELOVED_INTAKE_SOURCES)[number];
+/** @deprecated Prefer PRELOVED_INTAKE_SOURCES[0]; donation remains the default source. */
 export const PRELOVED_INTAKE_SOURCE = "donation" as const;
-export type PrelovedIntakeSource = typeof PRELOVED_INTAKE_SOURCE;
 
 export const DEFAULT_REFUSE_LIST = ["socks", "swimwear", "hats"] as const;
 
@@ -69,6 +71,8 @@ export type AcceptAndPoolInput = {
   price?: number;
   defectNote?: string | null;
   actorId?: string | null;
+  /** When set, accept is attributed to this tenant consignment lot. */
+  consignmentLotId?: string | null;
 };
 
 export type RejectPrelovedIntakeInput = {
@@ -97,6 +101,8 @@ export type PrelovedStockListItem = {
   listedAt: Date;
   expiresAt: Date | null;
   defectNote: string | null;
+  /** Distinct consignment tickets that contributed units to this pooled SKU. */
+  lotTickets: string[];
 };
 
 /** Parent-shop DTO for an in-stock preloved SKU. imageUrl is the SKU photo or null. */
@@ -191,6 +197,26 @@ export class PrelovedCatalogMatchError extends Error {
   constructor(message = "No active catalog item with that size for this tenant.") {
     super(message);
     this.name = "PrelovedCatalogMatchError";
+  }
+}
+
+export class PrelovedConsignmentNotEnabledError extends Error {
+  readonly code = "consignment_not_enabled";
+
+  constructor(
+    message = "Turn on donation + consignment in Settings before linking a lot.",
+  ) {
+    super(message);
+    this.name = "PrelovedConsignmentNotEnabledError";
+  }
+}
+
+export class PrelovedConsignmentLotNotFoundError extends Error {
+  readonly code = "consignment_lot_not_found";
+
+  constructor(message = "That consignment lot was not found for this school.") {
+    super(message);
+    this.name = "PrelovedConsignmentLotNotFoundError";
   }
 }
 

--- a/apps/web/tests/preloved/helpers.ts
+++ b/apps/web/tests/preloved/helpers.ts
@@ -68,6 +68,48 @@ export async function confirmVisaPayment(paymentIntentId: string) {
   }
 }
 
+/** Pin qty / GST on a pooled SKU. Returns null when the row does not exist. */
+export async function pinPooledSkuForTest(opts: {
+  qty: number;
+  gstFree?: boolean;
+  size?: string;
+  condition?: string;
+}): Promise<{ skuId: string } | null> {
+  if (!Number.isInteger(opts.qty) || opts.qty < 0) {
+    throw new Error(`pinPooledSkuForTest expects non-negative integer qty, got ${opts.qty}`);
+  }
+  loadLocalEnv();
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL missing for pinPooledSkuForTest");
+  const sql = neon(url);
+  const size = opts.size ?? SIZE;
+  const condition = opts.condition ?? CONDITION;
+  const rows =
+    opts.gstFree === undefined
+      ? await sql`
+          update preloved_skus
+          set qty_on_hand = ${opts.qty}
+          where tenant_id = ${TENANT}
+            and source_item_id = ${ITEM_ID}
+            and size = ${size}
+            and condition = ${condition}
+          returning id
+        `
+      : await sql`
+          update preloved_skus
+          set qty_on_hand = ${opts.qty},
+              gst_free = ${opts.gstFree}
+          where tenant_id = ${TENANT}
+            and source_item_id = ${ITEM_ID}
+            and size = ${size}
+            and condition = ${condition}
+          returning id
+        `;
+  if (rows.length === 0) return null;
+  const row = rows[0] as { id: string };
+  return { skuId: row.id };
+}
+
 /** Pin qty_on_hand for the pooled size/condition SKU (race fixtures). */
 export async function pinPooledSkuQty(qty: number): Promise<{
   skuId: string;

--- a/apps/web/tests/preloved/m08-lot-intake.spec.ts
+++ b/apps/web/tests/preloved/m08-lot-intake.spec.ts
@@ -36,7 +36,10 @@ async function createConsignmentLot(page: Page, stamp: string) {
       },
     },
   );
-  expect(createRes.ok()).toBeTruthy();
+  if (!createRes.ok()) {
+    const body = await createRes.text();
+    throw new Error(`create consignment lot failed ${createRes.status()}: ${body}`);
+  }
   const created = (await createRes.json()) as {
     id?: string;
     ticketCode?: string;
@@ -224,11 +227,7 @@ test.describe("Phase 2 consignment lot → intake / stock", () => {
       });
       expect(offRes.ok()).toBeTruthy();
 
-      const { lotId: taxableLotId } = await createConsignmentLot(
-        page,
-        `tax-${Date.now()}`,
-      );
-      const consign = await postIntake(page, { consignmentLotId: taxableLotId });
+      const consign = await postIntake(page, { consignmentLotId: lotId });
       expect(consign.ok()).toBeTruthy();
       const consigned = (await consign.json()) as { sku?: { gstFree?: boolean } };
       expect(consigned.sku?.gstFree).toBe(false);

--- a/apps/web/tests/preloved/m08-lot-intake.spec.ts
+++ b/apps/web/tests/preloved/m08-lot-intake.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Phase 2 leftover: operator links a consignment lot ticket at intake so the
+ * accepted unit is attributed on stock and the consignments tab.
+ *
+ * Needs pnpm dev:web. Bound to demo-academy like m07.
+ */
+import { expect, test } from "playwright/test";
+import {
+  ITEM_NAME,
+  SIZE,
+  TENANT,
+  acceptSize10PoloGood,
+  chooseSelect,
+  devLogin,
+  ensurePrelovedEnabled,
+  pooledRow,
+} from "./helpers";
+
+test.describe("Phase 2 consignment lot → intake / stock", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("accept against a ticket; stock and lot show the link", async ({
+    page,
+  }) => {
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    await ensurePrelovedEnabled(page);
+
+    const enableRes = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+      data: {
+        prelovedEnabled: true,
+        intakeMode: "donation_and_consignment",
+        commissionBps: 5000,
+      },
+    });
+    expect(enableRes.ok()).toBeTruthy();
+
+    const createRes = await page.request.post(
+      `/api/tenant/${TENANT}/preloved/consign`,
+      {
+        data: {
+          familyName: "Lotlink",
+          studentName: "Ava",
+          email: "lotlink@example.com",
+          mobile: "0400000012",
+          payoutPreference: "school_fee_credit",
+          unsoldPreference: "donate",
+          items: [{ garment: "Sports polo", size: "10" }],
+          termsAccepted: true,
+        },
+      },
+    );
+    expect(createRes.ok()).toBeTruthy();
+    const created = (await createRes.json()) as {
+      id?: string;
+      ticketCode?: string;
+    };
+    expect(created.id).toBeTruthy();
+    expect(created.ticketCode).toMatch(/^CL-[A-Z0-9]{6}$/);
+    const ticket = created.ticketCode!;
+    const lotId = created.id!;
+
+    await page.goto(`/admin/${TENANT}/preloved/intake`);
+    await expect(page.getByTestId("intake-desk")).toBeVisible();
+    await expect(page.getByTestId("intake-lot-loading")).toHaveCount(0, {
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId("intake-lot")).toBeVisible();
+    await chooseSelect(page, "intake-item", ITEM_NAME);
+    await chooseSelect(page, "intake-size", SIZE);
+    await page.getByTestId("intake-condition").getByText("Good", { exact: true }).click();
+    await chooseSelect(page, "intake-lot", new RegExp(`^${ticket}\\s`));
+    await page.getByTestId("intake-accept").click();
+    await expect(page.getByTestId("intake-success")).toContainText(ticket);
+
+    await page.goto(`/admin/${TENANT}/preloved/stock`);
+    await expect(page.getByTestId("preloved-stock-page")).toBeVisible();
+    const row = pooledRow(page);
+    await expect(row).toBeVisible();
+    await expect(row.getByTestId("stock-lot-tickets")).toContainText(ticket);
+
+    await page.goto(`/admin/${TENANT}/preloved/consignments`);
+    await expect(page.getByTestId("consignments-list")).toBeVisible({
+      timeout: 15_000,
+    });
+    const lotRow = page.locator(
+      `[data-testid="consignments-row"][data-ticket="${ticket}"]`,
+    );
+    await expect(lotRow).toBeVisible();
+    await expect(lotRow).toHaveAttribute("data-accepted-qty", /[1-9]/);
+    await expect(lotRow.getByTestId("consignments-accepted-row")).toContainText(
+      ITEM_NAME,
+    );
+    await expect(lotRow.getByTestId("consignments-accepted-row")).toContainText(
+      SIZE,
+    );
+
+    const missing = await page.request.post(
+      `/api/tenant/${TENANT}/preloved/intake`,
+      {
+        data: {
+          action: "accepted",
+          sourceItemId: process.env.PRELOVED_ITEM_ID ?? "rvra-polo-ss",
+          size: SIZE,
+          condition: "good",
+          consignmentLotId: "00000000-0000-4000-8000-000000000000",
+        },
+      },
+    );
+    expect(missing.status()).toBe(404);
+    const missingBody = (await missing.json()) as { code?: string };
+    expect(missingBody.code).toBe("consignment_lot_not_found");
+
+    const donationRes = await page.request.patch(
+      `/api/tenant/${TENANT}/preloved`,
+      { data: { intakeMode: "donation_only" } },
+    );
+    expect(donationRes.ok()).toBeTruthy();
+    const blocked = await page.request.post(
+      `/api/tenant/${TENANT}/preloved/intake`,
+      {
+        data: {
+          action: "accepted",
+          sourceItemId: process.env.PRELOVED_ITEM_ID ?? "rvra-polo-ss",
+          size: SIZE,
+          condition: "good",
+          consignmentLotId: lotId,
+        },
+      },
+    );
+    expect(blocked.status()).toBe(400);
+    const blockedBody = (await blocked.json()) as { code?: string };
+    expect(blockedBody.code).toBe("consignment_not_enabled");
+
+    const restore = await page.request.patch(
+      `/api/tenant/${TENANT}/preloved`,
+      { data: { intakeMode: "donation_and_consignment" } },
+    );
+    expect(restore.ok()).toBeTruthy();
+
+    await page.goto(`/admin/${TENANT}/preloved/intake`);
+    await expect(page.getByTestId("intake-desk")).toBeVisible();
+    await acceptSize10PoloGood(page);
+    await expect(page.getByTestId("intake-success")).toContainText(/Donation pooled/i);
+  });
+});

--- a/apps/web/tests/preloved/m08-lot-intake.spec.ts
+++ b/apps/web/tests/preloved/m08-lot-intake.spec.ts
@@ -4,8 +4,9 @@
  *
  * Needs pnpm dev:web. Bound to demo-academy like m07.
  */
-import { expect, test } from "playwright/test";
+import { expect, test, type Page } from "playwright/test";
 import {
+  ITEM_ID,
   ITEM_NAME,
   SIZE,
   TENANT,
@@ -13,8 +14,49 @@ import {
   chooseSelect,
   devLogin,
   ensurePrelovedEnabled,
+  pinPooledSkuForTest,
   pooledRow,
 } from "./helpers";
+
+const MIXED_GST_CONDITION = "fair" as const;
+
+async function createConsignmentLot(page: Page, stamp: string) {
+  const createRes = await page.request.post(
+    `/api/tenant/${TENANT}/preloved/consign`,
+    {
+      data: {
+        familyName: `Gst${stamp}`,
+        studentName: "Kai",
+        email: `gst-${stamp}@example.com`,
+        mobile: "0400000013",
+        payoutPreference: "school_fee_credit",
+        unsoldPreference: "donate",
+        items: [{ garment: "Sports polo", size: SIZE }],
+        termsAccepted: true,
+      },
+    },
+  );
+  expect(createRes.ok()).toBeTruthy();
+  const created = (await createRes.json()) as {
+    id?: string;
+    ticketCode?: string;
+  };
+  expect(created.id).toBeTruthy();
+  expect(created.ticketCode).toMatch(/^CL-[A-Z0-9]{6}$/);
+  return { lotId: created.id!, ticket: created.ticketCode! };
+}
+
+async function postIntake(page: Page, body: Record<string, unknown> = {}) {
+  return page.request.post(`/api/tenant/${TENANT}/preloved/intake`, {
+    data: {
+      action: "accepted",
+      sourceItemId: ITEM_ID,
+      size: SIZE,
+      condition: MIXED_GST_CONDITION,
+      ...body,
+    },
+  });
+}
 
 test.describe("Phase 2 consignment lot → intake / stock", () => {
   test.use({ viewport: { width: 1440, height: 900 } });
@@ -141,5 +183,114 @@ test.describe("Phase 2 consignment lot → intake / stock", () => {
     await expect(page.getByTestId("intake-desk")).toBeVisible();
     await acceptSize10PoloGood(page);
     await expect(page.getByTestId("intake-success")).toContainText(/Donation pooled/i);
+  });
+
+  test("refuse mixed GST on a pooled SKU; matching donation still accepts", async ({
+    page,
+  }) => {
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    await ensurePrelovedEnabled(page);
+
+    const enableRes = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+      data: {
+        prelovedEnabled: true,
+        intakeMode: "donation_and_consignment",
+        commissionBps: 5000,
+        donatedGstFree: true,
+      },
+    });
+    expect(enableRes.ok()).toBeTruthy();
+
+    try {
+      await pinPooledSkuForTest({ qty: 0, size: SIZE, condition: MIXED_GST_CONDITION });
+      const { lotId } = await createConsignmentLot(page, `mix-${Date.now()}`);
+
+      const donate = await postIntake(page);
+      expect(donate.ok()).toBeTruthy();
+      const donated = (await donate.json()) as { sku?: { gstFree?: boolean } };
+      expect(donated.sku?.gstFree).toBe(true);
+
+      const mixedConsign = await postIntake(page, { consignmentLotId: lotId });
+      expect(mixedConsign.status()).toBe(409);
+      const mixedConsignBody = (await mixedConsign.json()) as { code?: string };
+      expect(mixedConsignBody.code).toBe("gst_pool_conflict");
+
+      const matchingDonate = await postIntake(page);
+      expect(matchingDonate.ok()).toBeTruthy();
+
+      await pinPooledSkuForTest({ qty: 0, size: SIZE, condition: MIXED_GST_CONDITION });
+      const offRes = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+        data: { donatedGstFree: false },
+      });
+      expect(offRes.ok()).toBeTruthy();
+
+      const { lotId: taxableLotId } = await createConsignmentLot(
+        page,
+        `tax-${Date.now()}`,
+      );
+      const consign = await postIntake(page, { consignmentLotId: taxableLotId });
+      expect(consign.ok()).toBeTruthy();
+      const consigned = (await consign.json()) as { sku?: { gstFree?: boolean } };
+      expect(consigned.sku?.gstFree).toBe(false);
+
+      const onRes = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+        data: { donatedGstFree: true },
+      });
+      expect(onRes.ok()).toBeTruthy();
+      const mixedDonate = await postIntake(page);
+      expect(mixedDonate.status()).toBe(409);
+      const mixedDonateBody = (await mixedDonate.json()) as { code?: string };
+      expect(mixedDonateBody.code).toBe("gst_pool_conflict");
+    } finally {
+      const restore = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+        data: {
+          intakeMode: "donation_and_consignment",
+          donatedGstFree: false,
+        },
+      });
+      expect(restore.ok()).toBeTruthy();
+    }
+  });
+
+  test("stale ticket selection cannot fall through as a donation", async ({
+    page,
+  }) => {
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    await ensurePrelovedEnabled(page);
+
+    const enableRes = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+      data: {
+        prelovedEnabled: true,
+        intakeMode: "donation_and_consignment",
+        commissionBps: 5000,
+      },
+    });
+    expect(enableRes.ok()).toBeTruthy();
+
+    const { ticket } = await createConsignmentLot(page, `stale-${Date.now()}`);
+
+    await page.goto(`/admin/${TENANT}/preloved/intake`);
+    await expect(page.getByTestId("intake-desk")).toBeVisible();
+    await expect(page.getByTestId("intake-lot-loading")).toHaveCount(0, {
+      timeout: 15_000,
+    });
+    await chooseSelect(page, "intake-item", ITEM_NAME);
+    await chooseSelect(page, "intake-size", SIZE);
+    await page.getByTestId("intake-condition").getByText("Fair", { exact: true }).click();
+    await chooseSelect(page, "intake-lot", new RegExp(`^${ticket}\\s`));
+
+    await page.route(`**/api/tenant/${TENANT}/preloved/consignment-lots`, (route) => {
+      if (route.request().method() === "GET") {
+        return route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Lots unavailable" }),
+        });
+      }
+      return route.continue();
+    });
+    await page.getByTestId("intake-lot-retry").click();
+    await expect(page.getByTestId("intake-lot-error")).toBeVisible();
+    await expect(page.getByTestId("intake-accept")).toBeDisabled();
   });
 });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:m05-parent-hydration": "pnpm --filter web test:m05-parent-hydration",
     "test:m06-last-unit-race": "pnpm --filter web test:m06-last-unit-race",
     "test:preloved-test-gaps": "pnpm --filter web test:preloved-test-gaps",
-    "test:m07-consignment-school-fee": "pnpm --filter web test:m07-consignment-school-fee"
+    "test:m07-consignment-school-fee": "pnpm --filter web test:m07-consignment-school-fee",
+    "test:m08-lot-intake": "pnpm --filter web test:m08-lot-intake"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/specs/_logs/OPEN_QUESTIONS.md
+++ b/specs/_logs/OPEN_QUESTIONS.md
@@ -21,7 +21,7 @@
       context: Spec default refuse list includes hats (Tara/CCGS). Some primary shops sell hats. Non-blocking; tenant can edit the list. Confirm only if hats should be allowed by default.
 
 - [x] **(plan)** School-fee credit as a payout option — raised: 2026-09-06, by: plan
-      context: Phase 2 first vertical (2026-09-12): parent consign form offers school-fee credit; operators mark lots manually. No school-finance integration. Payout CSV / sold-item linking still open.
+      context: Phase 2 first vertical (2026-09-12): parent consign form offers school-fee credit; operators mark lots manually. No school-finance integration. Lot→intake attribution shipped 2026-09-12 (`consignment_items`). Payout CSV / sold-line ledger still open.
 
 - [x] **(M04)** Operators have no inbox to read `preloved_donation_notes` — raised: 2026-09-07, by: build:M04
       context: Resolved 2026-09-12. Operator inbox at `/admin/[tenant]/preloved/inbox` lists `preloved_donation_notes` (empty / loading / error). Notes still do not create a SKU.


### PR DESCRIPTION
Operators can associate a consignment lot ticket with intake so accepted units are attributed on the rack and the lot.

## What shipped

- Intake desk (when `donation_and_consignment` is on): pick a ticket or keep donation. Empty / loading / error for the lot list.
- Accept with a ticket writes `source=consignment`, `consignment_lot_id` on the intake event, and a `consignment_items` row. SKUs still pool by item + size + condition.
- Stock Lot column shows tickets. Consignments tab shows accepted units on the rack.
- Migration `0023_consignment_lot_intake` (applied on this Neon).
- `pnpm test:m08-lot-intake` — accept against a ticket, stock + lot show the link, unknown lot 404, donation-only rejects a lot id.

## Not in this slice

- Payout CSV / commission ledger / sold-line remittance (`sold_order_line_id` is reserved, unused)
- Platform portal
- Unique consignment SKUs (units still pool with donations)

## Verify

- `pnpm check-types:web` pass
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:43173 pnpm test:m08-lot-intake` pass (1/1)

## Blockers for George

- Confirm mixed donation + consignment on the same pooled SKU is OK until the CSV slice (FIFO / sold-line linking). Default `donatedGstFree` is still false; a GST-free donated SKU can later receive a consigned unit.
- Confirm whether demo-academy should stay in `donation_and_consignment` after m07/m08.
- Next leftover: payout CSV / sold-line ledger.