### PR TITLE
fix(phase2): mask operator bank details and merge 409 marks

### DIFF
--- a/apps/web/src/app/admin/[tenant]/preloved/consignments/consignments-client.tsx
+++ b/apps/web/src/app/admin/[tenant]/preloved/consignments/consignments-client.tsx
@@ -7,7 +7,6 @@ import {
   formatLotPayoutStatus,
   formatPayoutPreference,
   formatUnsoldPreference,
-  payoutStatusForPreference,
   type ConsignmentLotPayoutStatus,
   type ConsignmentLotItemDraft,
   type ConsignmentPayoutPreference,
@@ -133,23 +132,16 @@ export function ConsignmentsClient({
   const markPayout = async (lot: ConsignmentLotRow) => {
     setMarkingId(lot.id);
     setMarkError("");
-    const payoutStatus = payoutStatusForPreference(lot.payoutPreference);
     try {
       const res = await fetch(
         `/api/tenant/${tenantId}/preloved/consignment-lots/${lot.id}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ payoutStatus }),
-        },
+        { method: "PATCH" },
       );
       const data = (await res.json().catch(() => null)) as {
         error?: string;
+        code?: string;
         lot?: ConsignmentLotRow;
       } | null;
-      if (!res.ok) {
-        throw new Error(data?.error ?? "Failed to mark payout.");
-      }
       if (data?.lot) {
         setLots((prev) =>
           prev
@@ -157,6 +149,11 @@ export function ConsignmentsClient({
             : prev,
         );
       }
+      if (res.ok) return;
+      if (res.status === 409 && data?.code === "already_marked" && data.lot) {
+        return;
+      }
+      throw new Error(data?.error ?? "Failed to mark payout.");
     } catch (err) {
       console.error("Mark payout failed:", err);
       setMarkError(
@@ -229,7 +226,8 @@ export function ConsignmentsClient({
         Parent consignment lots. Accept garments on Intake against a ticket.
         When a consigned unit sells, the shop keeps the published commission and
         the remainder is the amount owing. Export the treasurer CSV for EFT,
-        school-fee credit, or donated proceeds — marks stay manual.
+        school-fee credit, or donated proceeds — marks stay manual. Full BSB
+        and account numbers appear only on that CSV.
         {commissionBps != null
           ? ` Shop commission: ${formatCommissionPercent(commissionBps)}.`
           : null}
@@ -457,7 +455,11 @@ function LotsList({
               {lot.payoutPreference === "eft" ? (
                 <>
                   <dt style={{ color: "var(--color-ink-dim)" }}>Bank</dt>
-                  <dd className="tnum" style={{ color: "var(--color-ink)" }}>
+                  <dd
+                    className="tnum"
+                    style={{ color: "var(--color-ink)" }}
+                    data-testid="consignments-bank"
+                  >
                     {lot.bankAccountName} · BSB {lot.bankBsb} · {lot.bankAccountNumber}
                   </dd>
                 </>

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/[lotId]/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/[lotId]/route.ts
@@ -11,6 +11,9 @@ import {
 import { isConsignmentIntakeMode } from "@/lib/preloved-consignment";
 import { serializeConsignmentLot } from "../serialize";
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // PATCH /api/tenant/:tenantId/preloved/consignment-lots/:lotId — manual payout mark.
 // Status is derived from the lot payout preference. Client body is ignored.
 export async function PATCH(
@@ -18,6 +21,9 @@ export async function PATCH(
   { params }: { params: Promise<{ tenantId: string; lotId: string }> },
 ) {
   const { tenantId, lotId } = await params;
+  if (!UUID_RE.test(lotId)) {
+    return NextResponse.json({ error: "Lot not found" }, { status: 404 });
+  }
   try {
     const authResult = await requireSessionUser();
     if ("response" in authResult) return authResult.response;

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/serialize.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/consignment-lots/serialize.ts
@@ -1,8 +1,13 @@
-import type { ConsignmentLotListItem } from "@/lib/preloved-consignment";
+import {
+  maskConsignmentLotBank,
+  type ConsignmentLotListItem,
+} from "@/lib/preloved-consignment";
 
+/** Operator list/PATCH JSON. BSB/account are masked; treasurer CSV keeps full digits. */
 export function serializeConsignmentLot(lot: ConsignmentLotListItem) {
+  const masked = maskConsignmentLotBank(lot);
   return {
-    ...lot,
+    ...masked,
     createdAt: lot.createdAt.toISOString(),
     payoutMarkedAt: lot.payoutMarkedAt?.toISOString() ?? null,
     acceptedUnits: lot.acceptedUnits.map((unit) => ({

--- a/apps/web/src/app/api/tenant/[tenantId]/preloved/payout.csv/route.ts
+++ b/apps/web/src/app/api/tenant/[tenantId]/preloved/payout.csv/route.ts
@@ -12,6 +12,7 @@ import { isConsignmentIntakeMode } from "@/lib/preloved-consignment";
 import { buildPayoutCsv, payoutCsvFilename } from "@/lib/preloved-payout";
 
 // GET /api/tenant/:tenantId/preloved/payout.csv — treasurer remittance ledger.
+// Full BSB/account for EFT. Operator list/PATCH JSON stays masked.
 // ?pending=1 limits to lots not yet marked paid / credited / donated.
 export async function GET(
   req: NextRequest,

--- a/apps/web/src/lib/preloved-consignment.ts
+++ b/apps/web/src/lib/preloved-consignment.ts
@@ -171,6 +171,40 @@ export function isValidBsb(value: string): boolean {
   return /^\d{6}$/.test(normalizeBsb(value));
 }
 
+const BANK_MASK = "•";
+
+/** Keep the last N digits; used for operator list/PATCH JSON, not treasurer CSV. */
+export function maskBankDigits(
+  value: string | null | undefined,
+  visibleLast: number,
+): string | null {
+  if (value == null) return null;
+  const digits = value.replace(/\s|-/g, "");
+  if (!digits) return null;
+  const keep = Math.min(Math.max(visibleLast, 0), digits.length);
+  return `${BANK_MASK.repeat(digits.length - keep)}${digits.slice(-keep)}`;
+}
+
+export function maskBsb(value: string | null | undefined): string | null {
+  return maskBankDigits(value, 3);
+}
+
+export function maskAccountNumber(
+  value: string | null | undefined,
+): string | null {
+  return maskBankDigits(value, 4);
+}
+
+export function maskConsignmentLotBank<
+  T extends { bankBsb: string | null; bankAccountNumber: string | null },
+>(lot: T): T {
+  return {
+    ...lot,
+    bankBsb: maskBsb(lot.bankBsb),
+    bankAccountNumber: maskAccountNumber(lot.bankAccountNumber),
+  };
+}
+
 export function payoutStatusForPreference(
   preference: ConsignmentPayoutPreference,
 ): ConsignmentLotPayoutStatus {

--- a/apps/web/tests/preloved/helpers.ts
+++ b/apps/web/tests/preloved/helpers.ts
@@ -293,6 +293,18 @@ export async function ensurePrelovedDisabled(page: Page) {
   });
 }
 
+/** Put shared demo-academy back to donation-only after consignment gates. */
+export async function restoreDonationOnlyIntake(page: Page) {
+  const res = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+    data: { intakeMode: "donation_only" },
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `restore donation_only failed: ${res.status()} ${await res.text()}`,
+    );
+  }
+}
+
 export async function ensurePrelovedEnabled(
   page: Page,
 ): Promise<{ donatedGstFree: boolean }> {

--- a/apps/web/tests/preloved/m07-consignment-school-fee.spec.ts
+++ b/apps/web/tests/preloved/m07-consignment-school-fee.spec.ts
@@ -9,7 +9,16 @@ import {
   TENANT,
   devLogin,
   ensurePrelovedEnabled,
+  restoreDonationOnlyIntake,
 } from "./helpers";
+import { maskAccountNumber, maskBsb } from "../../src/lib/preloved-consignment";
+
+test("mask BSB last 3 and account last 4 for operator JSON", () => {
+  expect(maskBsb("062000")).toBe("•••000");
+  expect(maskAccountNumber("12345678")).toBe("••••5678");
+  expect(maskBsb(null)).toBeNull();
+  expect(maskAccountNumber("")).toBeNull();
+});
 
 test.describe("Phase 2 consignment / school-fee credit", () => {
   test("parent submits lot; operator marks school-fee credited", async ({
@@ -26,6 +35,8 @@ test.describe("Phase 2 consignment / school-fee credit", () => {
       },
     });
     expect(enableRes.ok()).toBeTruthy();
+
+    try {
 
     await page.goto(`/${TENANT}/preloved/consign`);
     await expect(page.getByTestId("consign-page")).toBeVisible();
@@ -124,5 +135,55 @@ test.describe("Phase 2 consignment / school-fee credit", () => {
       lot?: { payoutStatus?: string };
     };
     expect(deriveBody.lot?.payoutStatus).toBe("school_fee_credited");
+
+    const badId = await page.request.patch(
+      `/api/tenant/${TENANT}/preloved/consignment-lots/not-a-uuid`,
+    );
+    expect(badId.status()).toBe(404);
+
+    const mergeCreate = await page.request.post(
+      `/api/tenant/${TENANT}/preloved/consign`,
+      {
+        data: {
+          familyName: "Merge",
+          studentName: "Already",
+          email: "merge-marked@example.com",
+          mobile: "0400000002",
+          payoutPreference: "school_fee_credit",
+          unsoldPreference: "donate",
+          items: [{ garment: "Sports jacket", size: "14" }],
+          termsAccepted: true,
+        },
+      },
+    );
+    expect(mergeCreate.ok()).toBeTruthy();
+    const mergeLot = (await mergeCreate.json()) as {
+      ticketCode?: string;
+      id?: string;
+    };
+    expect(mergeLot.ticketCode).toMatch(/^CL-[A-Z0-9]{6}$/);
+    expect(mergeLot.id).toBeTruthy();
+
+    await page.reload();
+    const mergeRow = page.locator(
+      `[data-testid="consignments-row"][data-ticket="${mergeLot.ticketCode}"]`,
+    );
+    await expect(mergeRow).toBeVisible({ timeout: 15_000 });
+    await expect(mergeRow).toHaveAttribute("data-payout-status", "pending");
+
+    const markFirst = await page.request.patch(
+      `/api/tenant/${TENANT}/preloved/consignment-lots/${mergeLot.id}`,
+    );
+    expect(markFirst.ok()).toBeTruthy();
+    await mergeRow.getByTestId("consignments-mark-payout").click();
+    await expect(mergeRow).toHaveAttribute(
+      "data-payout-status",
+      "school_fee_credited",
+      { timeout: 10_000 },
+    );
+    await expect(page.getByTestId("consignments-mark-error")).toHaveCount(0);
+    } finally {
+      await restoreDonationOnlyIntake(page);
+    }
   });
 });

--- a/apps/web/tests/preloved/m08-lot-intake.spec.ts
+++ b/apps/web/tests/preloved/m08-lot-intake.spec.ts
@@ -16,6 +16,7 @@ import {
   ensurePrelovedEnabled,
   pinPooledSkuForTest,
   pooledRow,
+  restoreDonationOnlyIntake,
 } from "./helpers";
 
 const MIXED_GST_CONDITION = "fair" as const;
@@ -78,6 +79,8 @@ test.describe("Phase 2 consignment lot → intake / stock", () => {
       },
     });
     expect(enableRes.ok()).toBeTruthy();
+
+    try {
 
     const createRes = await page.request.post(
       `/api/tenant/${TENANT}/preloved/consign`,
@@ -186,6 +189,9 @@ test.describe("Phase 2 consignment lot → intake / stock", () => {
     await expect(page.getByTestId("intake-desk")).toBeVisible();
     await acceptSize10PoloGood(page);
     await expect(page.getByTestId("intake-success")).toContainText(/Donation pooled/i);
+    } finally {
+      await restoreDonationOnlyIntake(page);
+    }
   });
 
   test("refuse mixed GST on a pooled SKU; matching donation still accepts", async ({
@@ -243,7 +249,7 @@ test.describe("Phase 2 consignment lot → intake / stock", () => {
     } finally {
       const restore = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
         data: {
-          intakeMode: "donation_and_consignment",
+          intakeMode: "donation_only",
           donatedGstFree: false,
         },
       });
@@ -265,6 +271,8 @@ test.describe("Phase 2 consignment lot → intake / stock", () => {
       },
     });
     expect(enableRes.ok()).toBeTruthy();
+
+    try {
 
     const { ticket } = await createConsignmentLot(page, `stale-${Date.now()}`);
 
@@ -291,5 +299,8 @@ test.describe("Phase 2 consignment lot → intake / stock", () => {
     await page.getByTestId("intake-lot-retry").click();
     await expect(page.getByTestId("intake-lot-error")).toBeVisible();
     await expect(page.getByTestId("intake-accept")).toBeDisabled();
+    } finally {
+      await restoreDonationOnlyIntake(page);
+    }
   });
 });

--- a/apps/web/tests/preloved/m09-payout-csv.spec.ts
+++ b/apps/web/tests/preloved/m09-payout-csv.spec.ts
@@ -25,6 +25,7 @@ import {
   forceChargesEnabled,
   loadLocalEnv,
   pinPooledSkuQty,
+  restoreDonationOnlyIntake,
 } from "./helpers";
 
 test("commission split is integer cents, not a display-only cut", () => {
@@ -217,6 +218,7 @@ test.describe("Phase 2 payout CSV / sold-line ledger", () => {
     });
     expect(enableRes.ok()).toBeTruthy();
 
+    try {
     const stamp = String(Date.now()).slice(-8);
     const { lotId, ticket } = await createEftLot(page, stamp);
 
@@ -247,10 +249,23 @@ test.describe("Phase 2 payout CSV / sold-line ledger", () => {
     const lotsBody = (await lotsRes.json()) as {
       lots?: Array<{
         id: string;
+        bankBsb?: string | null;
+        bankAccountName?: string | null;
+        bankAccountNumber?: string | null;
         acceptedUnits?: Array<{ skuId: string }>;
       }>;
     };
     const lot = lotsBody.lots?.find((row) => row.id === lotId);
+    expect(lot?.bankBsb).toBe("•••000");
+    expect(lot?.bankAccountName).toBe("Payout Family");
+    expect(lot?.bankAccountNumber).toBe("••••5678");
+    expect(JSON.stringify(lot)).not.toContain("062000");
+    expect(JSON.stringify(lot)).not.toContain("12345678");
+    await expect(lotRow.getByTestId("consignments-bank")).toContainText("•••000");
+    await expect(lotRow.getByTestId("consignments-bank")).toContainText("••••5678");
+    await expect(lotRow.getByTestId("consignments-bank")).not.toContainText(
+      "12345678",
+    );
     const skuId = lot?.acceptedUnits?.[0]?.skuId;
     expect(skuId).toBeTruthy();
 
@@ -303,6 +318,7 @@ test.describe("Phase 2 payout CSV / sold-line ledger", () => {
     expect(ticketLine).toBeTruthy();
     expect(ticketLine).toContain("EFT");
     expect(ticketLine).toContain("062000");
+    expect(ticketLine).toContain("12345678");
     expect(ticketLine).toContain(split.saleAud.toFixed(2));
     expect(ticketLine).toContain("5000");
     expect(ticketLine).toContain(split.commissionAud.toFixed(2));
@@ -315,6 +331,9 @@ test.describe("Phase 2 payout CSV / sold-line ledger", () => {
     expect(download.suggestedFilename()).toMatch(
       new RegExp(`^payout-${TENANT}-\\d{4}-\\d{2}-\\d{2}\\.csv$`),
     );
+    } finally {
+      await restoreDonationOnlyIntake(page);
+    }
   });
 
   test("export CSV surfaces an error state", async ({ page }) => {
@@ -328,6 +347,8 @@ test.describe("Phase 2 payout CSV / sold-line ledger", () => {
       },
     });
     expect(enableRes.ok()).toBeTruthy();
+
+    try {
 
     await page.route(`**/api/tenant/${TENANT}/preloved/payout.csv**`, (route) => {
       return route.fulfill({
@@ -345,5 +366,8 @@ test.describe("Phase 2 payout CSV / sold-line ledger", () => {
     await expect(page.getByTestId("consignments-export-error")).toContainText(
       "Ledger unavailable",
     );
+    } finally {
+      await restoreDonationOnlyIntake(page);
+    }
   });
 });


### PR DESCRIPTION
Phase 2 leftover — mark/bank polish.

## What shipped

- Operator consignment **GET/PATCH JSON** masks BSB (last 3) and account number (last 4). Account name stays visible. The consignments list no longer shows plaintext digits.
- **Treasurer `payout.csv`** still exports full BSB/account for EFT. Copy on the consignments tab says full numbers appear only on that CSV.
- Mark button no longer sends ignored `{ payoutStatus }`. A `409 already_marked` response **merges `lot` into local state** instead of showing a hard error.
- Pending-only derived marks are unchanged (server still derives status from preference and updates only while `pending`).
- Malformed `lotId` is **404** (no Postgres uuid-cast 500).
- `m07` / `m08` / `m09` restore demo-academy to `donation_only` in `finally`.

## Not in this slice

- Ledger robustness (neon-http UPDATE/INSERT, concurrent FIFO `rn`, commission stamp window)
- Void remittance on refund (George accepted sold-at-charge-time)
- Platform portal
- Encrypting bank columns at rest

## Verify

| Gate | Result |
|---|---|
| `pnpm check-types:web` | pass |
| `pnpm test:m07-consignment-school-fee` (`PLAYWRIGHT_BASE_URL=http://127.0.0.1:43173`) | pass (2/2) |
| `pnpm test:m09-payout-csv` | pass (3/3) — GET masked, CSV full `062000` / `12345678` |
| `pnpm test:m08-lot-intake` | pass (3/3) |

Base: `main` @ `d9c56fa` (#52).