### PR TITLE
fix(phase2): ledger robustness for concurrent FIFO and split writes

### DIFF
--- a/apps/web/src/app/api/orders/route.ts
+++ b/apps/web/src/app/api/orders/route.ts
@@ -240,7 +240,7 @@ export async function POST(req: NextRequest) {
       });
       return NextResponse.json(
         { orderId: existingOrder.id, idempotent: true },
-        { status: 200 }
+        { status: 200 },
       );
     }
 

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -217,6 +217,8 @@ export async function POST(req: NextRequest) {
     });
 
     if (resolved) {
+      // Must throw on failure so Stripe redelivers. Do not swallow — a 200
+      // here used to drop sold-line inserts after a neon-http split write.
       await recordConsignmentSoldLinesBestEffort({
         orderId: resolved.id,
         tenantId: resolved.tenantId,

--- a/apps/web/src/db/preloved-queries.ts
+++ b/apps/web/src/db/preloved-queries.ts
@@ -4,7 +4,7 @@
  */
 import { cache } from "react";
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNotNull, lt, sql } from "drizzle-orm";
 import {
   DEFAULT_PRICE_FRACTION_OF_NEW,
   PRELOVED_INTAKE_SOURCE,
@@ -54,7 +54,6 @@ import {
 } from "@/lib/preloved-consignment";
 import {
   parseMoney2,
-  splitSaleCommission,
   type PayoutCsvRow,
 } from "@/lib/preloved-payout";
 import { policyTextWithPrelovedRefundClause } from "@/lib/preloved-refund-policy";
@@ -648,11 +647,20 @@ export type RecordConsignmentSoldLinesResult = {
   recorded: number;
 };
 
+const LEDGER_WRITE_ATTEMPTS = 3;
+
 /**
  * FIFO-attribute unsold consignment units to a paid order's preloved lines and
  * write remittance rows with the tenant's commissionBps at sale time.
+ *
+ * One SQL statement (neon-http: never db.transaction): SKIP LOCKED claim +
+ * ledger INSERT. Concurrent qty-1 sales on the same SKU take distinct units
+ * (loser gets the next unlocked item, or allocates 0 — treated as donated).
+ * Same-order replay uses an advisory lock and the unique item index.
+ *
  * Idempotent: already-sold items and existing ledger rows are left alone.
  * Donation units in the same pool are not attributed (no consignment_items).
+ * Pre-existing sold-without-ledger orphans (old split writes) are inserted here.
  */
 export async function recordConsignmentSoldLinesForOrder(input: {
   orderId: string;
@@ -666,127 +674,181 @@ export async function recordConsignmentSoldLinesForOrder(input: {
 
   const settings = await getPrelovedSettings(tenantId);
   const commissionBps = settings.commissionBps;
+  const lockKey = `csl:${orderId}`;
 
-  const allocated = (await db.execute(sql`
-    WITH lines AS (
-      SELECT ol.id, ol.preloved_sku_id, ol.qty
-      FROM order_lines ol
-      INNER JOIN orders o ON o.id = ol.order_id
-      WHERE o.id = ${orderId}
-        AND o.tenant_id = ${tenantId}
-        AND ol.preloved_sku_id IS NOT NULL
-    ),
-    needed AS (
-      SELECT
-        ol.id AS order_line_id,
-        ol.preloved_sku_id,
-        row_number() OVER (
-          PARTITION BY ol.preloved_sku_id
-          ORDER BY ol.id, gs.n
-        ) AS rn
-      FROM lines ol
-      CROSS JOIN LATERAL generate_series(1, ol.qty) AS gs(n)
-    ),
-    available AS (
-      SELECT
-        ci.id AS item_id,
-        ci.preloved_sku_id,
-        row_number() OVER (
-          PARTITION BY ci.preloved_sku_id
-          ORDER BY ci.created_at, ci.id
-        ) AS rn
-      FROM consignment_items ci
-      WHERE ci.tenant_id = ${tenantId}
-        AND ci.sold_order_line_id IS NULL
-        AND ci.preloved_sku_id IN (SELECT preloved_sku_id FROM lines)
-    ),
-    alloc AS (
-      SELECT n.order_line_id, a.item_id
-      FROM needed n
-      INNER JOIN available a
-        ON a.preloved_sku_id = n.preloved_sku_id
-       AND a.rn = n.rn
-    )
-    UPDATE consignment_items ci
-    SET sold_order_line_id = alloc.order_line_id
-    FROM alloc
-    WHERE ci.id = alloc.item_id
-      AND ci.sold_order_line_id IS NULL
-    RETURNING ci.id
-  `)) as { rows: { id: string }[] };
-
-  const pending = await db
-    .select({
-      consignmentItemId: consignmentItems.id,
-      lotId: consignmentItems.lotId,
-      prelovedSkuId: consignmentItems.prelovedSkuId,
-      orderLineId: orderLines.id,
-      unitPrice: orderLines.unitPrice,
-    })
-    .from(consignmentItems)
-    .innerJoin(orderLines, eq(orderLines.id, consignmentItems.soldOrderLineId))
-    .innerJoin(orders, eq(orders.id, orderLines.orderId))
-    .leftJoin(
-      consignmentSoldLines,
-      eq(consignmentSoldLines.consignmentItemId, consignmentItems.id),
-    )
-    .where(
-      and(
-        eq(consignmentItems.tenantId, tenantId),
-        eq(orders.id, orderId),
-        eq(orders.tenantId, tenantId),
-        isNull(consignmentSoldLines.id),
+  type LedgerWriteRow = { allocated: number; recorded: number };
+  const result = (await db.execute(sql`
+      WITH lock AS (
+        SELECT pg_advisory_xact_lock(hashtext(${lockKey})::bigint) AS held
       ),
-    );
-
-  if (pending.length === 0) {
-    return { allocated: allocated.rows.length, recorded: 0 };
-  }
-
-  try {
-    const inserted = await db
-      .insert(consignmentSoldLines)
-      .values(
-        pending.map((row) => {
-          const saleAud = parseMoney2(row.unitPrice);
-          const split = splitSaleCommission(saleAud, commissionBps);
-          return {
-            tenantId,
-            lotId: row.lotId,
-            consignmentItemId: row.consignmentItemId,
-            orderId,
-            orderLineId: row.orderLineId,
-            prelovedSkuId: row.prelovedSkuId,
-            qty: 1,
-            saleUnitPrice: split.saleAud.toFixed(2),
-            saleLineTotal: split.saleAud.toFixed(2),
-            commissionBps,
-            commissionAmount: split.commissionAud.toFixed(2),
-            remittanceAmount: split.remittanceAud.toFixed(2),
-          };
-        }),
+      lines AS (
+        SELECT ol.id, ol.preloved_sku_id, ol.qty
+        FROM order_lines ol
+        INNER JOIN orders o ON o.id = ol.order_id
+        WHERE o.id = ${orderId}
+          AND o.tenant_id = ${tenantId}
+          AND ol.preloved_sku_id IS NOT NULL
+          AND EXISTS (SELECT 1 FROM lock)
+      ),
+      needed AS (
+        SELECT
+          ol.id AS order_line_id,
+          ol.preloved_sku_id,
+          row_number() OVER (
+            PARTITION BY ol.preloved_sku_id
+            ORDER BY ol.id, gs.n
+          ) AS rn
+        FROM lines ol
+        CROSS JOIN LATERAL generate_series(1, ol.qty) AS gs(n)
+      ),
+      sku_need AS (
+        SELECT preloved_sku_id, COUNT(*)::int AS need
+        FROM needed
+        GROUP BY preloved_sku_id
+      ),
+      locked AS (
+        SELECT
+          claimed.id AS item_id,
+          claimed.lot_id,
+          claimed.preloved_sku_id,
+          row_number() OVER (
+            PARTITION BY claimed.preloved_sku_id
+            ORDER BY claimed.created_at, claimed.id
+          ) AS rn
+        FROM sku_need s
+        JOIN LATERAL (
+          SELECT ci.id, ci.lot_id, ci.preloved_sku_id, ci.created_at
+          FROM consignment_items ci
+          WHERE ci.tenant_id = ${tenantId}
+            AND ci.preloved_sku_id = s.preloved_sku_id
+            AND ci.sold_order_line_id IS NULL
+          ORDER BY ci.created_at, ci.id
+          FOR UPDATE OF ci SKIP LOCKED
+          LIMIT s.need
+        ) claimed ON true
+      ),
+      alloc AS (
+        SELECT n.order_line_id, l.item_id
+        FROM needed n
+        INNER JOIN locked l
+          ON l.preloved_sku_id = n.preloved_sku_id
+         AND l.rn = n.rn
+      ),
+      updated AS (
+        UPDATE consignment_items ci
+        SET sold_order_line_id = alloc.order_line_id
+        FROM alloc
+        WHERE ci.id = alloc.item_id
+          AND ci.sold_order_line_id IS NULL
+        RETURNING ci.id, ci.lot_id, ci.preloved_sku_id, ci.sold_order_line_id
+      ),
+      pending AS (
+        SELECT
+          u.id AS consignment_item_id,
+          u.lot_id,
+          u.preloved_sku_id,
+          u.sold_order_line_id AS order_line_id,
+          ol.unit_price
+        FROM updated u
+        INNER JOIN order_lines ol ON ol.id = u.sold_order_line_id
+        UNION
+        SELECT
+          ci.id,
+          ci.lot_id,
+          ci.preloved_sku_id,
+          ol.id,
+          ol.unit_price
+        FROM consignment_items ci
+        INNER JOIN order_lines ol ON ol.id = ci.sold_order_line_id
+        INNER JOIN orders o ON o.id = ol.order_id
+        LEFT JOIN consignment_sold_lines csl
+          ON csl.consignment_item_id = ci.id
+        WHERE ci.tenant_id = ${tenantId}
+          AND o.id = ${orderId}
+          AND o.tenant_id = ${tenantId}
+          AND csl.id IS NULL
+          AND EXISTS (SELECT 1 FROM lock)
+      ),
+      inserted AS (
+        INSERT INTO consignment_sold_lines (
+          tenant_id,
+          lot_id,
+          consignment_item_id,
+          order_id,
+          order_line_id,
+          preloved_sku_id,
+          qty,
+          sale_unit_price,
+          sale_line_total,
+          commission_bps,
+          commission_amount,
+          remittance_amount
+        )
+        SELECT
+          ${tenantId},
+          p.lot_id,
+          p.consignment_item_id,
+          ${orderId},
+          p.order_line_id,
+          p.preloved_sku_id,
+          1,
+          ROUND(ROUND(p.unit_price::numeric * 100) / 100, 2),
+          ROUND(ROUND(p.unit_price::numeric * 100) / 100, 2),
+          ${commissionBps},
+          ROUND(
+            ROUND(ROUND(p.unit_price::numeric * 100) * ${commissionBps} / 10000.0) / 100,
+            2
+          ),
+          ROUND(
+            (
+              ROUND(p.unit_price::numeric * 100)
+              - ROUND(ROUND(p.unit_price::numeric * 100) * ${commissionBps} / 10000.0)
+            ) / 100,
+            2
+          )
+        FROM pending p
+        ON CONFLICT (consignment_item_id) DO NOTHING
+        RETURNING id
       )
-      .onConflictDoNothing({ target: consignmentSoldLines.consignmentItemId })
-      .returning({ id: consignmentSoldLines.id });
-    return { allocated: allocated.rows.length, recorded: inserted.length };
-  } catch (error) {
-    if (isUniqueConstraintError(error, "consignment_sold_lines_item_unique")) {
-      return { allocated: allocated.rows.length, recorded: 0 };
-    }
-    throw error;
+      SELECT
+        (SELECT COUNT(*)::int FROM updated) AS allocated,
+        (SELECT COUNT(*)::int FROM inserted) AS recorded
+    `)) as { rows: LedgerWriteRow[] };
+
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error("consignment sold-line write returned no result");
   }
+  return {
+    allocated: Number(row.allocated) || 0,
+    recorded: Number(row.recorded) || 0,
+  };
 }
 
-/** Best-effort remittance write. Order row already exists; webhook retries. */
+/**
+ * Remittance write after the order row exists. Retries transient neon-http
+ * failures, then rethrows so POST / webhook cannot return 200 with a lost
+ * sold line. Callers must not swallow this.
+ */
 export async function recordConsignmentSoldLinesBestEffort(input: {
   orderId: string;
   tenantId: string;
 }): Promise<void> {
-  try {
-    await recordConsignmentSoldLinesForOrder(input);
-  } catch (err) {
-    console.error("recordConsignmentSoldLinesForOrder failed", input, err);
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= LEDGER_WRITE_ATTEMPTS; attempt++) {
+    try {
+      await recordConsignmentSoldLinesForOrder(input);
+      return;
+    } catch (err) {
+      lastError = err;
+      console.error("recordConsignmentSoldLinesForOrder failed", {
+        ...input,
+        attempt,
+      }, err);
+      if (attempt >= LEDGER_WRITE_ATTEMPTS) break;
+    }
   }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 /** Treasurer ledger: one row per sold consigned unit, oldest first. */

--- a/apps/web/tests/preloved/m09-payout-csv.spec.ts
+++ b/apps/web/tests/preloved/m09-payout-csv.spec.ts
@@ -5,7 +5,7 @@
  * Needs pnpm dev:web and Stripe test keys. Bound to demo-academy like m08.
  */
 import { neon } from "@neondatabase/serverless";
-import { expect, test, type Page } from "playwright/test";
+import { expect, test, type APIResponse, type Page } from "playwright/test";
 import { computeTotals } from "../../src/lib/order-totals";
 import { PRELOVED_VARIANT_LABEL } from "../../src/lib/preloved";
 import {
@@ -159,7 +159,41 @@ async function mintAndPayPreloved(
   expect(piBody.paymentIntentId).toBeTruthy();
   await confirmVisaPayment(piBody.paymentIntentId!);
 
-  const orderRes = await page.request.post("/api/orders", {
+  const orderRes = await postPaidPrelovedOrder(page, {
+    paymentIntentId: piBody.paymentIntentId!,
+    totals,
+    skuId: args.skuId,
+    sourceItemId: args.sourceItemId,
+    unitPrice: args.unitPrice,
+    qty: args.qty,
+    label: args.label,
+  });
+  expect(
+    orderRes.ok(),
+    `order POST failed: ${orderRes.status()} ${await orderRes.text()}`,
+  ).toBeTruthy();
+  const orderBody = (await orderRes.json()) as { orderId?: string };
+  expect(orderBody.orderId).toBeTruthy();
+  return {
+    orderId: orderBody.orderId!,
+    paymentIntentId: piBody.paymentIntentId!,
+    totals,
+  };
+}
+
+async function postPaidPrelovedOrder(
+  page: Page,
+  args: {
+    paymentIntentId: string;
+    totals: { subtotal: number; gst: number; total: number };
+    skuId: string;
+    sourceItemId: string;
+    unitPrice: number;
+    qty: number;
+    label: string;
+  },
+): Promise<APIResponse> {
+  return page.request.post("/api/orders", {
     data: {
       tenantId: TENANT,
       parentName: `Payout Parent ${args.label}`,
@@ -170,10 +204,10 @@ async function mintAndPayPreloved(
       studentRoll: "9R",
       fulfilmentMethod: "pickup",
       deliveryFee: 0,
-      subtotal: totals.subtotal,
-      gst: totals.gst,
-      total: totals.total,
-      stripePaymentIntentId: piBody.paymentIntentId,
+      subtotal: args.totals.subtotal,
+      gst: args.totals.gst,
+      total: args.totals.total,
+      stripePaymentIntentId: args.paymentIntentId,
       refundPolicyAccepted: true,
       lines: [
         {
@@ -189,13 +223,57 @@ async function mintAndPayPreloved(
       ],
     },
   });
+}
+
+async function acceptConsignedGood(page: Page, lotId: string) {
+  const res = await page.request.post(`/api/tenant/${TENANT}/preloved/intake`, {
+    data: {
+      action: "accepted",
+      sourceItemId: ITEM_ID,
+      size: SIZE,
+      condition: "good",
+      consignmentLotId: lotId,
+    },
+  });
   expect(
-    orderRes.ok(),
-    `order POST failed: ${orderRes.status()} ${await orderRes.text()}`,
+    res.ok(),
+    `intake accept failed ${res.status()}: ${await res.text()}`,
   ).toBeTruthy();
-  const orderBody = (await orderRes.json()) as { orderId?: string };
-  expect(orderBody.orderId).toBeTruthy();
-  return { orderId: orderBody.orderId!, totals };
+}
+
+async function soldLinesForOrders(orderIds: string[]) {
+  loadLocalEnv();
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL missing for soldLinesForOrders");
+  const sql = neon(url);
+  const rows: Array<{
+    order_id: string;
+    consignment_item_id: string;
+    remittance_amount: string | number;
+    sold_order_line_id: string | null;
+  }> = [];
+  for (const orderId of orderIds) {
+    const part = await sql`
+      select
+        csl.order_id,
+        csl.consignment_item_id,
+        csl.remittance_amount,
+        ci.sold_order_line_id
+      from consignment_sold_lines csl
+      inner join consignment_items ci on ci.id = csl.consignment_item_id
+      where csl.order_id = ${orderId}
+      order by csl.created_at, csl.id
+    `;
+    rows.push(
+      ...(part as Array<{
+        order_id: string;
+        consignment_item_id: string;
+        remittance_amount: string | number;
+        sold_order_line_id: string | null;
+      }>),
+    );
+  }
+  return rows;
 }
 
 test.describe("Phase 2 payout CSV / sold-line ledger", () => {
@@ -366,6 +444,237 @@ test.describe("Phase 2 payout CSV / sold-line ledger", () => {
     await expect(page.getByTestId("consignments-export-error")).toContainText(
       "Ledger unavailable",
     );
+    } finally {
+      await restoreDonationOnlyIntake(page);
+    }
+  });
+
+  test("two concurrent qty-1 sales claim distinct FIFO units", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    const { donatedGstFree } = await ensurePrelovedEnabled(page);
+    const enableRes = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+      data: {
+        prelovedEnabled: true,
+        intakeMode: "donation_and_consignment",
+        commissionBps: 5000,
+      },
+    });
+    expect(enableRes.ok()).toBeTruthy();
+
+    try {
+      const stamp = String(Date.now()).slice(-8);
+      const lotA = await createEftLot(page, `${stamp}a`);
+      const lotB = await createEftLot(page, `${stamp}b`);
+      await acceptConsignedGood(page, lotA.lotId);
+      await acceptConsignedGood(page, lotB.lotId);
+
+      const pinned = await pinPooledSkuQty(2);
+      expect(pinned.sourceItemId).toBe(ITEM_ID);
+
+      const mint = async (label: string) => {
+        const totals = computeTotals({
+          lines: [
+            {
+              unitPrice: pinned.unitPrice,
+              qty: 1,
+              gstFree: donatedGstFree,
+            },
+          ],
+          delivery: "pickup",
+        });
+        await forceChargesEnabled();
+        const piRes = await page.request.post("/api/stripe/payment-intent", {
+          data: {
+            tenantId: TENANT,
+            amount: totals.total,
+            lines: [
+              {
+                itemId: pinned.sourceItemId,
+                variantLabel: PRELOVED_VARIANT_LABEL,
+                size: SIZE,
+                unitPrice: pinned.unitPrice,
+                qty: 1,
+                prelovedSkuId: pinned.skuId,
+              },
+            ],
+            delivery: "pickup",
+            subtotal: totals.subtotal,
+            gst: totals.gst,
+            metadata: {
+              parentEmail: OPERATOR_EMAIL,
+              studentName: `Fifo ${label}`,
+              studentYear: "Year 9",
+              delivery: "pickup",
+            },
+          },
+        });
+        expect(
+          piRes.ok(),
+          `PI mint ${label} failed: ${piRes.status()} ${await piRes.text()}`,
+        ).toBeTruthy();
+        const body = (await piRes.json()) as { paymentIntentId?: string };
+        expect(body.paymentIntentId).toBeTruthy();
+        return { paymentIntentId: body.paymentIntentId!, totals };
+      };
+
+      const a = await mint("A");
+      const b = await mint("B");
+      expect(a.paymentIntentId).not.toBe(b.paymentIntentId);
+      await Promise.all([
+        confirmVisaPayment(a.paymentIntentId),
+        confirmVisaPayment(b.paymentIntentId),
+      ]);
+
+      const [resA, resB] = await Promise.all([
+        postPaidPrelovedOrder(page, {
+          paymentIntentId: a.paymentIntentId,
+          totals: a.totals,
+          skuId: pinned.skuId,
+          sourceItemId: pinned.sourceItemId,
+          unitPrice: pinned.unitPrice,
+          qty: 1,
+          label: `${stamp}A`,
+        }),
+        postPaidPrelovedOrder(page, {
+          paymentIntentId: b.paymentIntentId,
+          totals: b.totals,
+          skuId: pinned.skuId,
+          sourceItemId: pinned.sourceItemId,
+          unitPrice: pinned.unitPrice,
+          qty: 1,
+          label: `${stamp}B`,
+        }),
+      ]);
+
+      const outcomes = await Promise.all(
+        [
+          { label: "A", res: resA },
+          { label: "B", res: resB },
+        ].map(async (row) => ({
+          label: row.label,
+          status: row.res.status(),
+          body: (await row.res.json().catch(() => ({}))) as {
+            orderId?: string;
+            error?: string;
+          },
+        })),
+      );
+      const winners = outcomes.filter(
+        (row) =>
+          (row.status === 200 || row.status === 201) &&
+          typeof row.body.orderId === "string" &&
+          row.body.orderId.length > 0,
+      );
+      expect(
+        winners,
+        `expected two paid orders; got ${JSON.stringify(outcomes)}`,
+      ).toHaveLength(2);
+
+      const orderIds = winners.map((row) => row.body.orderId!);
+      expect(new Set(orderIds).size).toBe(2);
+
+      const lines = await soldLinesForOrders(orderIds);
+      expect(
+        lines,
+        `loser must claim the next unit, not drop: ${JSON.stringify(lines)}`,
+      ).toHaveLength(2);
+      expect(new Set(lines.map((row) => row.consignment_item_id)).size).toBe(2);
+      expect(new Set(lines.map((row) => row.order_id)).size).toBe(2);
+      expect(lines.every((row) => row.sold_order_line_id)).toBeTruthy();
+
+      await pinPooledSkuQty(1);
+    } finally {
+      await restoreDonationOnlyIntake(page);
+    }
+  });
+
+  test("idempotent POST restores a sold line after a lost insert", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    await devLogin(page, `/admin/${TENANT}/settings`);
+    const { donatedGstFree } = await ensurePrelovedEnabled(page);
+    const enableRes = await page.request.patch(`/api/tenant/${TENANT}/preloved`, {
+      data: {
+        prelovedEnabled: true,
+        intakeMode: "donation_and_consignment",
+        commissionBps: 5000,
+      },
+    });
+    expect(enableRes.ok()).toBeTruthy();
+
+    try {
+      const stamp = String(Date.now()).slice(-8);
+      const { lotId } = await createEftLot(page, `${stamp}r`);
+      await acceptConsignedGood(page, lotId);
+      const pinned = await pinPooledSkuQty(1);
+
+      const paid = await mintAndPayPreloved(page, {
+        skuId: pinned.skuId,
+        sourceItemId: pinned.sourceItemId,
+        unitPrice: pinned.unitPrice,
+        qty: 1,
+        donatedGstFree,
+        label: `${stamp}r`,
+      });
+
+      const before = await soldLinesForOrders([paid.orderId]);
+      expect(before.length).toBeGreaterThanOrEqual(1);
+      const itemIds = before.map((row) => row.consignment_item_id);
+
+      loadLocalEnv();
+      const url = process.env.DATABASE_URL;
+      if (!url) throw new Error("DATABASE_URL missing for orphan delete");
+      const sql = neon(url);
+      await sql`
+        delete from consignment_sold_lines
+        where order_id = ${paid.orderId}
+      `;
+      const orphaned: Array<{ id: string }> = [];
+      for (const itemId of itemIds) {
+        const part = await sql`
+          select id
+          from consignment_items
+          where id = ${itemId}
+            and sold_order_line_id is not null
+        `;
+        orphaned.push(...(part as Array<{ id: string }>));
+      }
+      expect(orphaned.length).toBe(itemIds.length);
+      const missing = await soldLinesForOrders([paid.orderId]);
+      expect(missing).toHaveLength(0);
+
+      const replay = await postPaidPrelovedOrder(page, {
+        paymentIntentId: paid.paymentIntentId,
+        totals: paid.totals,
+        skuId: pinned.skuId,
+        sourceItemId: pinned.sourceItemId,
+        unitPrice: pinned.unitPrice,
+        qty: 1,
+        label: `${stamp}r`,
+      });
+      expect(
+        replay.ok(),
+        `idempotent replay failed: ${replay.status()} ${await replay.text()}`,
+      ).toBeTruthy();
+      const replayBody = (await replay.json()) as {
+        orderId?: string;
+        idempotent?: boolean;
+      };
+      expect(replayBody.orderId).toBe(paid.orderId);
+
+      const restored = await soldLinesForOrders([paid.orderId]);
+      expect(restored).toHaveLength(before.length);
+      expect(
+        new Set(restored.map((row) => row.consignment_item_id)),
+      ).toEqual(new Set(itemIds));
+
+      await pinPooledSkuQty(1);
     } finally {
       await restoreDonationOnlyIntake(page);
     }

--- a/apps/web/tests/preloved/m09-payout-csv.spec.ts
+++ b/apps/web/tests/preloved/m09-payout-csv.spec.ts
@@ -56,36 +56,41 @@ test("commission split is integer cents, not a display-only cut", () => {
 });
 
 async function createEftLot(page: Page, stamp: string) {
-  const createRes = await page.request.post(
-    `/api/tenant/${TENANT}/preloved/consign`,
-    {
-      data: {
-        familyName: `Payout${stamp}`,
-        studentName: "Remi",
-        email: `payout-${stamp}@example.com`,
-        mobile: "0400000014",
-        payoutPreference: "eft",
-        bankBsb: "062000",
-        bankAccountName: "Payout Family",
-        bankAccountNumber: "12345678",
-        unsoldPreference: "donate",
-        items: [{ garment: "Sports polo", size: SIZE }],
-        termsAccepted: true,
+  let lastError = "create consignment lot failed";
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    const createRes = await page.request.post(
+      `/api/tenant/${TENANT}/preloved/consign`,
+      {
+        data: {
+          familyName: `Payout${stamp}`,
+          studentName: "Remi",
+          email: `payout-${stamp}-a${attempt}@example.com`,
+          mobile: "0400000014",
+          payoutPreference: "eft",
+          bankBsb: "062000",
+          bankAccountName: "Payout Family",
+          bankAccountNumber: "12345678",
+          unsoldPreference: "donate",
+          items: [{ garment: "Sports polo", size: SIZE }],
+          termsAccepted: true,
+        },
       },
-    },
-  );
-  if (!createRes.ok()) {
-    throw new Error(
-      `create consignment lot failed ${createRes.status()}: ${await createRes.text()}`,
     );
+    if (createRes.ok()) {
+      const created = (await createRes.json()) as {
+        id?: string;
+        ticketCode?: string;
+      };
+      expect(created.id).toBeTruthy();
+      expect(created.ticketCode).toMatch(/^CL-[A-Z0-9]{6}$/);
+      return { lotId: created.id!, ticket: created.ticketCode! };
+    }
+    lastError = `create consignment lot failed ${createRes.status()}: ${await createRes.text()}`;
+    if (createRes.status() !== 500 || attempt === 3) {
+      throw new Error(lastError);
+    }
   }
-  const created = (await createRes.json()) as {
-    id?: string;
-    ticketCode?: string;
-  };
-  expect(created.id).toBeTruthy();
-  expect(created.ticketCode).toMatch(/^CL-[A-Z0-9]{6}$/);
-  return { lotId: created.id!, ticket: created.ticketCode! };
+  throw new Error(lastError);
 }
 
 async function unsoldRankForLot(skuId: string, lotId: string) {

--- a/decisions/INDEX.md
+++ b/decisions/INDEX.md
@@ -73,7 +73,8 @@
 - 2026-09-07 · 65ef5136 · build:M06 · orders.userId is null for non-uuid dev-login ids
 - 2026-09-07 · c0f472c8 · build:M06 · Tick last-unit AC from sequential oversell plus CAS; no concurrent e2e
 
-## Misc  ([decisions/misc.md](misc.md)) — 3
+## Misc  ([decisions/misc.md](misc.md)) — 4
 - 2026-09-06 · 2f31cd1c · onboard · HeroUI OSS only — this repo is open source
 - 2026-09-11 · 47952782 · build:followup · Write-off records leftover qty only; qty 0 is already cleared
 - 2026-09-11 · 34541772 · build:followup · Operator inbox lists preloved_donation_notes under Preloved
+- 2026-09-12 · d27665d9 · build:phase2 · Atomic SKIP LOCKED sold-line write; BestEffort rethrows

--- a/decisions/misc.md
+++ b/decisions/misc.md
@@ -40,3 +40,15 @@
 - **Risks / known issues:** Inbox lists the newest 200 notes only.
 - **Links:** apps/web/src/app/admin/[tenant]/preloved/inbox; apps/web/src/app/api/tenant/[tenantId]/preloved/donation-notes/route.ts
 
+## Atomic SKIP LOCKED sold-line write; BestEffort rethrows
+- **ID:** d27665d9-7a2a-49be-88f4-c859129a94c8
+- **Date:** 2026-09-12T16:27:21Z
+- **Stage:** build:phase2
+- **Decision:** Claim consignment units with FOR UPDATE SKIP LOCKED and write consignment_sold_lines in one neon-http statement. recordConsignmentSoldLinesBestEffort retries three times then rethrows so webhook/POST cannot 200 after a lost insert.
+- **Why:** neon-http forbids db.transaction. The old row_number join let two qty-1 sales target the same oldest unit; the UPDATE/INSERT split plus swallowed BestEffort could mark items sold with no remittance row while Stripe saw 200.
+- **Alternatives:** Keep two statements and only rethrow; per-item UPDATE loop; advisory lock only without SKIP LOCKED
+- **Pros:** Concurrent sales take the next unlocked unit; claim+ledger commit together; unique item index and orphan UNION remain as replay backstops
+- **Cons:** Commission math is now SQL ROUND to match splitSaleCommission; LATERAL LIMIT depends on Postgres
+- **Risks / known issues:** If SKIP LOCKED+LIMIT s.need is rejected by this Postgres, the write fails loudly (5xx) instead of silently dropping
+- **Links:** apps/web/src/db/preloved-queries.ts;apps/web/src/app/api/stripe/webhook/route.ts;apps/web/tests/preloved/m09-payout-csv.spec.ts
+

--- a/specs/_logs/CAPABILITY_LESSONS.md
+++ b/specs/_logs/CAPABILITY_LESSONS.md
@@ -1024,3 +1024,16 @@
 - **Evidence:** apps/web/src/db/schema.ts catalogVariants (id/itemId/label/price/sizes/active); apps/web/src/app/api/catalog/route.ts; m06 spec catalog fingerprint + qty-99 PI
 - **Links:** specs/milestones/M06-preloved-fulfilment.md
 
+## neon-http sold-line claim and remittance insert must be one statement with SKIP LOCKED
+- **ID:** f2aeda36-0ff6-4e39-8c21-fbd628bfe4d1
+- **Date:** 2026-09-12T16:29:28Z
+- **DocId:** 0300
+- **Kind:** works
+- **Status:** verified
+- **Milestone:** phase2
+- **Project:** uniform_order
+- **Version scope:** Next.js 16.2.4, drizzle neon-http, Playwright 1.59, Neon Postgres
+- **Detail:** Two HTTP statements plus a swallowed best-effort let UPDATE commit and INSERT fail while the webhook returned 200. Concurrent FIFO row_number joins both targeted the oldest unsold unit. One CTE with FOR UPDATE SKIP LOCKED plus INSERT, and BestEffort that retries then rethrows, keeps unique-index replay and does not drop the next unit.
+- **Evidence:** pnpm check-types:web pass; PLAYWRIGHT_BASE_URL=http://127.0.0.1:43173 pnpm test:m09-payout-csv 5/5 including concurrent qty-1 FIFO and orphan-ledger replay
+- **Links:** apps/web/src/db/preloved-queries.ts
+


### PR DESCRIPTION
Phase 2 leftover after #51/#53: make `recordConsignmentSoldLinesForOrder` safe under neon-http.

## What shipped

- **Concurrent FIFO:** claim unsold `consignment_items` with `FOR UPDATE SKIP LOCKED` (LATERAL `LIMIT` per SKU). Two qty-1 sales on one SKU take distinct units; the loser gets the next unlocked item, or allocates 0 (treated as donated). Same-order replay takes an advisory lock.
- **Split write:** claim `UPDATE` and remittance `INSERT` run in **one SQL statement**. A failed insert rolls back the claim. `recordConsignmentSoldLinesBestEffort` retries three times, then **rethrows** so webhook / `POST /api/orders` cannot return 200 with a lost sold line.
- **Backstops kept:** unique `consignment_sold_lines_item_unique`, `ON CONFLICT DO NOTHING`, and a UNION of already-sold-to-this-order orphans (old two-statement leftovers).
- **Not in this slice:** void-on-refund, platform portal, commission stamped at PaymentIntent time.

## Verify

- `pnpm check-types:web` — pass
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:43173 pnpm test:m09-payout-csv` — 5/5 (existing CSV + export error, plus concurrent FIFO and orphan-ledger replay)

## Decisions

- Sold-at-charge-time stays (George). Extra sold qty beyond claimed units is still donated.
- Bank details and marks are unchanged.

Decision `d27665d9`. Lesson `f2aeda36` (capability 0300).