### PR TITLE
test(preloved): empty Preloved filter e2e without skip

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test:m03-intake-stock": "playwright test -c playwright.config.ts tests/preloved/m03-intake-stock.spec.ts",
     "test:m04-donate-refund": "playwright test -c playwright.config.ts tests/preloved/m04-donate-refund.spec.ts",
     "test:m05-parent-preloved-shop": "playwright test -c playwright.config.ts tests/preloved/m05-parent-preloved-shop.spec.ts",
+    "test:m05-empty-preloved-filter": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online playwright test -c playwright.config.ts tests/preloved/m05-empty-preloved-filter.spec.ts",
     "test:m06-preloved-fulfilment": "playwright test -c playwright.config.ts tests/preloved/m06-preloved-fulfilment.spec.ts",
     "test:admin-dashboard": "playwright test -c playwright.admin.config.ts",
     "test:preloved-followups": "PRELOVED_TENANT=demo-academy OPERATOR_EMAIL=operator@demo.uniformorder.online playwright test -c playwright.config.ts tests/preloved/preloved-followups.spec.ts",

--- a/apps/web/tests/preloved/helpers.ts
+++ b/apps/web/tests/preloved/helpers.ts
@@ -68,6 +68,62 @@ export async function confirmVisaPayment(paymentIntentId: string) {
   }
 }
 
