### PR TITLE
feat(phase2): consignment sold-line ledger and treasurer payout CSV

### DIFF
--- a/apps/web/drizzle/0024_consignment_sold_lines.sql
+++ b/apps/web/drizzle/0024_consignment_sold_lines.sql
@@ -1,0 +1,35 @@
+DO $$ BEGIN
+  ALTER TABLE "consignment_items"
+    ADD CONSTRAINT "consignment_items_sold_order_line_id_order_lines_id_fk"
+    FOREIGN KEY ("sold_order_line_id") REFERENCES "order_lines"("id")
+    ON DELETE set null ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_consignment_items_sold_line"
+  ON "consignment_items" ("sold_order_line_id");--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "consignment_sold_lines" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" text NOT NULL REFERENCES "tenants"("id") ON DELETE cascade,
+	"lot_id" uuid NOT NULL REFERENCES "consignment_lots"("id") ON DELETE cascade,
+	"consignment_item_id" uuid NOT NULL REFERENCES "consignment_items"("id") ON DELETE restrict,
+	"order_id" text NOT NULL REFERENCES "orders"("id") ON DELETE restrict,
+	"order_line_id" uuid NOT NULL REFERENCES "order_lines"("id") ON DELETE restrict,
+	"preloved_sku_id" uuid NOT NULL REFERENCES "preloved_skus"("id") ON DELETE restrict,
+	"qty" integer DEFAULT 1 NOT NULL,
+	"sale_unit_price" numeric(10, 2) NOT NULL,
+	"sale_line_total" numeric(10, 2) NOT NULL,
+	"commission_bps" integer NOT NULL,
+	"commission_amount" numeric(10, 2) NOT NULL,
+	"remittance_amount" numeric(10, 2) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "consignment_sold_lines_qty_positive" CHECK ("qty" >= 1)
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "consignment_sold_lines_item_unique"
+  ON "consignment_sold_lines" ("consignment_item_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_consignment_sold_lines_tenant_time"
+  ON "consignment_sold_lines" ("tenant_id", "created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_consignment_sold_lines_lot_time"
+  ON "consignment_sold_lines" ("lot_id", "created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_consignment_sold_lines_order"
+  ON "consignment_sold_lines" ("order_id");

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1789100000000,
       "tag": "0023_consignment_lot_intake",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1789200000000,
+      "tag": "0024_consignment_sold_lines",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "test:preloved-test-gaps": "pnpm test:m05-parent-hydration && pnpm test:m06-last-unit-race",
     "test:m07-consignment-school-fee": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online playwright test -c playwright.config.ts tests/preloved/m07-consignment-school-fee.spec.ts",
     "test:m08-lot-intake": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online PRELOVED_ITEM_ID=rvra-polo-ss PRELOVED_ITEM_NAME='Polo Shirt — Short Sleeve' playwright test -c playwright.config.ts tests/preloved/m08-lot-intake.spec.ts",
+    "test:m09-payout-csv": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online PRELOVED_ITEM_ID=rvra-polo-ss PRELOVED_ITEM_NAME='Polo Shirt — Short Sleeve' playwright test -c playwright.config.ts tests/preloved/m09-payout-csv.spec.ts",
     "demo:seed:dry": "node ../../demo/demo_data/run.mjs seed --dry-run",
     "demo:seed": "node ../../demo/demo_data/run.mjs seed",
     "demo:cleanup": "node ../../demo/demo_data/run.mjs cleanup",

--- a/apps/web/src/app/admin/[tenant]/preloved/consignments/consignments-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/consignments/consignments-client.tsx
@@ -13,6 +13,7 @@ import {
   type ConsignmentPayoutPreference,
   type ConsignmentUnsoldPreference,
 } from "@/lib/preloved-consignment";
+import { formatCsvMoney } from "@/lib/preloved-payout";
 
 export type ConsignmentLotRow = {
   id: string;
@@ -37,10 +38,34 @@ export type ConsignmentLotRow = {
     size: string;
     condition: "good" | "fair";
     qty: number;
+    soldOrderLineId: string | null;
     createdAt: string;
   }[];
   acceptedQty: number;
+  soldLines: {
+    id: string;
+    consignmentItemId: string;
+    orderId: string;
+    orderLineId: string;
+    itemName: string;
+    size: string;
+    condition: "good" | "fair";
+    qty: number;
+    saleUnitPrice: number;
+    saleLineTotal: number;
+    commissionBps: number;
+    commissionAmount: number;
+    remittanceAmount: number;
+    createdAt: string;
+  }[];
+  soldQty: number;
+  remittanceTotal: number;
+  commissionTotal: number;
 };
+
+function parseMoneySum(values: number[]): number {
+  return values.reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
+}
 
 function formatReceived(iso: string, timeZone: string) {
   return new Date(iso).toLocaleString("en-AU", {
@@ -66,6 +91,10 @@ export function ConsignmentsClient({
   const [loading, setLoading] = useState(true);
   const [markingId, setMarkingId] = useState<string | null>(null);
   const [markError, setMarkError] = useState("");
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState("");
+  const [exportNotice, setExportNotice] = useState("");
+  const [pendingOnly, setPendingOnly] = useState(false);
 
   const loadLots = useCallback(async () => {
     setLoading(true);
@@ -138,20 +167,100 @@ export function ConsignmentsClient({
     }
   };
 
+  const exportPayoutCsv = async () => {
+    setExporting(true);
+    setExportError("");
+    setExportNotice("");
+    try {
+      const qs = pendingOnly ? "?pending=1" : "";
+      const res = await fetch(
+        `/api/tenant/${tenantId}/preloved/payout.csv${qs}`,
+      );
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(data?.error ?? "Failed to export payout CSV.");
+      }
+      const csv = await res.text();
+      const count = Number(res.headers.get("X-Payout-Row-Count") ?? "0");
+      const match = /filename="([^"]+)"/.exec(
+        res.headers.get("Content-Disposition") ?? "",
+      );
+      const filename = match?.[1] ?? `payout-${tenantId}.csv`;
+      const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+      if (count === 0) {
+        setExportNotice(
+          "No sold consignment lines yet. Downloaded a headers-only CSV.",
+        );
+      }
+    } catch (err) {
+      console.error("Payout CSV export failed:", err);
+      setExportError(
+        err instanceof Error ? err.message : "Failed to export payout CSV.",
+      );
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const soldLineCount = (lots ?? []).reduce(
+    (sum, lot) => sum + (lot.soldQty ?? 0),
+    0,
+  );
+  const remittanceOwing = parseMoneySum(
+    (lots ?? [])
+      .filter((lot) => lot.payoutStatus === "pending")
+      .map((lot) => lot.remittanceTotal ?? 0),
+  );
+
   return (
     <div className="flex-1 overflow-y-auto p-7" data-testid="consignments-panel">
       <p
         className="text-[13px] mb-4 max-w-2xl"
         style={{ color: "var(--color-ink-dim)" }}
       >
-        Parent consignment lots. Accept garments on Intake against a ticket so
-        sold units can be attributed later. Bank details are operator-only. Mark
-        school-fee credit, EFT, or donated proceeds by hand — there is no
-        school-finance integration.
+        Parent consignment lots. Accept garments on Intake against a ticket.
+        When a consigned unit sells, the shop keeps the published commission and
+        the remainder is the amount owing. Export the treasurer CSV for EFT,
+        school-fee credit, or donated proceeds — marks stay manual.
         {commissionBps != null
           ? ` Shop commission: ${formatCommissionPercent(commissionBps)}.`
           : null}
+        {!loading && !error && lots && lots.length > 0
+          ? ` ${soldLineCount} sold · $${formatCsvMoney(remittanceOwing)} pending owing.`
+          : null}
       </p>
+
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <label
+          className="flex items-center gap-2 text-[13px]"
+          style={{ color: "var(--color-ink)" }}
+        >
+          <input
+            type="checkbox"
+            checked={pendingOnly}
+            onChange={(event) => setPendingOnly(event.target.checked)}
+            data-testid="consignments-export-pending"
+          />
+          Pending payouts only
+        </label>
+        <Button
+          size="sm"
+          onPress={() => void exportPayoutCsv()}
+          isPending={exporting}
+          isDisabled={exporting || loading}
+          data-testid="consignments-export-csv"
+        >
+          Export payout CSV
+        </Button>
+      </div>
 
       {markError ? (
         <div className="mb-4 max-w-xl" data-testid="consignments-mark-error">
@@ -163,6 +272,28 @@ export function ConsignmentsClient({
             </Alert.Content>
           </Alert>
         </div>
+      ) : null}
+
+      {exportError ? (
+        <div className="mb-4 max-w-xl" data-testid="consignments-export-error">
+          <Alert status="danger">
+            <Alert.Indicator />
+            <Alert.Content>
+              <Alert.Title>Could not export payout CSV</Alert.Title>
+              <Alert.Description>{exportError}</Alert.Description>
+            </Alert.Content>
+          </Alert>
+        </div>
+      ) : null}
+
+      {exportNotice ? (
+        <p
+          className="mb-4 max-w-xl text-[13px]"
+          style={{ color: "var(--color-ink-dim)" }}
+          data-testid="consignments-export-empty"
+        >
+          {exportNotice}
+        </p>
       ) : null}
 
       {loading ? <LotsLoading /> : null}
@@ -282,6 +413,7 @@ function LotsList({
             data-ticket={lot.ticketCode}
             data-payout-status={lot.payoutStatus}
             data-accepted-qty={String(lot.acceptedQty ?? 0)}
+            data-sold-qty={String(lot.soldQty ?? 0)}
           >
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
@@ -355,10 +487,49 @@ function LotsList({
                       >
                         {unit.itemName} · {unit.size} · {unit.condition} · qty{" "}
                         {unit.qty}
+                        {unit.soldOrderLineId ? " · sold" : ""}
                       </li>
                     ))}
                   </ul>
                 )}
+              </dd>
+              <dt style={{ color: "var(--color-ink-dim)" }}>Sold</dt>
+              <dd
+                style={{ color: "var(--color-ink)" }}
+                data-testid="consignments-sold"
+              >
+                {(lot.soldLines ?? []).length === 0 ? (
+                  <span data-testid="consignments-sold-empty">
+                    No sold units yet. Amount owing appears after a paid sale.
+                  </span>
+                ) : (
+                  <ul className="space-y-0.5">
+                    {(lot.soldLines ?? []).map((line) => (
+                      <li
+                        key={line.id}
+                        data-testid="consignments-sold-row"
+                        data-order-id={line.orderId}
+                      >
+                        {line.itemName} · {line.size} · {line.condition} · sale $
+                        {formatCsvMoney(line.saleLineTotal)} · shop $
+                        {formatCsvMoney(line.commissionAmount)} (
+                        {formatCommissionPercent(line.commissionBps)}) · owing $
+                        {formatCsvMoney(line.remittanceAmount)} · {line.orderId}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </dd>
+              <dt style={{ color: "var(--color-ink-dim)" }}>Owing</dt>
+              <dd
+                className="tnum"
+                style={{ color: "var(--color-ink)" }}
+                data-testid="consignments-owing"
+              >
+                ${formatCsvMoney(lot.remittanceTotal ?? 0)}
+                {(lot.commissionTotal ?? 0) > 0
+                  ? ` after $${formatCsvMoney(lot.commissionTotal)} shop cut`
+                  : ""}
               </dd>
             </dl>
 

--- a/apps/web/src/app/admin/[tenant]/preloved/intake/intake-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/intake/intake-client.tsx
@@ -661,7 +661,7 @@ function IntakeLotField({
         </Select.Popover>
         <Description>
           Consigned garments still pool on the rack by item, size, and
-          condition. The ticket is stored so a later payout CSV can attribute
+          condition. The ticket is stored so the payout CSV can attribute
           sold units.
         </Description>
       </Select>

--- a/apps/web/src/app/api/orders/route.ts
+++ b/apps/web/src/app/api/orders/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, orders, orderLines, tenants, pendingOrderSnapshots } from "@/db";
 import type { PendingOrderLineSnapshot } from "@/db/schema";
-import { decrementPrelovedForPaymentIntent } from "@/db/preloved-queries";
+import {
+  decrementPrelovedForPaymentIntent,
+  recordConsignmentSoldLinesBestEffort,
+} from "@/db/preloved-queries";
 import {
   getOrdersByTenant,
   getOrdersByTenantAndParentEmail,
@@ -231,6 +234,10 @@ export async function POST(req: NextRequest) {
       if (existingOrder.userId && existingOrder.userId !== authResult.user.id) {
         return NextResponse.json({ error: "Payment intent already used" }, { status: 409 });
       }
+      await recordConsignmentSoldLinesBestEffort({
+        orderId: existingOrder.id,
+        tenantId,
+      });
       return NextResponse.json(
         { orderId: existingOrder.id, idempotent: true },
         { status: 200 }
@@ -533,6 +540,10 @@ export async function POST(req: NextRequest) {
             if (duplicateOrder.userId && duplicateOrder.userId !== authResult.user.id) {
               return NextResponse.json({ error: "Payment intent already used" }, { status: 409 });
             }
+            await recordConsignmentSoldLinesBestEffort({
+              orderId: duplicateOrder.id,
+              tenantId,
+            });
             return NextResponse.json(
               { orderId: duplicateOrder.id, idempotent: true },
               { status: 200 }
@@ -547,6 +558,11 @@ export async function POST(req: NextRequest) {
     if (!createdOrderId) {
       throw new Error("Unable to generate a unique order ID");
     }
+
+    await recordConsignmentSoldLinesBestEffort({
+      orderId: createdOrderId,
+      tenantId,
+    });
 
     // The snapshot has served its purpose — the authoritative copy now lives in
     // order_lines. Best-effort: a stale row is harmless (the PI id is already

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -11,7 +11,10 @@ import {
   orderLines,
   pendingOrderSnapshots,
 } from "@/db/schema";
-import { decrementPrelovedForPaymentIntent } from "@/db/preloved-queries";
+import {
+  decrementPrelovedForPaymentIntent,
+  recordConsignmentSoldLinesBestEffort,
+} from "@/db/preloved-queries";
 import { sendOrderRefundEmail } from "@/lib/email";
 import { recordOrderPaid } from "@/lib/orders/record-order-paid";
 import { PrelovedInsufficientQtyError } from "@/lib/preloved";
@@ -212,6 +215,13 @@ export async function POST(req: NextRequest) {
       paymentIntentId: pi.id,
       resolved,
     });
+
+    if (resolved) {
+      await recordConsignmentSoldLinesBestEffort({
+        orderId: resolved.id,
+        tenantId: resolved.tenantId,
+      });
+    }
 
     return NextResponse.json({ received: true });
   }

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/[lotId]/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/[lotId]/route.ts
@@ -8,22 +8,8 @@ import {
   ensureTenantAccess,
   requireSessionUser,
 } from "@/lib/auth/authorization";
-import {
-  isConsignmentIntakeMode,
-  type ConsignmentLotListItem,
-} from "@/lib/preloved-consignment";
-
-function serializeLot(lot: ConsignmentLotListItem) {
-  return {
-    ...lot,
-    createdAt: lot.createdAt.toISOString(),
-    payoutMarkedAt: lot.payoutMarkedAt?.toISOString() ?? null,
-    acceptedUnits: lot.acceptedUnits.map((unit) => ({
-      ...unit,
-      createdAt: unit.createdAt.toISOString(),
-    })),
-  };
-}
+import { isConsignmentIntakeMode } from "@/lib/preloved-consignment";
+import { serializeConsignmentLot } from "../serialize";
 
 // PATCH /api/tenant/:tenantId/preloved/consignment-lots/:lotId — manual payout mark.
 // Status is derived from the lot payout preference. Client body is ignored.
@@ -64,7 +50,7 @@ export async function PATCH(
         {
           error: "Lot payout already marked",
           code: "already_marked",
-          lot: serializeLot(result.lot),
+          lot: serializeConsignmentLot(result.lot),
         },
         { status: 409 },
       );
@@ -72,7 +58,7 @@ export async function PATCH(
 
     return NextResponse.json({
       ok: true,
-      lot: serializeLot(result.lot),
+      lot: serializeConsignmentLot(result.lot),
     });
   } catch (err) {
     console.error(

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/serialize.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/serialize.ts
@@ -1,0 +1,17 @@
+import type { ConsignmentLotListItem } from "@/lib/preloved-consignment";
+
+export function serializeConsignmentLot(lot: ConsignmentLotListItem) {
+  return {
+    ...lot,
+    createdAt: lot.createdAt.toISOString(),
+    payoutMarkedAt: lot.payoutMarkedAt?.toISOString() ?? null,
+    acceptedUnits: lot.acceptedUnits.map((unit) => ({
+      ...unit,
+      createdAt: unit.createdAt.toISOString(),
+    })),
+    soldLines: lot.soldLines.map((line) => ({
+      ...line,
+      createdAt: line.createdAt.toISOString(),
+    })),
+  };
+}

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/payout.csv/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/payout.csv/route.ts
@@ -1,16 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getTenant } from "@/db/queries";
-import { getPrelovedSettings, listConsignmentLots } from "@/db/preloved-queries";
+import {
+  getPrelovedSettings,
+  listConsignmentSoldLinesForExport,
+} from "@/db/preloved-queries";
 import {
   ensureTenantAccess,
   requireSessionUser,
 } from "@/lib/auth/authorization";
 import { isConsignmentIntakeMode } from "@/lib/preloved-consignment";
-import { serializeConsignmentLot } from "./serialize";
+import { buildPayoutCsv, payoutCsvFilename } from "@/lib/preloved-payout";
 
-// GET /api/tenant/:tenantId/preloved/consignment-lots — operator list.
+// GET /api/tenant/:tenantId/preloved/payout.csv — treasurer remittance ledger.
+// ?pending=1 limits to lots not yet marked paid / credited / donated.
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ tenantId: string }> },
 ) {
   const { tenantId } = await params;
@@ -22,7 +26,10 @@ export async function GET(
     if (!tenant) {
       return NextResponse.json({ error: "Tenant not found" }, { status: 404 });
     }
-    const tenantAccessResponse = ensureTenantAccess(authResult.user, tenant.shopEmail);
+    const tenantAccessResponse = ensureTenantAccess(
+      authResult.user,
+      tenant.shopEmail,
+    );
     if (tenantAccessResponse) return tenantAccessResponse;
 
     const settings = await getPrelovedSettings(tenantId);
@@ -36,19 +43,27 @@ export async function GET(
       );
     }
 
-    const lots = await listConsignmentLots(tenantId);
-    return NextResponse.json({
-      ok: true,
-      commissionBps: settings.commissionBps,
-      lots: lots.map(serializeConsignmentLot),
+    const pendingOnly = req.nextUrl.searchParams.get("pending") === "1";
+    const rows = await listConsignmentSoldLinesForExport(tenantId, {
+      pendingOnly,
+    });
+    const csv = buildPayoutCsv(rows);
+    return new NextResponse(csv, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${payoutCsvFilename(tenantId)}"`,
+        "Cache-Control": "no-store",
+        "X-Payout-Row-Count": String(rows.length),
+      },
     });
   } catch (err) {
     console.error(
-      "GET /api/tenant/[tenantId]/preloved/consignment-lots error:",
+      "GET /api/tenant/[tenantId]/preloved/payout.csv error:",
       err,
     );
     return NextResponse.json(
-      { error: "Failed to load consignment lots" },
+      { error: "Failed to export payout CSV" },
       { status: 500 },
     );
   }

--- a/apps/web/src/db/preloved-queries.ts
+++ b/apps/web/src/db/preloved-queries.ts
@@ -4,7 +4,7 @@
  */
 import { cache } from "react";
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, gt, inArray, isNotNull, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, lt, sql } from "drizzle-orm";
 import {
   DEFAULT_PRICE_FRACTION_OF_NEW,
   PRELOVED_INTAKE_SOURCE,
@@ -49,8 +49,14 @@ import {
   type ConsignmentAcceptedUnit,
   type ConsignmentLotItemDraft,
   type ConsignmentLotListItem,
+  type ConsignmentSoldLine,
   type InsertConsignmentLotInput,
 } from "@/lib/preloved-consignment";
+import {
+  parseMoney2,
+  splitSaleCommission,
+  type PayoutCsvRow,
+} from "@/lib/preloved-payout";
 import { policyTextWithPrelovedRefundClause } from "@/lib/preloved-refund-policy";
 import { logAuditEvent } from "@/lib/audit/log";
 import type { AuditActorRole } from "@/lib/audit/types";
@@ -61,6 +67,9 @@ import {
   catalogVariants,
   consignmentItems,
   consignmentLots,
+  consignmentSoldLines,
+  orderLines,
+  orders,
   prelovedDonationNotes,
   prelovedIntakeEvents,
   prelovedSkus,
@@ -313,6 +322,10 @@ function mapConsignmentLotRow(row: ConsignmentLotRow): ConsignmentLotListItem {
     createdAt: row.createdAt,
     acceptedUnits: [],
     acceptedQty: 0,
+    soldLines: [],
+    soldQty: 0,
+    remittanceTotal: 0,
+    commissionTotal: 0,
   };
 }
 
@@ -345,6 +358,7 @@ async function attachAcceptedUnits(
       size: consignmentItems.size,
       condition: consignmentItems.condition,
       qty: consignmentItems.qty,
+      soldOrderLineId: consignmentItems.soldOrderLineId,
       createdAt: consignmentItems.createdAt,
     })
     .from(consignmentItems)
@@ -366,6 +380,7 @@ async function attachAcceptedUnits(
       size: row.size,
       condition: row.condition,
       qty: row.qty,
+      soldOrderLineId: row.soldOrderLineId,
       createdAt: row.createdAt,
     };
     const list = byLot.get(row.lotId) ?? [];
@@ -381,6 +396,90 @@ async function attachAcceptedUnits(
       acceptedQty: acceptedUnits.reduce((sum, unit) => sum + unit.qty, 0),
     };
   });
+}
+
+async function attachSoldLines(
+  tenantId: string,
+  lots: ConsignmentLotListItem[],
+): Promise<ConsignmentLotListItem[]> {
+  if (lots.length === 0) return lots;
+  const lotIds = lots.map((lot) => lot.id);
+  const rows = await db
+    .select({
+      id: consignmentSoldLines.id,
+      lotId: consignmentSoldLines.lotId,
+      consignmentItemId: consignmentSoldLines.consignmentItemId,
+      orderId: consignmentSoldLines.orderId,
+      orderLineId: consignmentSoldLines.orderLineId,
+      itemName: catalogItems.name,
+      size: consignmentItems.size,
+      condition: consignmentItems.condition,
+      qty: consignmentSoldLines.qty,
+      saleUnitPrice: consignmentSoldLines.saleUnitPrice,
+      saleLineTotal: consignmentSoldLines.saleLineTotal,
+      commissionBps: consignmentSoldLines.commissionBps,
+      commissionAmount: consignmentSoldLines.commissionAmount,
+      remittanceAmount: consignmentSoldLines.remittanceAmount,
+      createdAt: consignmentSoldLines.createdAt,
+    })
+    .from(consignmentSoldLines)
+    .innerJoin(
+      consignmentItems,
+      eq(consignmentItems.id, consignmentSoldLines.consignmentItemId),
+    )
+    .innerJoin(catalogItems, eq(catalogItems.id, consignmentItems.sourceItemId))
+    .where(
+      and(
+        eq(consignmentSoldLines.tenantId, tenantId),
+        inArray(consignmentSoldLines.lotId, lotIds),
+      ),
+    )
+    .orderBy(desc(consignmentSoldLines.createdAt));
+
+  const byLot = new Map<string, ConsignmentSoldLine[]>();
+  for (const row of rows) {
+    const line: ConsignmentSoldLine = {
+      id: row.id,
+      consignmentItemId: row.consignmentItemId,
+      orderId: row.orderId,
+      orderLineId: row.orderLineId,
+      itemName: row.itemName,
+      size: row.size,
+      condition: row.condition,
+      qty: row.qty,
+      saleUnitPrice: parseMoney2(row.saleUnitPrice),
+      saleLineTotal: parseMoney2(row.saleLineTotal),
+      commissionBps: row.commissionBps,
+      commissionAmount: parseMoney2(row.commissionAmount),
+      remittanceAmount: parseMoney2(row.remittanceAmount),
+      createdAt: row.createdAt,
+    };
+    const list = byLot.get(row.lotId) ?? [];
+    list.push(line);
+    byLot.set(row.lotId, list);
+  }
+
+  return lots.map((lot) => {
+    const soldLines = byLot.get(lot.id) ?? [];
+    return {
+      ...lot,
+      soldLines,
+      soldQty: soldLines.reduce((sum, line) => sum + line.qty, 0),
+      remittanceTotal: parseMoney2(
+        soldLines.reduce((sum, line) => sum + line.remittanceAmount, 0),
+      ),
+      commissionTotal: parseMoney2(
+        soldLines.reduce((sum, line) => sum + line.commissionAmount, 0),
+      ),
+    };
+  });
+}
+
+async function hydrateConsignmentLots(
+  tenantId: string,
+  lots: ConsignmentLotListItem[],
+): Promise<ConsignmentLotListItem[]> {
+  return attachSoldLines(tenantId, await attachAcceptedUnits(tenantId, lots));
 }
 
 async function attachLotTickets(
@@ -466,7 +565,7 @@ export async function listConsignmentLots(
     .where(eq(consignmentLots.tenantId, tenantId))
     .orderBy(desc(consignmentLots.createdAt))
     .limit(CONSIGNMENT_LOT_LIST_LIMIT);
-  return attachAcceptedUnits(tenantId, rows.map(mapConsignmentLotRow));
+  return hydrateConsignmentLots(tenantId, rows.map(mapConsignmentLotRow));
 }
 
 export type MarkConsignmentLotPayoutResult =
@@ -499,7 +598,7 @@ export async function markConsignmentLotPayout(opts: {
     return { ok: false, reason: "not_found" };
   }
   if (existing.payoutStatus !== "pending") {
-    const [lot] = await attachAcceptedUnits(opts.tenantId, [
+    const [lot] = await hydrateConsignmentLots(opts.tenantId, [
       mapConsignmentLotRow(existing),
     ]);
     return {
@@ -528,7 +627,7 @@ export async function markConsignmentLotPayout(opts: {
     if (!current) {
       return { ok: false, reason: "not_found" };
     }
-    const [lot] = await attachAcceptedUnits(opts.tenantId, [
+    const [lot] = await hydrateConsignmentLots(opts.tenantId, [
       mapConsignmentLotRow(current),
     ]);
     return {
@@ -538,10 +637,224 @@ export async function markConsignmentLotPayout(opts: {
     };
   }
 
-  const [lot] = await attachAcceptedUnits(opts.tenantId, [
+  const [lot] = await hydrateConsignmentLots(opts.tenantId, [
     mapConsignmentLotRow(row),
   ]);
   return { ok: true, lot };
+}
+
+export type RecordConsignmentSoldLinesResult = {
+  allocated: number;
+  recorded: number;
+};
+
+/**
+ * FIFO-attribute unsold consignment units to a paid order's preloved lines and
+ * write remittance rows with the tenant's commissionBps at sale time.
+ * Idempotent: already-sold items and existing ledger rows are left alone.
+ * Donation units in the same pool are not attributed (no consignment_items).
+ */
+export async function recordConsignmentSoldLinesForOrder(input: {
+  orderId: string;
+  tenantId: string;
+}): Promise<RecordConsignmentSoldLinesResult> {
+  const orderId = input.orderId.trim();
+  const tenantId = input.tenantId.trim();
+  if (!orderId || !tenantId) {
+    throw new Error("orderId and tenantId are required");
+  }
+
+  const settings = await getPrelovedSettings(tenantId);
+  const commissionBps = settings.commissionBps;
+
+  const allocated = (await db.execute(sql`
+    WITH lines AS (
+      SELECT ol.id, ol.preloved_sku_id, ol.qty
+      FROM order_lines ol
+      INNER JOIN orders o ON o.id = ol.order_id
+      WHERE o.id = ${orderId}
+        AND o.tenant_id = ${tenantId}
+        AND ol.preloved_sku_id IS NOT NULL
+    ),
+    needed AS (
+      SELECT
+        ol.id AS order_line_id,
+        ol.preloved_sku_id,
+        row_number() OVER (
+          PARTITION BY ol.preloved_sku_id
+          ORDER BY ol.id, gs.n
+        ) AS rn
+      FROM lines ol
+      CROSS JOIN LATERAL generate_series(1, ol.qty) AS gs(n)
+    ),
+    available AS (
+      SELECT
+        ci.id AS item_id,
+        ci.preloved_sku_id,
+        row_number() OVER (
+          PARTITION BY ci.preloved_sku_id
+          ORDER BY ci.created_at, ci.id
+        ) AS rn
+      FROM consignment_items ci
+      WHERE ci.tenant_id = ${tenantId}
+        AND ci.sold_order_line_id IS NULL
+        AND ci.preloved_sku_id IN (SELECT preloved_sku_id FROM lines)
+    ),
+    alloc AS (
+      SELECT n.order_line_id, a.item_id
+      FROM needed n
+      INNER JOIN available a
+        ON a.preloved_sku_id = n.preloved_sku_id
+       AND a.rn = n.rn
+    )
+    UPDATE consignment_items ci
+    SET sold_order_line_id = alloc.order_line_id
+    FROM alloc
+    WHERE ci.id = alloc.item_id
+      AND ci.sold_order_line_id IS NULL
+    RETURNING ci.id
+  `)) as { rows: { id: string }[] };
+
+  const pending = await db
+    .select({
+      consignmentItemId: consignmentItems.id,
+      lotId: consignmentItems.lotId,
+      prelovedSkuId: consignmentItems.prelovedSkuId,
+      orderLineId: orderLines.id,
+      unitPrice: orderLines.unitPrice,
+    })
+    .from(consignmentItems)
+    .innerJoin(orderLines, eq(orderLines.id, consignmentItems.soldOrderLineId))
+    .innerJoin(orders, eq(orders.id, orderLines.orderId))
+    .leftJoin(
+      consignmentSoldLines,
+      eq(consignmentSoldLines.consignmentItemId, consignmentItems.id),
+    )
+    .where(
+      and(
+        eq(consignmentItems.tenantId, tenantId),
+        eq(orders.id, orderId),
+        eq(orders.tenantId, tenantId),
+        isNull(consignmentSoldLines.id),
+      ),
+    );
+
+  if (pending.length === 0) {
+    return { allocated: allocated.rows.length, recorded: 0 };
+  }
+
+  try {
+    const inserted = await db
+      .insert(consignmentSoldLines)
+      .values(
+        pending.map((row) => {
+          const saleAud = parseMoney2(row.unitPrice);
+          const split = splitSaleCommission(saleAud, commissionBps);
+          return {
+            tenantId,
+            lotId: row.lotId,
+            consignmentItemId: row.consignmentItemId,
+            orderId,
+            orderLineId: row.orderLineId,
+            prelovedSkuId: row.prelovedSkuId,
+            qty: 1,
+            saleUnitPrice: split.saleAud.toFixed(2),
+            saleLineTotal: split.saleAud.toFixed(2),
+            commissionBps,
+            commissionAmount: split.commissionAud.toFixed(2),
+            remittanceAmount: split.remittanceAud.toFixed(2),
+          };
+        }),
+      )
+      .onConflictDoNothing({ target: consignmentSoldLines.consignmentItemId })
+      .returning({ id: consignmentSoldLines.id });
+    return { allocated: allocated.rows.length, recorded: inserted.length };
+  } catch (error) {
+    if (isUniqueConstraintError(error, "consignment_sold_lines_item_unique")) {
+      return { allocated: allocated.rows.length, recorded: 0 };
+    }
+    throw error;
+  }
+}
+
+/** Best-effort remittance write. Order row already exists; webhook retries. */
+export async function recordConsignmentSoldLinesBestEffort(input: {
+  orderId: string;
+  tenantId: string;
+}): Promise<void> {
+  try {
+    await recordConsignmentSoldLinesForOrder(input);
+  } catch (err) {
+    console.error("recordConsignmentSoldLinesForOrder failed", input, err);
+  }
+}
+
+/** Treasurer ledger: one row per sold consigned unit, oldest first. */
+export async function listConsignmentSoldLinesForExport(
+  tenantId: string,
+  opts?: { pendingOnly?: boolean },
+): Promise<PayoutCsvRow[]> {
+  const pendingOnly = opts?.pendingOnly === true;
+  const rows = await db
+    .select({
+      soldAt: consignmentSoldLines.createdAt,
+      ticketCode: consignmentLots.ticketCode,
+      familyName: consignmentLots.familyName,
+      studentName: consignmentLots.studentName,
+      email: consignmentLots.email,
+      mobile: consignmentLots.mobile,
+      payoutPreference: consignmentLots.payoutPreference,
+      payoutStatus: consignmentLots.payoutStatus,
+      bankBsb: consignmentLots.bankBsb,
+      bankAccountName: consignmentLots.bankAccountName,
+      bankAccountNumber: consignmentLots.bankAccountNumber,
+      itemName: catalogItems.name,
+      size: consignmentItems.size,
+      condition: consignmentItems.condition,
+      orderId: consignmentSoldLines.orderId,
+      salePrice: consignmentSoldLines.saleLineTotal,
+      commissionBps: consignmentSoldLines.commissionBps,
+      commissionAmount: consignmentSoldLines.commissionAmount,
+      remittanceAmount: consignmentSoldLines.remittanceAmount,
+    })
+    .from(consignmentSoldLines)
+    .innerJoin(consignmentLots, eq(consignmentLots.id, consignmentSoldLines.lotId))
+    .innerJoin(
+      consignmentItems,
+      eq(consignmentItems.id, consignmentSoldLines.consignmentItemId),
+    )
+    .innerJoin(catalogItems, eq(catalogItems.id, consignmentItems.sourceItemId))
+    .where(
+      pendingOnly
+        ? and(
+            eq(consignmentSoldLines.tenantId, tenantId),
+            eq(consignmentLots.payoutStatus, "pending"),
+          )
+        : eq(consignmentSoldLines.tenantId, tenantId),
+    )
+    .orderBy(asc(consignmentSoldLines.createdAt), asc(consignmentSoldLines.id));
+
+  return rows.map((row) => ({
+    soldAt: row.soldAt,
+    ticketCode: row.ticketCode,
+    familyName: row.familyName,
+    studentName: row.studentName,
+    email: row.email,
+    mobile: row.mobile,
+    payoutPreference: row.payoutPreference,
+    payoutStatus: row.payoutStatus,
+    bankBsb: row.bankBsb,
+    bankAccountName: row.bankAccountName,
+    bankAccountNumber: row.bankAccountNumber,
+    itemName: row.itemName,
+    size: row.size,
+    condition: row.condition,
+    orderId: row.orderId,
+    salePrice: parseMoney2(row.salePrice),
+    commissionBps: row.commissionBps,
+    commissionAmount: parseMoney2(row.commissionAmount),
+    remittanceAmount: parseMoney2(row.remittanceAmount),
+  }));
 }
 
 function variantHasSize(sizes: unknown, size: string): boolean {

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -432,8 +432,8 @@ export const consignmentItems = pgTable(
     size: text("size").notNull(),
     condition: prelovedConditionEnum("condition").notNull(),
     qty: integer("qty").notNull().default(1),
-    // Later payout CSV / sold-line ledger fills this. No FK yet — order_lines
-    // is declared later and remittance is a separate slice.
+    // Filled when a paid order consumes this unit (FIFO). FK is in SQL only —
+    // order_lines is declared later in this file.
     soldOrderLineId: uuid("sold_order_line_id"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
@@ -604,6 +604,64 @@ export const orderLines = pgTable(
   (t) => ({
     orderItemIdx: index("idx_order_lines_order_id_item_id").on(t.orderId, t.itemId),
   })
+);
+
+// One remittance row per sold consigned unit. commission_bps is snapshotted
+// from tenant settings at sale time so a later settings edit cannot rewrite
+// the treasurer ledger.
+export const consignmentSoldLines = pgTable(
+  "consignment_sold_lines",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    lotId: uuid("lot_id")
+      .notNull()
+      .references(() => consignmentLots.id, { onDelete: "cascade" }),
+    consignmentItemId: uuid("consignment_item_id")
+      .notNull()
+      .references(() => consignmentItems.id, { onDelete: "restrict" }),
+    orderId: text("order_id")
+      .notNull()
+      .references(() => orders.id, { onDelete: "restrict" }),
+    orderLineId: uuid("order_line_id")
+      .notNull()
+      .references(() => orderLines.id, { onDelete: "restrict" }),
+    prelovedSkuId: uuid("preloved_sku_id")
+      .notNull()
+      .references(() => prelovedSkus.id, { onDelete: "restrict" }),
+    qty: integer("qty").notNull().default(1),
+    saleUnitPrice: numeric("sale_unit_price", { precision: 10, scale: 2 }).notNull(),
+    saleLineTotal: numeric("sale_line_total", { precision: 10, scale: 2 }).notNull(),
+    commissionBps: integer("commission_bps").notNull(),
+    commissionAmount: numeric("commission_amount", {
+      precision: 10,
+      scale: 2,
+    }).notNull(),
+    remittanceAmount: numeric("remittance_amount", {
+      precision: 10,
+      scale: 2,
+    }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    itemUnique: uniqueIndex("consignment_sold_lines_item_unique").on(
+      t.consignmentItemId,
+    ),
+    tenantTimeIdx: index("idx_consignment_sold_lines_tenant_time").on(
+      t.tenantId,
+      t.createdAt,
+    ),
+    lotTimeIdx: index("idx_consignment_sold_lines_lot_time").on(
+      t.lotId,
+      t.createdAt,
+    ),
+    orderIdx: index("idx_consignment_sold_lines_order").on(t.orderId),
+    qtyPositive: check("consignment_sold_lines_qty_positive", sql`${t.qty} >= 1`),
+  }),
 );
 
 // ─── Order refunds ───────────────────────────────────────────────────────────
@@ -779,3 +837,4 @@ export type PrelovedIntakeEventRow = typeof prelovedIntakeEvents.$inferSelect;
 export type PrelovedDonationNoteRow = typeof prelovedDonationNotes.$inferSelect;
 export type ConsignmentLotRow = typeof consignmentLots.$inferSelect;
 export type ConsignmentItemRow = typeof consignmentItems.$inferSelect;
+export type ConsignmentSoldLineRow = typeof consignmentSoldLines.$inferSelect;

--- a/apps/web/src/lib/preloved-consignment.ts
+++ b/apps/web/src/lib/preloved-consignment.ts
@@ -60,6 +60,24 @@ export type ConsignmentAcceptedUnit = {
   size: string;
   condition: "good" | "fair";
   qty: number;
+  soldOrderLineId: string | null;
+  createdAt: Date;
+};
+
+export type ConsignmentSoldLine = {
+  id: string;
+  consignmentItemId: string;
+  orderId: string;
+  orderLineId: string;
+  itemName: string;
+  size: string;
+  condition: "good" | "fair";
+  qty: number;
+  saleUnitPrice: number;
+  saleLineTotal: number;
+  commissionBps: number;
+  commissionAmount: number;
+  remittanceAmount: number;
   createdAt: Date;
 };
 
@@ -81,6 +99,10 @@ export type ConsignmentLotListItem = {
   createdAt: Date;
   acceptedUnits: ConsignmentAcceptedUnit[];
   acceptedQty: number;
+  soldLines: ConsignmentSoldLine[];
+  soldQty: number;
+  remittanceTotal: number;
+  commissionTotal: number;
 };
 
 export function isConsignmentIntakeMode(mode: string): boolean {

--- a/apps/web/src/lib/preloved-payout.ts
+++ b/apps/web/src/lib/preloved-payout.ts
@@ -1,0 +1,153 @@
+/**
+ * Phase 2 consignment remittance — commission split + treasurer CSV.
+ * Snapshot commissionBps at sale time; do not recompute from live settings.
+ * This module must not import the DB client.
+ */
+import {
+  DEFAULT_COMMISSION_BPS,
+  formatPayoutPreference,
+  isValidCommissionBps,
+  type ConsignmentLotPayoutStatus,
+  type ConsignmentPayoutPreference,
+} from "./preloved-consignment";
+
+export const PAYOUT_CSV_HEADERS = [
+  "Sold at",
+  "Ticket",
+  "Family",
+  "Student",
+  "Email",
+  "Mobile",
+  "Payout preference",
+  "Payout status",
+  "BSB",
+  "Account name",
+  "Account number",
+  "Item",
+  "Size",
+  "Condition",
+  "Order",
+  "Sale price",
+  "Commission bps",
+  "Commission %",
+  "Shop commission",
+  "Amount owing",
+] as const;
+
+export type PayoutCsvRow = {
+  soldAt: Date;
+  ticketCode: string;
+  familyName: string;
+  studentName: string;
+  email: string;
+  mobile: string;
+  payoutPreference: ConsignmentPayoutPreference;
+  payoutStatus: ConsignmentLotPayoutStatus;
+  bankBsb: string | null;
+  bankAccountName: string | null;
+  bankAccountNumber: string | null;
+  itemName: string;
+  size: string;
+  condition: "good" | "fair";
+  orderId: string;
+  salePrice: number;
+  commissionBps: number;
+  commissionAmount: number;
+  remittanceAmount: number;
+};
+
+export type SaleCommissionSplit = {
+  saleCents: number;
+  commissionCents: number;
+  remittanceCents: number;
+  saleAud: number;
+  commissionAud: number;
+  remittanceAud: number;
+};
+
+export function parseMoney2(value: unknown, fallback = 0): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Shop keeps commissionBps / 10_000 of the sale; parent remittance is the rest.
+ * Integer cents so 50% of $19.95 is $9.98 / $9.97, never a display-only cut.
+ */
+export function splitSaleCommission(
+  saleAud: number,
+  commissionBps: number = DEFAULT_COMMISSION_BPS,
+): SaleCommissionSplit {
+  if (!isValidCommissionBps(commissionBps)) {
+    throw new RangeError("commissionBps must be an integer between 0 and 10000");
+  }
+  if (!Number.isFinite(saleAud) || saleAud < 0) {
+    throw new RangeError("saleAud must be a finite amount of 0 or more");
+  }
+  const saleCents = Math.round(saleAud * 100);
+  const commissionCents = Math.round((saleCents * commissionBps) / 10_000);
+  const remittanceCents = saleCents - commissionCents;
+  return {
+    saleCents,
+    commissionCents,
+    remittanceCents,
+    saleAud: saleCents / 100,
+    commissionAud: commissionCents / 100,
+    remittanceAud: remittanceCents / 100,
+  };
+}
+
+export function csvCell(value: string | number | null | undefined): string {
+  const raw = value == null ? "" : String(value);
+  if (/[",\n\r]/.test(raw)) return `"${raw.replace(/"/g, '""')}"`;
+  return raw;
+}
+
+export function formatCsvMoney(value: number): string {
+  return parseMoney2(value).toFixed(2);
+}
+
+export function formatCommissionBpsPercent(bps: number): string {
+  return `${(bps / 100).toFixed(bps % 100 === 0 ? 0 : 1)}%`;
+}
+
+export function formatPayoutCsvIso(value: Date): string {
+  return value.toISOString();
+}
+
+export function buildPayoutCsv(rows: readonly PayoutCsvRow[]): string {
+  const lines = [
+    PAYOUT_CSV_HEADERS.join(","),
+    ...rows.map((row) =>
+      [
+        csvCell(formatPayoutCsvIso(row.soldAt)),
+        csvCell(row.ticketCode),
+        csvCell(row.familyName),
+        csvCell(row.studentName),
+        csvCell(row.email),
+        csvCell(row.mobile),
+        csvCell(formatPayoutPreference(row.payoutPreference)),
+        csvCell(row.payoutStatus),
+        csvCell(row.bankBsb),
+        csvCell(row.bankAccountName),
+        csvCell(row.bankAccountNumber),
+        csvCell(row.itemName),
+        csvCell(row.size),
+        csvCell(row.condition),
+        csvCell(row.orderId),
+        csvCell(formatCsvMoney(row.salePrice)),
+        csvCell(row.commissionBps),
+        csvCell(formatCommissionBpsPercent(row.commissionBps)),
+        csvCell(formatCsvMoney(row.commissionAmount)),
+        csvCell(formatCsvMoney(row.remittanceAmount)),
+      ].join(","),
+    ),
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+export function payoutCsvFilename(tenantId: string, now = new Date()): string {
+  const day = now.toISOString().slice(0, 10);
+  return `payout-${tenantId}-${day}.csv`;
+}

--- a/apps/web/tests/preloved/m09-payout-csv.spec.ts
+++ b/apps/web/tests/preloved/m09-payout-csv.spec.ts
@@ -1,0 +1,349 @@
+/**
+ * Phase 2 leftover: paid consigned units write a sold-line ledger with the
+ * snapshotted commission, and operators export a treasurer payout CSV.
+ *
+ * Needs pnpm dev:web and Stripe test keys. Bound to demo-academy like m08.
+ */
+import { neon } from "@neondatabase/serverless";
+import { expect, test, type Page } from "playwright/test";
+import { computeTotals } from "../../src/lib/order-totals";
+import { PRELOVED_VARIANT_LABEL } from "../../src/lib/preloved";
+import {
+  PAYOUT_CSV_HEADERS,
+  splitSaleCommission,
+} from "../../src/lib/preloved-payout";
+import {
+  ITEM_ID,
+  ITEM_NAME,
+  OPERATOR_EMAIL,
+  SIZE,
+  TENANT,
+  chooseSelect,
+  confirmVisaPayment,
+  devLogin,
+  ensurePrelovedEnabled,
+  forceChargesEnabled,
+  loadLocalEnv,
+  pinPooledSkuQty,
+} from "./helpers";
+
+test("commission split is integer cents, not a display-only cut", () => {
+  expect(splitSaleCommission(19.95, 5000)).toEqual({
+    saleCents: 1995,
+    commissionCents: 998,
+    remittanceCents: 997,
+    saleAud: 19.95,
+    commissionAud: 9.98,
+    remittanceAud: 9.97,
+  });
+  expect(splitSaleCommission(20, 2500)).toEqual({
+    saleCents: 2000,
+    commissionCents: 500,
+    remittanceCents: 1500,
+    saleAud: 20,
+    commissionAud: 5,
+    remittanceAud: 15,
+  });
+  expect(splitSaleCommission(10, 0)).toMatchObject({
+    commissionAud: 0,
+    remittanceAud: 10,
+  });
+  expect(splitSaleCommission(10, 10_000)).toMatchObject({
+    commissionAud: 10,
+    remittanceAud: 0,
+  });
+});
+
+async function createEftLot(page: Page, stamp: string) {
+  const createRes = await page.request.post(
+    `/api/tenant/${TENANT}/preloved/consign`,
+    {
+      data: {
+        familyName: `Payout${stamp}`,
+        studentName: "Remi",
+        email: `payout-${stamp}@example.com`,
+        mobile: "0400000014",
+        payoutPreference: "eft",
+        bankBsb: "062000",
+        bankAccountName: "Payout Family",
+        bankAccountNumber: "12345678",
+        unsoldPreference: "donate",
+        items: [{ garment: "Sports polo", size: SIZE }],
+        termsAccepted: true,
+      },
+    },
+  );
+  if (!createRes.ok()) {
+    throw new Error(
+      `create consignment lot failed ${createRes.status()}: ${await createRes.text()}`,
+    );
+  }
+  const created = (await createRes.json()) as {
+    id?: string;
+    ticketCode?: string;
+  };
+  expect(created.id).toBeTruthy();
+  expect(created.ticketCode).toMatch(/^CL-[A-Z0-9]{6}$/);
+  return { lotId: created.id!, ticket: created.ticketCode! };
+}
+
+async function unsoldRankForLot(skuId: string, lotId: string) {
+  loadLocalEnv();
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL missing for unsoldRankForLot");
+  const sql = neon(url);
+  const rows = await sql`
+    select id, lot_id
+    from consignment_items
+    where preloved_sku_id = ${skuId}
+      and sold_order_line_id is null
+    order by created_at, id
+  `;
+  const index = rows.findIndex((row) => String(row.lot_id) === lotId);
+  return { index, count: rows.length };
+}
+
+async function mintAndPayPreloved(
+  page: Page,
+  args: {
+    skuId: string;
+    sourceItemId: string;
+    unitPrice: number;
+    qty: number;
+    donatedGstFree: boolean;
+    label: string;
+  },
+) {
+  const totals = computeTotals({
+    lines: [
+      {
+        unitPrice: args.unitPrice,
+        qty: args.qty,
+        gstFree: args.donatedGstFree,
+      },
+    ],
+    delivery: "pickup",
+  });
+  await forceChargesEnabled();
+  const piRes = await page.request.post("/api/stripe/payment-intent", {
+    data: {
+      tenantId: TENANT,
+      amount: totals.total,
+      lines: [
+        {
+          itemId: args.sourceItemId,
+          variantLabel: PRELOVED_VARIANT_LABEL,
+          size: SIZE,
+          unitPrice: args.unitPrice,
+          qty: args.qty,
+          prelovedSkuId: args.skuId,
+        },
+      ],
+      delivery: "pickup",
+      subtotal: totals.subtotal,
+      gst: totals.gst,
+      metadata: {
+        parentEmail: OPERATOR_EMAIL,
+        studentName: `Payout ${args.label}`,
+        studentYear: "Year 9",
+        delivery: "pickup",
+      },
+    },
+  });
+  expect(
+    piRes.ok(),
+    `PI mint failed: ${piRes.status()} ${await piRes.text()}`,
+  ).toBeTruthy();
+  const piBody = (await piRes.json()) as { paymentIntentId?: string };
+  expect(piBody.paymentIntentId).toBeTruthy();
+  await confirmVisaPayment(piBody.paymentIntentId!);
+
+  const orderRes = await page.request.post("/api/orders", {
+    data: {
+      tenantId: TENANT,
+      parentName: `Payout Parent ${args.label}`,
+      parentEmail: OPERATOR_EMAIL,
+      parentMobile: "0412345678",
+      studentName: `Payout Student ${args.label}`,
+      studentYear: "Year 9",
+      studentRoll: "9R",
+      fulfilmentMethod: "pickup",
+      deliveryFee: 0,
+      subtotal: totals.subtotal,
+      gst: totals.gst,
+      total: totals.total,
+      stripePaymentIntentId: piBody.paymentIntentId,
+      refundPolicyAccepted: true,
+      lines: [
+        {
+          itemId: args.sourceItemId,
+          itemName: ITEM_NAME,
+          variantLabel: PRELOVED_VARIANT_LABEL,
+          size: SIZE,
+          qty: args.qty,
+          unitPrice: args.unitPrice,
+          lineTotal: args.unitPrice * args.qty,
+          prelovedSkuId: args.skuId,
+        },
+      ],
+    },
+  });
+  expect(
+    orderRes.ok(),
+    `order POST failed: ${orderRes.status()} ${await orderRes.text()}`,
+  ).toBeTruthy();
+  const orderBody = (await orderRes.json()) as { orderId?: string };
+  expect(orderBody.orderId).toBeTruthy();
+  return { orderId: orderBody.orderId!, totals };
+}
+
+test.describe("Phase 2 payout CSV / sold-line ledger", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("sale records remittance; treasurer CSV uses snapshotted commission", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    const { donatedGstFree } = await ensurePrelovedEnabled(page);
+
+    const enableRes = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+      data: {
+        prelovedEnabled: true,
+        intakeMode: "donation_and_consignment",
+        commissionBps: 5000,
+      },
+    });
+    expect(enableRes.ok()).toBeTruthy();
+
+    const stamp = String(Date.now()).slice(-8);
+    const { lotId, ticket } = await createEftLot(page, stamp);
+
+    await page.goto(`/admin/${TENANT}/preloved/intake`);
+    await expect(page.getByTestId("intake-desk")).toBeVisible();
+    await expect(page.getByTestId("intake-lot-loading")).toHaveCount(0, {
+      timeout: 15_000,
+    });
+    await chooseSelect(page, "intake-item", ITEM_NAME);
+    await chooseSelect(page, "intake-size", SIZE);
+    await page.getByTestId("intake-condition").getByText("Good", { exact: true }).click();
+    await chooseSelect(page, "intake-lot", new RegExp(`^${ticket}\\s`));
+    await page.getByTestId("intake-accept").click();
+    await expect(page.getByTestId("intake-success")).toContainText(ticket);
+
+    await page.goto(`/admin/${TENANT}/preloved/consignments`);
+    const lotRow = page.locator(
+      `[data-testid="consignments-row"][data-ticket="${ticket}"]`,
+    );
+    await expect(lotRow).toBeVisible({ timeout: 15_000 });
+    await expect(lotRow.getByTestId("consignments-sold-empty")).toBeVisible();
+    await expect(lotRow.getByTestId("consignments-owing")).toContainText("$0.00");
+
+    const lotsRes = await page.request.get(
+      `/api/tenant/${TENANT}/preloved/consignment-lots`,
+    );
+    expect(lotsRes.ok()).toBeTruthy();
+    const lotsBody = (await lotsRes.json()) as {
+      lots?: Array<{
+        id: string;
+        acceptedUnits?: Array<{ skuId: string }>;
+      }>;
+    };
+    const lot = lotsBody.lots?.find((row) => row.id === lotId);
+    const skuId = lot?.acceptedUnits?.[0]?.skuId;
+    expect(skuId).toBeTruthy();
+
+    const rank = await unsoldRankForLot(skuId!, lotId);
+    expect(rank.index).toBeGreaterThanOrEqual(0);
+    const buyQty = rank.index + 1;
+    expect(buyQty).toBeLessThanOrEqual(12);
+
+    const pinned = await pinPooledSkuQty(buyQty);
+    expect(pinned.skuId).toBe(skuId);
+    expect(pinned.sourceItemId).toBe(ITEM_ID);
+
+    const paid = await mintAndPayPreloved(page, {
+      skuId: skuId!,
+      sourceItemId: ITEM_ID,
+      unitPrice: pinned.unitPrice,
+      qty: buyQty,
+      donatedGstFree,
+      label: stamp,
+    });
+
+    const split = splitSaleCommission(pinned.unitPrice, 5000);
+
+    await page.goto(`/admin/${TENANT}/preloved/consignments`);
+    await expect(lotRow.getByTestId("consignments-sold-row")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(lotRow).toHaveAttribute("data-sold-qty", "1");
+    await expect(lotRow.getByTestId("consignments-sold-row")).toContainText(
+      paid.orderId,
+    );
+    await expect(lotRow.getByTestId("consignments-sold-row")).toContainText(
+      `owing $${split.remittanceAud.toFixed(2)}`,
+    );
+    await expect(lotRow.getByTestId("consignments-owing")).toContainText(
+      `$${split.remittanceAud.toFixed(2)}`,
+    );
+
+    const csvRes = await page.request.get(
+      `/api/tenant/${TENANT}/preloved/payout.csv`,
+    );
+    expect(csvRes.ok()).toBeTruthy();
+    expect(csvRes.headers()["content-type"] ?? "").toContain("text/csv");
+    const csv = await csvRes.text();
+    const headerLine = csv.trim().split("\n")[0];
+    expect(headerLine).toBe(PAYOUT_CSV_HEADERS.join(","));
+    const ticketLine = csv
+      .split("\n")
+      .find((line) => line.includes(ticket) && line.includes(paid.orderId));
+    expect(ticketLine).toBeTruthy();
+    expect(ticketLine).toContain("EFT");
+    expect(ticketLine).toContain("062000");
+    expect(ticketLine).toContain(split.saleAud.toFixed(2));
+    expect(ticketLine).toContain("5000");
+    expect(ticketLine).toContain(split.commissionAud.toFixed(2));
+    expect(ticketLine).toContain(split.remittanceAud.toFixed(2));
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.getByTestId("consignments-export-csv").click(),
+    ]);
+    expect(download.suggestedFilename()).toMatch(
+      new RegExp(`^payout-${TENANT}-\\d{4}-\\d{2}-\\d{2}\\.csv$`),
+    );
+  });
+
+  test("export CSV surfaces an error state", async ({ page }) => {
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    await ensurePrelovedEnabled(page);
+    const enableRes = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+      data: {
+        prelovedEnabled: true,
+        intakeMode: "donation_and_consignment",
+        commissionBps: 5000,
+      },
+    });
+    expect(enableRes.ok()).toBeTruthy();
+
+    await page.route(`**/api/tenant/${TENANT}/preloved/payout.csv**`, (route) => {
+      return route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Ledger unavailable" }),
+      });
+    });
+
+    await page.goto(`/admin/${TENANT}/preloved/consignments`);
+    await expect(page.getByTestId("consignments-export-csv")).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByTestId("consignments-export-csv").click();
+    await expect(page.getByTestId("consignments-export-error")).toContainText(
+      "Ledger unavailable",
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:m06-last-unit-race": "pnpm --filter web test:m06-last-unit-race",
     "test:preloved-test-gaps": "pnpm --filter web test:preloved-test-gaps",
     "test:m07-consignment-school-fee": "pnpm --filter web test:m07-consignment-school-fee",
-    "test:m08-lot-intake": "pnpm --filter web test:m08-lot-intake"
+    "test:m08-lot-intake": "pnpm --filter web test:m08-lot-intake",
+    "test:m09-payout-csv": "pnpm --filter web test:m09-payout-csv"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/specs/_logs/OPEN_QUESTIONS.md
+++ b/specs/_logs/OPEN_QUESTIONS.md
@@ -21,7 +21,7 @@
       context: Spec default refuse list includes hats (Tara/CCGS). Some primary shops sell hats. Non-blocking; tenant can edit the list. Confirm only if hats should be allowed by default.
 
 - [x] **(plan)** School-fee credit as a payout option — raised: 2026-09-06, by: plan
-      context: Phase 2 first vertical (2026-09-12): parent consign form offers school-fee credit; operators mark lots manually. No school-finance integration. Lot→intake attribution shipped 2026-09-12 (`consignment_items`). Payout CSV / sold-line ledger still open.
+      context: Phase 2 first vertical (2026-09-12): parent consign form offers school-fee credit; operators mark lots manually. No school-finance integration. Lot→intake attribution shipped 2026-09-12 (`consignment_items`). Payout CSV / sold-line ledger shipped 2026-09-12 (`consignment_sold_lines`, treasurer CSV).
 
 - [x] **(M04)** Operators have no inbox to read `preloved_donation_notes` — raised: 2026-09-07, by: build:M04
       context: Resolved 2026-09-12. Operator inbox at `/admin/[tenant]/preloved/inbox` lists `preloved_donation_notes` (empty / loading / error). Notes still do not create a SKU.


### PR DESCRIPTION
When a consigned unit sells, the shop now records a remittance line against the lot and operators can download a treasurer payout CSV.

## What shipped

- Paid orders FIFO-attribute unsold `consignment_items` to the order’s preloved lines and write `consignment_sold_lines` with **snapshotted** `commissionBps` (sale, shop cut, amount owing).
- Donation units in the same pool are not attributed (no consignment item).
- Consignments tab shows sold lines + owing, and **Export payout CSV** (all sold lines, or pending lots only). Empty / loading / error covered.
- `GET /api/tenant/:id/preloved/payout.csv` — operator-auth CSV. Headers-only when the ledger is empty.
- Migration `0024_consignment_sold_lines` (applied on this Neon). Also adds the `sold_order_line_id` → `order_lines` FK.

## Verify

- `pnpm check-types:web` pass
- `pnpm test:m09-payout-csv` pass (3/3) on `http://127.0.0.1:43173` / demo-academy

## Out of scope

- Platform portal
- Bank-detail encryption (BSB/account stay operator-only plaintext, included on EFT CSV rows)
- School-finance integration (marks stay manual)

## Apply on other environments

Run `0024_consignment_sold_lines.sql` (or `drizzle-kit migrate` if that path is healthy) before production use.