+export type PrelovedQtySnapshot = { id: string; qtyOnHand: number };
+
+/**
+ * Snapshot every in-stock preloved SKU for the tenant, then zero qty_on_hand so
+ * the parent Preloved filter renders empty without write-off or sale. Always
+ * restore via restoreShopPrelovedQty (try/finally).
+ */
+export async function emptyShopPrelovedQty(
+  tenantId: string = TENANT,
+): Promise<PrelovedQtySnapshot[]> {
+  loadLocalEnv();
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL missing for emptyShopPrelovedQty");
+  const sql = neon(url);
+  const rows = await sql`
+    select id, qty_on_hand
+    from preloved_skus
+    where tenant_id = ${tenantId}
+      and qty_on_hand > 0
+  `;
+  const snapshot = (rows as Array<{ id: string; qty_on_hand: number }>).map(
+    (row) => ({ id: row.id, qtyOnHand: Number(row.qty_on_hand) }),
+  );
+  if (snapshot.length === 0) return snapshot;
+  await sql`
+    update preloved_skus
+    set qty_on_hand = 0
+    where tenant_id = ${tenantId}
+      and qty_on_hand > 0
+  `;
+  return snapshot;
+}
+
+/** Restore qty_on_hand after emptyShopPrelovedQty. No-op on an empty snapshot. */
+export async function restoreShopPrelovedQty(
+  snapshot: PrelovedQtySnapshot[],
+): Promise<void> {
+  if (snapshot.length === 0) return;
+  loadLocalEnv();
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL missing for restoreShopPrelovedQty");
+  const sql = neon(url);
+  for (const row of snapshot) {
+    if (!Number.isInteger(row.qtyOnHand) || row.qtyOnHand < 0) {
+      throw new Error(
+        `restoreShopPrelovedQty bad qty for ${row.id}: ${row.qtyOnHand}`,
+      );
+    }
+    await sql`
+      update preloved_skus
+      set qty_on_hand = ${row.qtyOnHand}
+      where id = ${row.id}
+    `;
+  }
+}
+
 /** Pin qty / GST on a pooled SKU. Returns null when the row does not exist. */
 export async function pinPooledSkuForTest(opts: {
   qty: number;

--- a/apps/web/tests/preloved/m05-empty-preloved-filter.spec.ts
+++ b/apps/web/tests/preloved/m05-empty-preloved-filter.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * M05 leftover: parent Preloved filter empty state (donate copy + link).
+ *
+ * Non-destructive: snapshots in-stock qty, zeros the rack for the assertion,
+ * then restores. Does not write-off or sell units.
+ *
+ * Does not start the app. From repo root:
+ *   pnpm dev:web
+ *   PLAYWRIGHT_BASE_URL=http://127.0.0.1:<port> pnpm test:m05-empty-preloved-filter
+ *
+ * Bound to demo-academy by the package script (live Neon has no imhs).
+ */
+import { expect, test } from "playwright/test";
+import {
+  TENANT,
+  devLogin,
+  emptyShopPrelovedQty,
+  ensurePrelovedEnabled,
+  openCatalog,
+  restoreShopPrelovedQty,
+} from "./helpers";
+
+const MOBILE_VIEWPORT = { width: 430, height: 800 };
+const EMPTY_COPY = /No preloved in this size right now/i;
+const DONATE_HREF = `/${TENANT}/preloved/donate`;
+
+test.describe("M05 empty Preloved filter", () => {
+  test("empty Preloved filter shows donate copy and links to donate", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    await ensurePrelovedEnabled(page);
+
+    const snapshot = await emptyShopPrelovedQty();
+    try {
+      await openCatalog(page, "Preloved");
+      await expect(page.getByTestId("preloved-filter-chip")).toBeVisible();
+
+      const empty = page.getByTestId("preloved-empty");
+      await expect(empty).toBeVisible();
+      await expect(empty).toContainText(EMPTY_COPY);
+      await expect(
+        empty.getByRole("link", { name: "Donate outgrown items" }),
+      ).toHaveAttribute("href", DONATE_HREF);
+      await expect(page.getByTestId("preloved-card")).toHaveCount(0);
+    } finally {
+      await restoreShopPrelovedQty(snapshot);
+    }
+  });
+});

--- a/apps/web/tests/preloved/m05-parent-preloved-shop.spec.ts
+++ b/apps/web/tests/preloved/m05-parent-preloved-shop.spec.ts
@@ -21,10 +21,12 @@ import {
   TENANT,
   addNewPolo,
   devLogin,
+  emptyShopPrelovedQty,
   ensureInStockSku,
   ensurePrelovedDisabled,
   ensurePrelovedEnabled,
   openCatalog,
+  restoreShopPrelovedQty,
   skuCard,
 } from "./helpers";
 
@@ -193,29 +195,26 @@ test.describe("M05 parent preloved shop", () => {
   test("empty Preloved filter shows donate copy and links to donate", async ({
     page,
   }) => {
+    // Prefer the dedicated demo-academy gate: pnpm test:m05-empty-preloved-filter.
+    // This serial suite still covers the copy when helpers can reach DATABASE_URL.
     await devLogin(page, `/admin/${TENANT}/settings`);
     await ensurePrelovedEnabled(page);
     await page.setViewportSize(MOBILE_VIEWPORT);
 
-    await page.goto(`/admin/${TENANT}/preloved/stock`);
-    await expect(page.getByTestId("preloved-stock-page")).toBeVisible();
-    const rackEmpty = (await page.getByTestId("stock-empty").count()) > 0;
-    // Non-expired in-stock SKUs cannot be written off; M05 must not decrement
-    // qty. Empty-filter copy is asserted when the rack is empty (fresh tenant).
-    test.skip(
-      !rackEmpty,
-      "In-stock preloved SKUs are present; empty filter cannot render.",
-    );
-
-    await openCatalog(page, "Preloved");
-    const empty = page.getByTestId("preloved-empty");
-    await expect(empty).toBeVisible();
-    await expect(empty).toContainText(EMPTY_COPY);
-    await expect(empty.getByRole("link", { name: "Donate outgrown items" })).toHaveAttribute(
-      "href",
-      DONATE_HREF,
-    );
-    await expect(page.getByTestId("preloved-card")).toHaveCount(0);
+    // Non-destructive: zero qty_on_hand briefly, then restore. No write-off / sale.
+    const snapshot = await emptyShopPrelovedQty();
+    try {
+      await openCatalog(page, "Preloved");
+      const empty = page.getByTestId("preloved-empty");
+      await expect(empty).toBeVisible();
+      await expect(empty).toContainText(EMPTY_COPY);
+      await expect(
+        empty.getByRole("link", { name: "Donate outgrown items" }),
+      ).toHaveAttribute("href", DONATE_HREF);
+      await expect(page.getByTestId("preloved-card")).toHaveCount(0);
+    } finally {
+      await restoreShopPrelovedQty(snapshot);
+    }
   });
 
   test("mobile ~430px: Preloved filter, badge, and PDP copy", async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:m03-intake-stock": "pnpm --filter web test:m03-intake-stock",
     "test:m04-donate-refund": "pnpm --filter web test:m04-donate-refund",
     "test:m05-parent-preloved-shop": "pnpm --filter web test:m05-parent-preloved-shop",
+    "test:m05-empty-preloved-filter": "pnpm --filter web test:m05-empty-preloved-filter",
     "test:m06-preloved-fulfilment": "pnpm --filter web test:m06-preloved-fulfilment",
     "test:admin-dashboard": "pnpm --filter web test:admin-dashboard",
     "test:preloved-followups": "pnpm --filter web test:preloved-followups",

--- a/specs/_logs/OPEN_QUESTIONS.md
+++ b/specs/_logs/OPEN_QUESTIONS.md
@@ -29,8 +29,8 @@
 - [x] **(M05)** Parent-shop client islands do not hydrate in Playwright — raised: 2026-09-07, by: build:M05
       context: Resolved 2026-09-12. `allowedDevOrigins` + CSP `ws:`/`wss:` fix hydration on 127.0.0.1. Hard-fail coverage in `pnpm test:m05-parent-hydration` (preloved stepper `data-hydrated=true` + Add to cart; new catalogue Add to cart).
 
-- [ ] **(M05)** Empty Preloved filter e2e skipped when the rack already has stock — raised: 2026-09-07, by: build:M05
-      context: Write-off is expired-only and M05 must not decrement qty. A tenant that already has stock will `test.skip`. Copy+donate link exist in `catalog-grid.tsx`. Need a fresh empty tenant or a non-destructive empty fixture.
+- [x] **(M05)** Empty Preloved filter e2e skipped when the rack already has stock — raised: 2026-09-07, by: build:M05
+      context: Resolved with a non-destructive fixture (`emptyShopPrelovedQty` / `restoreShopPrelovedQty`) and `pnpm test:m05-empty-preloved-filter` on demo-academy. No write-off or sale; qty restored in `finally`.
 
 - [x] **(M06)** Live pay + pick-slip self-ver not run — raised: 2026-09-07, by: build:M06
       context: `pnpm test:m06-preloved-fulfilment` passed on demo-academy (qty 2→1, mixed-cart Stripe `pm_card_visa`, pick slip PRELOVED on preloved line only, Kanban To prepare/Ready/Needs attention/Completed). Desktop 1920×1080 screenshots in `.dev-local/m06-verify/`. playwright-cli chrome-for-testing was still installing; used project Playwright Chromium.

--- a/specs/milestones/M05-parent-preloved-shop.md
+++ b/specs/milestones/M05-parent-preloved-shop.md
@@ -57,7 +57,7 @@ Parents browse preloved next to new, see condition and stock, add a mixed cart c
 - [x] Item page shows condition, defects, ACL sentence; qty cannot exceed `qtyOnHand`
 - [x] Mixed cart of new polo + preloved jumper checks out; Stripe total is the sum; GST follows M02
 - [x] Adding qty above stock is impossible in UI
-- [ ] Empty preloved filter shows donate + buy-new copy linking to `/{tenant}/preloved/donate`
+- [x] Empty preloved filter shows donate + buy-new copy linking to `/{tenant}/preloved/donate`
 - [x] With preloved disabled, no preloved filter or SKUs
 - [x] `pnpm check-types:web` passes
 - [x] Playwright mobile (~430px) and desktop: browse → add preloved → mixed cart → checkout page totals


### PR DESCRIPTION
## Summary

Closes the Phase 1 M05 leftover: parent Preloved empty-filter e2e no longer `test.skip`s when the rack already has stock.

- Non-destructive fixture `emptyShopPrelovedQty` / `restoreShopPrelovedQty` snapshots in-stock qty, zeros it for the assertion, restores in `finally` (no write-off / sale).
- New gate `pnpm test:m05-empty-preloved-filter` bound to `demo-academy`.
- Serial M05 suite empty-filter test uses the same fixture.
- Marks the OPEN_QUESTIONS M05 empty-filter item resolved.

## Verification

- `pnpm check-types:web` — pass
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:43173 pnpm test:m05-empty-preloved-filter` — pass (1/1)

## Out of scope

- Mark/bank polish, platform portal, ledger robustness nits